### PR TITLE
Typo correction in NamedQuery.java

### DIFF
--- a/src/main/java/org/springframework/data/jpa/repository/query/NamedQuery.java
+++ b/src/main/java/org/springframework/data/jpa/repository/query/NamedQuery.java
@@ -63,7 +63,7 @@ final class NamedQuery extends AbstractJpaQuery {
 		}
 
 		if (parameters.hasPageableParameter()) {
-			LOG.info("Finder method {} is backed by a NamedQuery" + " but contains a Pageble parameter! Sorting deliviered "
+			LOG.warn("Finder method {} is backed by a NamedQuery" + " but contains a Pageable parameter! Sorting delivered "
 					+ "via this Pageable will not be applied!", method);
 		}
 


### PR DESCRIPTION
Changed log level for one of the log messages in NamedQuery from INFO to
WARN.  This was done to provide more forceful information to the
developer that sorting applied with named queries will be ignored.
