### PR TITLE
System property control of Bundlor configuration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,10 @@
 		<slf4j.version>1.6.1</slf4j.version>
 		<cdi.version>1.0</cdi.version>
 		<webbeans.version>1.1.3</webbeans.version>
-		
+
+		<bundlor.failOnWarnings>true</bundlor.failOnWarnings>
+		<bundlor.enabled>true</bundlor.enabled>
+
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<dist.id>spring-data-jpa</dist.id>
 		<dist.name>Spring Data JPA</dist.name>
@@ -570,7 +573,8 @@
 				<artifactId>com.springsource.bundlor.maven</artifactId>
 				<version>1.0.0.RELEASE</version>
 				<configuration>
-					<failOnWarnings>true</failOnWarnings>
+					<failOnWarnings>${bundlor.failOnWarnings}</failOnWarnings>
+					<enabled>${bundlor.enabled}</enabled>
 				</configuration>
 				<executions>
 					<execution>


### PR DESCRIPTION
Added the ability to control whether Bundlor will fail on warnings or whether
it is enabled at all, using Java system properties. By default, Bundlor will
be enabled and will fail on warnings. Specifying `-DfailOnWarnings=true/false`
and `-Dbundlor.enabled=true/false` as part of the Maven command will now
control Bundlor's operation.
