### PR TITLE
DATAJPA-107 - Add support to specify TemporalType on Date parameters in ...

### DIFF
--- a/src/main/java/org/springframework/data/jpa/repository/TemporalParam.java
+++ b/src/main/java/org/springframework/data/jpa/repository/TemporalParam.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.jpa.repository;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.util.Date;
+
+import javax.persistence.TemporalType;
+
+/**
+ * Annotation to declare an appropriate {@code TemporalType} on query method parameters.
+ * <p>
+ * Note that this annotation can only be used on parameters of type {@link Date}.
+ * </p>
+ * 
+ * @author Thomas Darimont
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.PARAMETER)
+@Documented
+public @interface TemporalParam {
+	/**
+	 * Defines the {@link TemporalType} to use for the given Parameter annotated with {@code TemporalParam}.
+	 */
+	TemporalType value() default TemporalType.DATE;
+}

--- a/src/main/java/org/springframework/data/jpa/repository/query/CriteriaQueryParameterBinder.java
+++ b/src/main/java/org/springframework/data/jpa/repository/query/CriteriaQueryParameterBinder.java
@@ -15,12 +15,14 @@
  */
 package org.springframework.data.jpa.repository.query;
 
+import java.util.Date;
 import java.util.Iterator;
 
+import javax.persistence.Parameter;
 import javax.persistence.Query;
 
+import org.springframework.data.jpa.repository.query.JpaParameters.JpaParameter;
 import org.springframework.data.jpa.repository.query.ParameterMetadataProvider.ParameterMetadata;
-import org.springframework.data.repository.query.Parameter;
 import org.springframework.data.repository.query.Parameters;
 import org.springframework.util.Assert;
 
@@ -29,6 +31,7 @@ import org.springframework.util.Assert;
  * parameters.
  * 
  * @author Oliver Gierke
