### PR TITLE
DATAJPA-265 - Make it possible to configure auditing with Java Config.

### DIFF
--- a/src/main/java/org/springframework/data/jpa/auditing/EnableJpaAuditing.java
+++ b/src/main/java/org/springframework/data/jpa/auditing/EnableJpaAuditing.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.data.jpa.auditing;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.springframework.context.annotation.Import;
+import org.springframework.context.annotation.aspectj.SpringConfiguredConfiguration;
+
+/**
+ * Annotation to enable auditing. Imports {@link SpringConfiguredConfiguration}, that allows dependency-injection on objects not managed by
+ * spring.
+ *
+ * @author Ranie Jade Ramiso
+ * @since 1.4
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+@Documented
+@Inherited
+@Import({SpringConfiguredConfiguration.class, JpaAuditingRegistrar.class})
+public @interface EnableJpaAuditing {
+
+	/**
+	 * Reference to a bean of type {@link org.springframework.data.domain.AuditorAware}.
+	 */
+	String auditorAwareRef() default "";
+
+	/**
+	 * Configures whether the creation and modification dates are set.
+	 */
+	boolean setDates() default true;
+
+
+	/**
+	 * Configuration whether to treat creation also as modification.
+	 */
+	boolean modifyOnCreate() default true;
+
+	/**
+	 * Reference to a bean of type {@link org.springframework.data.auditing.DateTimeProvider}. If not set
+	 * a default implementation will be provided.
+	 */
+	String dateTimeProviderRef() default "";
+}

--- a/src/main/java/org/springframework/data/jpa/auditing/JpaAuditingRegistrar.java
+++ b/src/main/java/org/springframework/data/jpa/auditing/JpaAuditingRegistrar.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.data.jpa.auditing;
+
+import org.springframework.beans.factory.config.BeanDefinition;
+import org.springframework.beans.factory.support.AbstractBeanDefinition;
+import org.springframework.beans.factory.support.BeanDefinitionBuilder;
+import org.springframework.beans.factory.support.BeanDefinitionRegistry;
+import org.springframework.beans.factory.support.RootBeanDefinition;
+import org.springframework.core.type.AnnotationMetadata;
+import org.springframework.data.auditing.config.AnnotationAuditingConfiguration;
+import org.springframework.data.auditing.config.AnnotationAuditingConfigurationSupport;
+import org.springframework.data.auditing.config.AuditingBeanDefinitionRegistrarSupport;
+
+/**
+ * JPA specific implementation for {@link AuditingBeanDefinitionRegistrarSupport}.
+ *
+ * @author Ranie Jade Ramiso
+ */
+public class JpaAuditingRegistrar extends AuditingBeanDefinitionRegistrarSupport {
+
+	private static final String AUDITING_ENTITY_LISTENER_CLASS_NAME = "org.springframework.data.jpa.domain.support.AuditingEntityListener";
+	private static final String AUDITING_BFPP_CLASS_NAME = "org.springframework.data.jpa.domain.support.AuditingBeanFactoryPostProcessor";
+
+	@Override
+	protected AnnotationAuditingConfiguration getConfiguration(AnnotationMetadata annotationMetadata) {
+		return new AnnotationAuditingConfigurationSupport(annotationMetadata, EnableJpaAuditing.class);
+	}
+
+	@Override
+	protected void postProcess(AnnotationAuditingConfiguration configuration, BeanDefinition auditingHandlerDefinition, BeanDefinitionRegistry registry) {
+		BeanDefinitionBuilder builder = BeanDefinitionBuilder.rootBeanDefinition(AUDITING_ENTITY_LISTENER_CLASS_NAME);
+		builder.addPropertyValue("auditingHandler", auditingHandlerDefinition);
+		builder.setScope("prototype");
+
+		registerInfrastructureBeans(builder.getRawBeanDefinition(), AUDITING_ENTITY_LISTENER_CLASS_NAME, registry);
+
+		RootBeanDefinition def = new RootBeanDefinition(AUDITING_BFPP_CLASS_NAME);
+		registerInfrastructureBeans(def, AUDITING_BFPP_CLASS_NAME, registry);
+
+	}
+
+	private void registerInfrastructureBeans(AbstractBeanDefinition definition, String id, BeanDefinitionRegistry registry) {
+		definition.setRole(BeanDefinition.ROLE_INFRASTRUCTURE);
+		registry.registerBeanDefinition(id, definition);
+	}
+}

