### PR TITLE
DATAJPA-170 - Add support for SpEL in query expressions.

### DIFF
--- a/src/main/java/org/springframework/data/jpa/repository/query/ExpressionBasedStringQuery.java
+++ b/src/main/java/org/springframework/data/jpa/repository/query/ExpressionBasedStringQuery.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.jpa.repository.query;
+
+import org.springframework.expression.Expression;
+import org.springframework.expression.ParserContext;
+import org.springframework.expression.spel.standard.SpelExpressionParser;
+import org.springframework.expression.spel.support.StandardEvaluationContext;
+
+/**
+ * Extension of {@link StringQuery} that evaluates the given query string as a SpEL template-expression.
+ * <p>
+ * Currently the following template variables are available:
+ * <ol>
+ * <li>#{#domainType} - the simple class name of the given entity</li>
+ * <ol>
+ * </p>
+ * 
+ * @author Thomas Darimont
+ */
+class ExpressionBasedStringQuery extends StringQuery {
+
+	private static final String DOMAIN_TYPE = "domainType";
+
+	/**
+	 * @param query
+	 */
+	public ExpressionBasedStringQuery(String query, Class<?> domainClass) {
+		super(renderQueryIfExpressionOrReturnQuery(query, domainClass));
+	}
+
+	private static String renderQueryIfExpressionOrReturnQuery(String query, Class<?> domainClass) {
+
+		if (!containsExpression(query)) {
+			return query;
+		}
+
+		StandardEvaluationContext evalContext = new StandardEvaluationContext();
+		evalContext.setVariable(DOMAIN_TYPE, domainClass.getSimpleName());
+
+		SpelExpressionParser parser = new SpelExpressionParser();
+		Expression expr = parser.parseExpression(query, ParserContext.TEMPLATE_EXPRESSION);
+
+		Object result = expr.getValue(evalContext, String.class);
+
+		if (result == null) {
+			return query;
+		}
+
+		return String.valueOf(result);
+	}
+
+	private static boolean containsExpression(String query) {
+		return query.contains("#{#" + DOMAIN_TYPE + "}");
+	}
+}

--- a/src/main/java/org/springframework/data/jpa/repository/query/SimpleJpaQuery.java
+++ b/src/main/java/org/springframework/data/jpa/repository/query/SimpleJpaQuery.java
@@ -32,6 +32,7 @@ import org.springframework.data.repository.query.RepositoryQuery;
  * {@link Query} from it.
  * 
  * @author Oliver Gierke
