### PR TITLE
Patch 3

### DIFF
--- a/src/main/java/org/springframework/data/jpa/repository/query/QueryUtils.java
+++ b/src/main/java/org/springframework/data/jpa/repository/query/QueryUtils.java
@@ -291,7 +291,7 @@ public abstract class QueryUtils {
 			Join<Object, Object> join = from.join(property.getName());
 			return (Expression<T>) (property.hasNext() ? toExpressionRecursively((From<?, ?>) join, property.next()) : join);
 		} else {
-			Path<Object> path = from.get(property.getName());
+			Path<Object> path = from.join(property.getName(), JoinType.LEFT);			
 			return (Expression<T>) (property.hasNext() ? toExpressionRecursively(path, property.next()) : path);
 		}
 	}


### PR DESCRIPTION
Order by property which is not mandatory (is not @NotNull) causes exclusion of rows with the null property from the result set. This patch "left joins" the property instead of an inner join.
