### PR TITLE
DATAJPA-353 - Adjusted path resolving of mappingFileLocations(…) to conf...

### DIFF
--- a/src/test/resources/org/springframework/data/jpa/support/module1/module1-orm.xml
+++ b/src/test/resources/org/springframework/data/jpa/support/module1/module1-orm.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<entity-mappings xmlns="http://java.sun.com/xml/ns/persistence/orm" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://java.sun.com/xml/ns/persistence/orm http://java.sun.com/xml/ns/persistence/orm_2_0.xsd" version="2.0">
+</entity-mappings>

--- a/src/test/resources/org/springframework/data/jpa/support/module2/module2-orm.xml
+++ b/src/test/resources/org/springframework/data/jpa/support/module2/module2-orm.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<entity-mappings xmlns="http://java.sun.com/xml/ns/persistence/orm" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://java.sun.com/xml/ns/persistence/orm http://java.sun.com/xml/ns/persistence/orm_2_0.xsd" version="2.0">
+</entity-mappings>


### PR DESCRIPTION
...orm to the JPA spec.

Adjusted scanForMappingFileLocations(…) in ClasspathScanningPersistenceUnitPostProcessor to resolve the paths to class-path loadable paths.
Updated test case findsMappingFile accordingly.
Added test case shouldFindJpaMappingFilesFromMultipleLocationsOnClasspath and required resources to verify that mapping files with recursive wildcard pattern can be found from multiple locations in class path.