+ * @author Thomas Darimont
  */
 class CriteriaQueryParameterBinder extends ParameterBinder {
 
@@ -40,7 +43,7 @@ class CriteriaQueryParameterBinder extends ParameterBinder {
 	 * 
 	 * @param parameters
 	 */
-	CriteriaQueryParameterBinder(Parameters parameters, Object[] values, Iterable<ParameterMetadata<?>> expressions) {
+	CriteriaQueryParameterBinder(JpaParameters parameters, Object[] values, Iterable<ParameterMetadata<?>> expressions) {
 
 		super(parameters, values);
 		Assert.notNull(expressions);
@@ -57,11 +60,17 @@ class CriteriaQueryParameterBinder extends ParameterBinder {
 	 */
 	@Override
 	@SuppressWarnings("unchecked")
-	protected void bind(Query query, Parameter parameter, Object value, int position) {
+	protected void bind(Query query, JpaParameter parameter, Object value, int position) {
 
 		ParameterMetadata<Object> metadata = (ParameterMetadata<Object>) expressions.next();
 
 		if (metadata.isIsNullParameter()) {
+			return;
+		}
+
+		if (parameter.isTemporalParameter()) {
+			query.setParameter((Parameter<Date>) (Object) metadata.getExpression(), (Date) metadata.prepare(value),
+					parameter.getTemporalType());
 			return;
 		}
 

--- a/src/main/java/org/springframework/data/jpa/repository/query/JpaParameters.java
+++ b/src/main/java/org/springframework/data/jpa/repository/query/JpaParameters.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.jpa.repository.query;
+
+import java.lang.reflect.Method;
+import java.util.Date;
+
+import javax.persistence.TemporalType;
+
+import org.springframework.core.MethodParameter;
+import org.springframework.data.jpa.repository.TemporalParam;
+import org.springframework.data.repository.query.Parameter;
+import org.springframework.data.repository.query.Parameters;
+
+/**
+ * Custom extension of {@link Parameters} discovering additional query parameter annotations.
+ * 
+ * @author Thomas Darimont
+ */
+public class JpaParameters extends Parameters {
+
+	/**
+	 * Creates a new {@link JpaParameters} instance from the given {@link Method}.
+	 * 
+	 * @param method must not be {@literal null}.
+	 */
+	public JpaParameters(Method method) {
+		super(method);
+	}
+
+	/* (non-Javadoc)
+	 * @see org.springframework.data.repository.query.Parameters#createParameter(org.springframework.core.MethodParameter)
+	 */
+	@Override
+	protected JpaParameter createParameter(MethodParameter parameter) {
+		return new JpaParameter(parameter);
+	}
+
+	/**
+	 * Custom {@link Parameter} implementation adding parameters of type {@link TemporalParam} to the special ones.
+	 * 
+	 * @author Oliver Gierke
+	 */
+	static class JpaParameter extends Parameter {
+
+		/**
+		 * Creates a new {@link JpaParameter}.
+		 * 
+		 * @param parameter must not be {@literal null}.
+		 */
+		JpaParameter(MethodParameter parameter) {
+			super(parameter);
+
+			if (!isDateParameter() && hasTemporalParamAnnotation()) {
+				throw new IllegalArgumentException(TemporalParam.class.getSimpleName()
+						+ " annotation is only allowed on Date parameter!");
+			}
+		}
+
+		/* (non-Javadoc)
+		 * @see org.springframework.data.repository.query.Parameter#isBindable()
+		 */
+		@Override
+		public boolean isBindable() {
+			return super.isBindable() || isTemporalParameter();
+		}
+
+		/* (non-Javadoc)
+		 * @see org.springframework.data.repository.query.Parameter#isSpecialParameter()
+		 */
+		@Override
+		public boolean isSpecialParameter() {
+			return super.isSpecialParameter() || isTemporalParameter();
+		}
+
+		/**
+		 * @return {@literal true} if this parameter is of type {@link Date} and has an {@link TemporalParam} annotation.
+		 */
+		public boolean isTemporalParameter() {
+			return isDateParameter() && hasTemporalParamAnnotation();
+		}
+
+		/**
+		 * @return the {@link TemporalType} on the {@link TemporalParam} annotation of the given {@link Parameter}.
+		 */
+		public TemporalType getTemporalType() {
+			return getParameterAnnotation(TemporalParam.class).value();
+		}
+
+		private boolean hasTemporalParamAnnotation() {
+			return getParameterAnnotation(TemporalParam.class) != null;
+		}
+
+		private boolean isDateParameter() {
+			return getType().equals(Date.class);
+		}
+	}
+}

--- a/src/main/java/org/springframework/data/jpa/repository/query/JpaQueryMethod.java
+++ b/src/main/java/org/springframework/data/jpa/repository/query/JpaQueryMethod.java
@@ -43,6 +43,7 @@ import org.springframework.util.StringUtils;
  * JPA specific extension of {@link QueryMethod}.
  * 
  * @author Oliver Gierke
+ * @author Thomas Darimont
  */
 public class JpaQueryMethod extends QueryMethod {
 
@@ -255,5 +256,21 @@ public class JpaQueryMethod extends QueryMethod {
 				.getValue(annotation, attribute);
 
 		return type.cast(value);
+	}
+
+	/* (non-Javadoc)
+	 * @see org.springframework.data.repository.query.QueryMethod#createParameters(java.lang.reflect.Method)
+	 */
+	@Override
+	protected JpaParameters createParameters(Method method) {
+		return new JpaParameters(method);
+	}
+
+	/* (non-Javadoc)
+	 * @see org.springframework.data.repository.query.QueryMethod#getParameters()
+	 */
+	@Override
+	public JpaParameters getParameters() {
+		return (JpaParameters) super.getParameters();
 	}
 }

--- a/src/main/java/org/springframework/data/jpa/repository/query/PartTreeJpaQuery.java
+++ b/src/main/java/org/springframework/data/jpa/repository/query/PartTreeJpaQuery.java
@@ -25,7 +25,6 @@ import javax.persistence.criteria.CriteriaQuery;
 
 import org.springframework.data.domain.Sort;
 import org.springframework.data.jpa.repository.query.ParameterMetadataProvider.ParameterMetadata;
-import org.springframework.data.repository.query.Parameters;
 import org.springframework.data.repository.query.ParametersParameterAccessor;
 import org.springframework.data.repository.query.parser.PartTree;
 
@@ -33,12 +32,13 @@ import org.springframework.data.repository.query.parser.PartTree;
  * A {@link AbstractJpaQuery} implementation based on a {@link PartTree}.
  * 
  * @author Oliver Gierke
+ * @author Thomas Darimont
  */
 public class PartTreeJpaQuery extends AbstractJpaQuery {
 
 	private final Class<?> domainClass;
 	private final PartTree tree;
-	private final Parameters parameters;
+	private final JpaParameters parameters;
 
 	private final QueryPreparer query;
 	private final QueryPreparer countQuery;

--- a/src/main/java/org/springframework/data/jpa/repository/query/StringQueryParameterBinder.java
+++ b/src/main/java/org/springframework/data/jpa/repository/query/StringQueryParameterBinder.java
@@ -17,6 +17,7 @@ package org.springframework.data.jpa.repository.query;
 
 import javax.persistence.Query;
 
+import org.springframework.data.jpa.repository.query.JpaParameters.JpaParameter;
 import org.springframework.data.jpa.repository.query.StringQuery.LikeBinding;
 import org.springframework.data.repository.query.Parameter;
 import org.springframework.data.repository.query.Parameters;
@@ -26,6 +27,7 @@ import org.springframework.util.Assert;
  * {@link ParameterBinder} that takes {@link LikeBinding}s encapsulated in a {@link StringQuery} into account.
  * 
  * @author Oliver Gierke
+ * @author Thomas Darimont
  */
 public class StringQueryParameterBinder extends ParameterBinder {
 
@@ -39,7 +41,7 @@ public class StringQueryParameterBinder extends ParameterBinder {
 	 * @param values must not be {@literal null}.
 	 * @param query must not be {@literal null}.
 	 */
-	public StringQueryParameterBinder(Parameters parameters, Object[] values, StringQuery query) {
+	public StringQueryParameterBinder(JpaParameters parameters, Object[] values, StringQuery query) {
 
 		super(parameters, values);
 
@@ -52,7 +54,7 @@ public class StringQueryParameterBinder extends ParameterBinder {
 	 * @see org.springframework.data.jpa.repository.query.ParameterBinder#bind(javax.persistence.Query, org.springframework.data.repository.query.Parameter, java.lang.Object, int)
 	 */
 	@Override
-	protected void bind(Query jpaQuery, Parameter methodParameter, Object value, int position) {
+	protected void bind(Query jpaQuery, JpaParameter methodParameter, Object value, int position) {
 
 		Object valueToBind = value;
 

--- a/src/test/java/org/springframework/data/jpa/repository/query/PartTreeJpaQueryIntegrationTests.java
+++ b/src/test/java/org/springframework/data/jpa/repository/query/PartTreeJpaQueryIntegrationTests.java
@@ -23,13 +23,21 @@ import static org.springframework.test.util.ReflectionTestUtils.*;
 
 import java.lang.reflect.Method;
 import java.util.Arrays;
+import java.util.Date;
 import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
 
 import javax.persistence.EntityManager;
+import javax.persistence.Parameter;
 import javax.persistence.PersistenceContext;
 import javax.persistence.Query;
+import javax.persistence.TemporalType;
 
 import org.hibernate.ejb.HibernateQuery;
+import org.hibernate.engine.TypedValue;
+import org.hibernate.type.TimestampType;
+import org.hibernate.type.Type;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -38,9 +46,11 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.domain.sample.User;
+import org.springframework.data.jpa.repository.TemporalParam;
 import org.springframework.data.jpa.repository.support.PersistenceProvider;
 import org.springframework.data.repository.Repository;
 import org.springframework.data.repository.core.support.DefaultRepositoryMetadata;
+import org.springframework.data.repository.query.Param;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
@@ -53,11 +63,9 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 @ContextConfiguration("classpath:infrastructure.xml")
 public class PartTreeJpaQueryIntegrationTests {
 
-	@Rule
-	public ExpectedException thrown = ExpectedException.none();
+	@Rule public ExpectedException thrown = ExpectedException.none();
 
-	@PersistenceContext
-	EntityManager entityManager;
+	@PersistenceContext EntityManager entityManager;
 
 	/**
 	 * @see DATADOC-90
@@ -111,6 +119,32 @@ public class PartTreeJpaQueryIntegrationTests {
 		assertThat(hibernateQuery.getHibernateQuery().getQueryString(), endsWith("firstname is null"));
 	}
 
+	/**
+	 * @throws Exception
+	 * @see https://jira.springsource.org/browse/DATAJPA-107
+	 */
+	@Test
+	public void shouldSetTemporalQueryParameterToTimestamp() throws Exception {
+
+		Method method = UserRepository.class.getMethod("findByCreatedAtAfter", Date.class);
+		JpaQueryMethod queryMethod = new JpaQueryMethod(method, new DefaultRepositoryMetadata(UserRepository.class),
+				PersistenceProvider.fromEntityManager(entityManager));
+		PartTreeJpaQuery jpaQuery = new PartTreeJpaQuery(queryMethod, entityManager);
+		Date date = new Date();
+		Query query = jpaQuery.createQuery(new Object[] { date });
+
+		HibernateQuery hibernateQuery = getValue(query, "h.target.val$jpaqlQuery");
+		Parameter<?> parameter = hibernateQuery.getParameter("param0");
+		Object parameterValue = hibernateQuery.getParameterValue(parameter);
+		Map<?, ?> namedParameterType = getValue(hibernateQuery.getHibernateQuery(), "namedParameters");
+		TypedValue refDateParam = (TypedValue) namedParameterType.get("param0");
+
+		assertThat(parameter, is(notNullValue()));
+		assertThat(hibernateQuery.getHibernateQuery().getQueryString(), endsWith("createdAt>:param0"));
+		assertThat(parameterValue, is((Object) date));
+		assertThat(refDateParam.getType(), is((Type) TimestampType.INSTANCE));
+	}
+
 	private void testIgnoreCase(String methodName, Object... values) throws Exception {
 
 		Class<?>[] parameterTypes = new Class[values.length];
@@ -144,5 +178,7 @@ public class PartTreeJpaQueryIntegrationTests {
 		User findByIdIgnoringCase(Integer id);
 
 		User findByIdAllIgnoringCase(Integer id);
+
+		List<User> findByCreatedAtAfter(@TemporalParam(TemporalType.TIMESTAMP) @Param("refDate") Date refDate);
 	}
 }

--- a/src/test/java/org/springframework/data/jpa/repository/query/SimpleJpaQueryUnitTests.java
+++ b/src/test/java/org/springframework/data/jpa/repository/query/SimpleJpaQueryUnitTests.java
@@ -45,7 +45,6 @@ import org.springframework.data.jpa.repository.sample.UserRepository;
 import org.springframework.data.jpa.repository.support.DefaultJpaEntityMetadata;
 import org.springframework.data.jpa.repository.support.JpaEntityMetadata;
 import org.springframework.data.repository.core.RepositoryMetadata;
-import org.springframework.data.repository.query.Parameters;
 
 /**
  * Unit test for {@link SimpleJpaQuery}.
@@ -90,7 +89,7 @@ public class SimpleJpaQueryUnitTests {
 		method = mock(JpaQueryMethod.class);
 		when(method.getCountQuery()).thenReturn("foo");
 		when(method.getParameters()).thenReturn(
-				new Parameters(SimpleJpaQueryUnitTests.class.getMethod("prefersDeclaredCountQueryOverCreatingOne")));
+				new JpaParameters(SimpleJpaQueryUnitTests.class.getMethod("prefersDeclaredCountQueryOverCreatingOne")));
 		when(method.getEntityInformation()).thenReturn((JpaEntityMetadata) new DefaultJpaEntityMetadata<User>(User.class));
 		when(em.createQuery("foo", Long.class)).thenReturn(query);
 


### PR DESCRIPTION
...query-methods.

Introduced JpaParameters abstraction to support custom jpa-specific annotations on query parameters.
Adjusted Parameter binders to use the JpaParameters abstraction.
Added special handling for temporal JpaParameters to ParameterBinder.bind(…) and CriteriaQueryParameterBinder.bind(…). 
Added test case to ParameterBinderUnitTests.
Added test case to PartTreeJpaQueryIntegrationTests.
