### PR TITLE
DATAJPA-377 - Remove unnecessary "order by"-part from generated count qu...

### DIFF
--- a/src/test/java/org/springframework/data/jpa/repository/query/QueryUtilsUnitTests.java
+++ b/src/test/java/org/springframework/data/jpa/repository/query/QueryUtilsUnitTests.java
@@ -210,7 +210,7 @@ public class QueryUtilsUnitTests {
 	public void usesReturnedVariableInCOuntProjectionIfSet() {
 
 		assertCountQuery("select distinct m.genre from Media m where m.user = ?1 order by m.genre asc",
-				"select count(distinct m.genre) from Media m where m.user = ?1 order by m.genre asc");
+				"select count(distinct m.genre) from Media m where m.user = ?1");
 	}
 
 	/**
@@ -231,6 +231,13 @@ public class QueryUtilsUnitTests {
 
 		Sort sort = new Sort("sum(foo)");
 		assertThat(applySorting("select p from Person p", sort, "p"), endsWith("order by sum(foo) asc"));
+	}
+
+	@Test
+	public void removesOrderByInGeneratedCountQueryFromOriginalQueryIfPresent() {
+
+		assertCountQuery("select distinct m.genre from Media m where m.user = ?1 OrDer  By   m.genre ASC",
+				"select count(distinct m.genre) from Media m where m.user = ?1");
 	}
 
 	private void assertCountQuery(String originalQuery, String countQuery) {


### PR DESCRIPTION
...ery.

Adjusted createCountQueryFor in QueryUtils to leave out the order by part in the generated query. This avoids problems with databases that require columns specified in the order by clause to be in the select / group by list for count queries (e.g. H2).
In addition to that this should give us a little performance boost if the database did not already optimise the query execution.
Added test case removesOrderByInGeneratedCountQueryFromOriginalQueryIfPresent.