--- a/src/test/java/org/springframework/data/jpa/auditing/Domain.java
+++ b/src/test/java/org/springframework/data/jpa/auditing/Domain.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2013 the original author or authors.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.data.jpa.auditing;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.OneToOne;
+
+import org.joda.time.DateTime;
+import org.springframework.data.annotation.CreatedBy;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedBy;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.AbstractPersistable;
+
+/**
+* @author Ranie Jade Ramiso
+*/
+@Entity
+class Domain extends AbstractPersistable<Long> {
+
+	@Column
+	private String name;
+
+	@CreatedBy
+	@OneToOne
+	private Principal createdBy;
+
+	@CreatedDate
+	@Column
+	private DateTime createdDate;
+
+	@LastModifiedBy
+	@OneToOne
+	private Principal lastModifiedBy;
+
+	@LastModifiedDate
+	@Column
+	private DateTime lastModifiedDate;
+
+	public Principal getCreatedBy() {
+		return createdBy;
+	}
+
+	public void setCreatedBy(Principal createdBy) {
+		this.createdBy = createdBy;
+	}
+
+	public DateTime getCreatedDate() {
+		return createdDate;
+	}
+
+	public void setCreatedDate(DateTime createdDate) {
+		this.createdDate = createdDate;
+	}
+
+	public Principal getLastModifiedBy() {
+		return lastModifiedBy;
+	}
+
+	public void setLastModifiedBy(Principal lastModifiedBy) {
+		this.lastModifiedBy = lastModifiedBy;
+	}
+
+	public DateTime getLastModifiedDate() {
+		return lastModifiedDate;
+	}
+
+	public void setLastModifiedDate(DateTime lastModifiedDate) {
+		this.lastModifiedDate = lastModifiedDate;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+}

--- a/src/test/java/org/springframework/data/jpa/auditing/DomainRepository.java
+++ b/src/test/java/org/springframework/data/jpa/auditing/DomainRepository.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2013 the original author or authors.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.data.jpa.auditing;
+
+import org.springframework.data.repository.CrudRepository;
+
+/**
+ * @author Ranie Jade Ramiso
+ */
+public interface DomainRepository extends CrudRepository<Domain, Long> {
+}

--- a/src/test/java/org/springframework/data/jpa/auditing/JpaAuditingRegistrarIntegrationTests.java
+++ b/src/test/java/org/springframework/data/jpa/auditing/JpaAuditingRegistrarIntegrationTests.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright 2013 the original author or authors.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.data.jpa.auditing;
+
+import javax.annotation.Resource;
+import javax.sql.DataSource;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.domain.AuditorAware;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseBuilder;
+import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseType;
+import org.springframework.orm.jpa.JpaTransactionManager;
+import org.springframework.orm.jpa.LocalContainerEntityManagerFactoryBean;
+import org.springframework.orm.jpa.vendor.Database;
+import org.springframework.orm.jpa.vendor.HibernateJpaVendorAdapter;
+import org.springframework.transaction.PlatformTransactionManager;
+
+import static org.junit.Assert.*;
+
+/**
+ * Integration tests for enabling auditing via java configuration.
+ *
+ * @author Ranie Jade Ramiso
+ */
+public class JpaAuditingRegistrarIntegrationTests {
+
+	private ApplicationContext context = new AnnotationConfigApplicationContext(SampleConfig.class);
+
+	private PrincipalRepository principalRepository;
+
+	private DomainRepository domainRepository;
+
+	@Before
+	public void setup() {
+		principalRepository = context.getBean(PrincipalRepository.class);
+		domainRepository = context.getBean(DomainRepository.class);
+		SampleConfig.PRINCIPAL = principalRepository.save(SampleConfig.PRINCIPAL);
+	}
+
+	@Test
+	public void testAuditNew() {
+		Domain domain = new Domain();
+
+		domainRepository.save(domain);
+
+		domain = domainRepository.findOne(domain.getId());
+		assertNotNull(domain);
+
+		assertNotNull(domain.getCreatedBy());
+		assertNotNull(domain.getCreatedDate());
+		assertEquals(SampleConfig.PRINCIPAL, domain.getCreatedBy());
+		assertNull(domain.getLastModifiedBy());
+		assertNull(domain.getLastModifiedDate());
+	}
+
+	@Test
+	public void testAuditUpdate() {
+		Domain domain = new Domain();
+
+		// first save
+		domain = domainRepository.save(domain);
+
+		// update
+		domain.setName("a very simple name");
+		domainRepository.save(domain);
+
+		domain = domainRepository.findOne(domain.getId());
+		assertNotNull(domain);
+
+		assertNotNull(domain.getCreatedBy());
+		assertNotNull(domain.getCreatedDate());
+		assertEquals(SampleConfig.PRINCIPAL, domain.getCreatedBy());
+
+		assertNotNull(domain.getLastModifiedBy());
+		assertNotNull(domain.getLastModifiedDate());
+		assertEquals(SampleConfig.PRINCIPAL, domain.getLastModifiedBy());
+	}
+
+	@Configuration
+	@EnableJpaAuditing(auditorAwareRef = "principalService", setDates = true, modifyOnCreate = false)
+	@EnableJpaRepositories(basePackages = "org.springframework.data.jpa.auditing")
+	static class SampleConfig {
+		public static Principal PRINCIPAL = new Principal();
+
+		@Bean(name = "principalService")
+		public AuditorAware<Principal> getAuditorAware() {
+			return new AuditorAware<Principal>() {
+				@Resource
+				private PrincipalRepository principalRepository;
+
+				public Principal getCurrentAuditor() {
+					return principalRepository.findOne(PRINCIPAL.getId());
+				}
+			};
+		}
+
+		@Bean
+		public DataSource dataSource() {
+			EmbeddedDatabaseBuilder builder = new EmbeddedDatabaseBuilder();
+			return builder.setType(EmbeddedDatabaseType.HSQL).build();
+		}
+
+		@Bean
+		public LocalContainerEntityManagerFactoryBean entityManagerFactory() {
+			HibernateJpaVendorAdapter vendorAdapter = new HibernateJpaVendorAdapter();
+			vendorAdapter.setDatabase(Database.HSQL);
+			vendorAdapter.setGenerateDdl(true);
+
+			LocalContainerEntityManagerFactoryBean factory = new LocalContainerEntityManagerFactoryBean();
+			factory.setPersistenceUnitName("audit");
+			factory.setDataSource(dataSource());
+			factory.setJpaVendorAdapter(vendorAdapter);
+
+			return factory;
+		}
+
+
+		@Bean
+		public PlatformTransactionManager transactionManager() {
+
+			JpaTransactionManager txManager = new JpaTransactionManager();
+			txManager.setEntityManagerFactory(entityManagerFactory().getObject());
+			return txManager;
+		}
+	}
+}

--- a/src/test/java/org/springframework/data/jpa/auditing/Principal.java
+++ b/src/test/java/org/springframework/data/jpa/auditing/Principal.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2013 the original author or authors.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.data.jpa.auditing;
+
+import javax.persistence.Entity;
+
+import org.springframework.data.jpa.domain.AbstractPersistable;
+
+/**
+* @author Ranie Jade Ramiso
+*/
+@Entity
+class Principal extends AbstractPersistable<Long> {
+}

--- a/src/test/java/org/springframework/data/jpa/auditing/PrincipalRepository.java
+++ b/src/test/java/org/springframework/data/jpa/auditing/PrincipalRepository.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2013 the original author or authors.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.data.jpa.auditing;
+
+import org.springframework.data.repository.CrudRepository;
+
+/**
+ * @author Ranie Jade Ramiso
+ */
+public interface PrincipalRepository extends CrudRepository<Principal, Long> {
+}

--- a/src/test/resources/META-INF/persistence.xml
+++ b/src/test/resources/META-INF/persistence.xml
@@ -34,4 +34,10 @@
 			<property name="hibernate.hbm2ddl.auto" value="update" />
 		</properties>
 	</persistence-unit>
+	<persistence-unit name="audit">
+		<class>org.springframework.data.jpa.auditing.Domain</class>
+		<class>org.springframework.data.jpa.auditing.Principal</class>
+		<class>org.springframework.data.jpa.domain.sample.User</class>
+		<exclude-unlisted-classes>true</exclude-unlisted-classes>
+	</persistence-unit>
 </persistence>


### PR DESCRIPTION
Added JpaAuditingRegistrar, JPA specific implementation for configuring auditing via Java Config. To enable auditing annotate your @Configuration classes with @EnableJpaAuditing, providing atleast a reference to a AuditorAware. @EnableJpaAuditing automatically imports SpringConfiguredConfiguration, which enables dependency-injection on objects not managed by spring. Also provided integration tests.

Support for enabling auditing via java config. Feel free to polish the code a bit :)