+ * @author Thomas Darimont
  */
 final class SimpleJpaQuery extends AbstractJpaQuery {
 
@@ -50,7 +51,8 @@ final class SimpleJpaQuery extends AbstractJpaQuery {
 		super(method, em);
 
 		this.method = method;
-		this.query = new StringQuery(queryString);
+		this.query = method.getEntityInformation() == null ? new StringQuery(queryString) : new ExpressionBasedStringQuery(
+				queryString, method.getEntityInformation().getJavaType());
 
 		Parameters parameters = method.getParameters();
 		boolean hasPagingOrSortingParameter = parameters.hasPageableParameter() || parameters.hasSortParameter();

--- a/src/test/java/org/springframework/data/jpa/domain/sample/AbstractMappedType.java
+++ b/src/test/java/org/springframework/data/jpa/domain/sample/AbstractMappedType.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.jpa.domain.sample;
+
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.MappedSuperclass;
+
+/**
+ * @author Thomas Darimont
+ */
+@MappedSuperclass
+public abstract class AbstractMappedType {
+
+	public AbstractMappedType() {}
+
+	public AbstractMappedType(String attribute1) {
+		this.attribute1 = attribute1;
+	}
+
+	@Id @GeneratedValue Long id;
+	String attribute1;
+}

--- a/src/test/java/org/springframework/data/jpa/domain/sample/ConcreteType1.java
+++ b/src/test/java/org/springframework/data/jpa/domain/sample/ConcreteType1.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.jpa.domain.sample;
+
+import javax.persistence.Entity;
+
+/**
+ * @author Thomas Darimont
+ */
+@Entity
+public class ConcreteType1 extends AbstractMappedType {
+
+	public ConcreteType1() {}
+
+	public ConcreteType1(String attribute1) {
+		super(attribute1);
+	}
+}

--- a/src/test/java/org/springframework/data/jpa/domain/sample/ConcreteType2.java
+++ b/src/test/java/org/springframework/data/jpa/domain/sample/ConcreteType2.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.jpa.domain.sample;
+
+import javax.persistence.Entity;
+
+/**
+ * @author Thomas Darimont
+ */
+@Entity
+public class ConcreteType2 extends AbstractMappedType {
+
+	public ConcreteType2() {}
+
+	public ConcreteType2(String attribute1) {
+		super(attribute1);
+	}
+}

--- a/src/test/java/org/springframework/data/jpa/repository/MappedTypeRepositoryTests.java
+++ b/src/test/java/org/springframework/data/jpa/repository/MappedTypeRepositoryTests.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.jpa.repository;
+
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.*;
+
+import java.util.List;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.ImportResource;
+import org.springframework.data.jpa.domain.sample.ConcreteType1;
+import org.springframework.data.jpa.domain.sample.ConcreteType2;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+import org.springframework.data.jpa.repository.sample.ConcreteRepository1;
+import org.springframework.data.jpa.repository.sample.ConcreteRepository2;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.support.AnnotationConfigContextLoader;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * @author Thomas Darimont
+ */
+@Transactional
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration(loader = AnnotationConfigContextLoader.class)
+public class MappedTypeRepositoryTests {
+
+	@Configuration
+	@ImportResource("classpath:infrastructure.xml")
+	@EnableJpaRepositories
+	static class Config {}
+
+	@Autowired ConcreteRepository1 concreteRepository1;
+
+	@Autowired ConcreteRepository2 concreteRepository2;
+
+	/**
+	 * @see DATAJPA-170
+	 */
+	@Test
+	public void supportForExpressionBasedQueryMethods() {
+
+		concreteRepository1.save(new ConcreteType1("foo"));
+		concreteRepository2.save(new ConcreteType2("foo"));
+
+		List<ConcreteType1> concretes1 = concreteRepository1.findAllByAttribute1("foo");
+		List<ConcreteType2> concretes2 = concreteRepository2.findAllByAttribute1("foo");
+
+		assertThat(concretes1.size(), is(1));
+		assertThat(concretes2.size(), is(1));
+
+	}
+
+}

--- a/src/test/java/org/springframework/data/jpa/repository/query/ExpressionBasedStringQueryUnitTests.java
+++ b/src/test/java/org/springframework/data/jpa/repository/query/ExpressionBasedStringQueryUnitTests.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.jpa.repository.query;
+
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+import org.springframework.data.jpa.domain.sample.User;
+
+/**
+ * Unit tests for {@link ExpressionBasedStringQuery}.
+ * 
+ * @author Thomas Darimont
+ */
+public class ExpressionBasedStringQueryUnitTests {
+
+	/**
+	 * @see DATAJPA-170
+	 */
+	@Test
+	public void shouldReturnQueryWithDomainTypeExpressionReplacedWithSimpleDomainTypeName() {
+
+		String source = "select from #{#domainType} u where u.firstname like :firstname";
+		StringQuery query = new ExpressionBasedStringQuery(source, User.class);
+		String result = query.getQuery();
+
+		assertThat(result, is("select from User u where u.firstname like :firstname"));
+	}
+}

--- a/src/test/java/org/springframework/data/jpa/repository/sample/ConcreteRepository1.java
+++ b/src/test/java/org/springframework/data/jpa/repository/sample/ConcreteRepository1.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.jpa.repository.sample;
+
+import org.springframework.data.jpa.domain.sample.ConcreteType1;
+
+/**
+ * @author Thomas Darimont
+ */
+public interface ConcreteRepository1 extends MappedTypeRepository<ConcreteType1> {
+
+}

--- a/src/test/java/org/springframework/data/jpa/repository/sample/ConcreteRepository2.java
+++ b/src/test/java/org/springframework/data/jpa/repository/sample/ConcreteRepository2.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.jpa.repository.sample;
+
+import org.springframework.data.jpa.domain.sample.ConcreteType2;
+
+/**
+ * @author Thomas Darimont
+ */
+public interface ConcreteRepository2 extends MappedTypeRepository<ConcreteType2> {
+
+}

--- a/src/test/java/org/springframework/data/jpa/repository/sample/MappedTypeRepository.java
+++ b/src/test/java/org/springframework/data/jpa/repository/sample/MappedTypeRepository.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.jpa.repository.sample;
+
+import java.util.List;
+
+import org.springframework.data.jpa.domain.sample.AbstractMappedType;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+/**
+ * @author Thomas Darimont
+ */
+public interface MappedTypeRepository<T extends AbstractMappedType> extends JpaRepository<T, Long> {
+
+	@Query("from  #{#domainType} t where t.attribute1=?1")
+	List<T> findAllByAttribute1(String attribute1);
+}

--- a/src/test/resources/META-INF/persistence.xml
+++ b/src/test/resources/META-INF/persistence.xml
@@ -15,6 +15,9 @@
 		<class>org.springframework.data.jpa.domain.sample.SampleEntityPK</class>
 		<class>org.springframework.data.jpa.domain.sample.SampleWithIdClass</class>
 		<class>org.springframework.data.jpa.domain.sample.VersionedUser</class>
+		<class>org.springframework.data.jpa.domain.sample.AbstractMappedType</class>
+		<class>org.springframework.data.jpa.domain.sample.ConcreteType1</class>
+		<class>org.springframework.data.jpa.domain.sample.ConcreteType2</class>
 		<exclude-unlisted-classes>true</exclude-unlisted-classes>
 	</persistence-unit>
 	<persistence-unit name="querydsl">


### PR DESCRIPTION
Introduced ExpressionBasedStringQuery to support the SpEL expression template rendering.
Changed SimpleJpaQuery to use ExpressionBasedStringQuery by default if possible.
Added test case to MappedTypeRepositoryTests for repositories with SpEL expression based query methods.
Added test case to ExpressionBasedStringQueryUnitTests.
