### PR TITLE
Provide JPA repository interface without paging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,7 @@ target/
 .springBeans
 .sonar4clipse
 *.sonar4clipseExternals
+*.iml
+*.ipr
+*.iws
+/.idea/

--- a/src/main/java/org/springframework/data/jpa/repository/CrudJpaRepository.java
+++ b/src/main/java/org/springframework/data/jpa/repository/CrudJpaRepository.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.jpa.repository;
+
+import java.io.Serializable;
+import java.util.List;
+
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.data.repository.NoRepositoryBean;
+
+/**
+ * JPA specific extension of {@link org.springframework.data.repository.Repository} that supports all CRUD operations
+ * from {@link CrudRepository}. You will probably want to use {@link JpaRepository}, which also supports
+ * pagination with {@link org.springframework.data.repository.PagingAndSortingRepository}. This simply provides a
+ * cleaner interface for when you do not want to expose the pagination methods.
+ * <p>
+ * All current implementations of this interface also implement {@link JpaRepository}.
+ *
+ * @author Oliver Gierke
+ * @author Nick Williams
+ */
+@NoRepositoryBean
+public interface CrudJpaRepository<T, ID extends Serializable> extends CrudRepository<T, ID> {
+
+    /*
+     * (non-Javadoc)
+     * @see org.springframework.data.repository.CrudRepository#findAll()
+     */
+    List<T> findAll();
+
+    /*
+     * (non-Javadoc)
+     * @see org.springframework.data.repository.CrudRepository#findAll(java.lang.Iterable)
+     */
+    List<T> findAll(Iterable<ID> ids);
+
+    /*
+     * (non-Javadoc)
+     * @see org.springframework.data.repository.CrudRepository#save(java.lang.Iterable)
+     */
+    <S extends T> List<S> save(Iterable<S> entities);
+
+    /**
+     * Flushes all pending changes to the database.
+     */
+    void flush();
+
+    /**
+     * Saves an entity and flushes changes instantly.
+     *
+     * @param entity The entity to save
+     * @return the saved entity.
+     */
+    T saveAndFlush(T entity);
+
+    /**
+     * Deletes the given entities in a batch which means it will create a single {@link Query}. Assume that we will clear
+     * the {@link javax.persistence.EntityManager} after the call.
+     *
+     * @param entities The entities to delete
+     */
+    void deleteInBatch(Iterable<T> entities);
+
+    /**
+     * Deletes all entities in a batch call.
+     */
+    void deleteAllInBatch();
+}

--- a/src/main/java/org/springframework/data/jpa/repository/JpaRepository.java
+++ b/src/main/java/org/springframework/data/jpa/repository/JpaRepository.java
@@ -26,57 +26,15 @@ import org.springframework.data.repository.PagingAndSortingRepository;
  * JPA specific extension of {@link org.springframework.data.repository.Repository}.
  * 
  * @author Oliver Gierke
+ * @author Nick Williams
  */
 @NoRepositoryBean
-public interface JpaRepository<T, ID extends Serializable> extends PagingAndSortingRepository<T, ID> {
-
-	/*
-	 * (non-Javadoc)
-	 * @see org.springframework.data.repository.CrudRepository#findAll()
-	 */
-	List<T> findAll();
+public interface JpaRepository<T, ID extends Serializable>
+        extends CrudJpaRepository<T, ID>, PagingAndSortingRepository<T, ID> {
 
 	/*
 	 * (non-Javadoc)
 	 * @see org.springframework.data.repository.PagingAndSortingRepository#findAll(org.springframework.data.domain.Sort)
 	 */
 	List<T> findAll(Sort sort);
-
-	/*
-	 * (non-Javadoc)
-	 * @see org.springframework.data.repository.CrudRepository#findAll(java.lang.Iterable)
-	 */
-	List<T> findAll(Iterable<ID> ids);
-
-	/*
-	 * (non-Javadoc)
-	 * @see org.springframework.data.repository.CrudRepository#save(java.lang.Iterable)
-	 */
-	<S extends T> List<S> save(Iterable<S> entities);
-
-	/**
-	 * Flushes all pending changes to the database.
-	 */
-	void flush();
-
-	/**
-	 * Saves an entity and flushes changes instantly.
-	 * 
-	 * @param entity
-	 * @return the saved entity
-	 */
-	T saveAndFlush(T entity);
-
-	/**
-	 * Deletes the given entities in a batch which means it will create a single {@link Query}. Assume that we will clear
-	 * the {@link javax.persistence.EntityManager} after the call.
-	 * 
-	 * @param entities
-	 */
-	void deleteInBatch(Iterable<T> entities);
-
-	/**
-	 * Deletes all entites in a batch call.
-	 */
-	void deleteAllInBatch();
 }

--- a/src/test/java/org/springframework/data/jpa/repository/UserRepositoryTests.java
+++ b/src/test/java/org/springframework/data/jpa/repository/UserRepositoryTests.java
@@ -55,6 +55,7 @@ import org.springframework.data.domain.Sort.Order;
 import org.springframework.data.jpa.domain.Specification;
 import org.springframework.data.jpa.domain.sample.Role;
 import org.springframework.data.jpa.domain.sample.User;
+import org.springframework.data.jpa.repository.sample.CrudOnlyUserRepository;
 import org.springframework.data.jpa.repository.sample.UserRepository;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
@@ -68,6 +69,7 @@ import org.springframework.transaction.annotation.Transactional;
  * 
  * @author Oliver Gierke
  * @author Kevin Raymond
+ * @author Nick Williams
  */
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration("classpath:application-context.xml")
@@ -78,6 +80,7 @@ public class UserRepositoryTests {
 
 	// CUT
 	@Autowired UserRepository repository;
+    @Autowired CrudOnlyUserRepository crudOnlyRepository;
 
 	// Test fixture
 	User firstUser, secondUser, thirdUser, fourthUser;
@@ -115,6 +118,9 @@ public class UserRepositoryTests {
 
 		User foundPerson = repository.findOne(id);
 		assertThat(firstUser.getFirstname(), is(foundPerson.getFirstname()));
+
+        User foundPerson2 = crudOnlyRepository.findOne(id);
+        assertThat(firstUser.getFirstname(), is(foundPerson2.getFirstname()));
 	}
 
 	@Test

--- a/src/test/java/org/springframework/data/jpa/repository/sample/CrudOnlyUserRepository.java
+++ b/src/test/java/org/springframework/data/jpa/repository/sample/CrudOnlyUserRepository.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.jpa.repository.sample;
+
+import org.springframework.data.jpa.domain.sample.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+/**
+ * Interface for testing that CRUD-only repositories implementing CrudJpaRepository still work.
+ *
+ * @author Nick Williams
+ */
+public interface CrudOnlyUserRepository extends JpaRepository<User, Integer> {
+}

--- a/src/test/resources/application-context.xml
+++ b/src/test/resources/application-context.xml
@@ -22,6 +22,12 @@
 			</bean>
 		</property>
 	</bean>
+
+	<!-- Configure a CRUD-only DAO for User class -->
+	<bean id="crudOnlyUserDao" class="org.springframework.data.jpa.repository.support.JpaRepositoryFactoryBean">
+		<property name="repositoryInterface"
+				  value="org.springframework.data.jpa.repository.sample.CrudOnlyUserRepository" />
+	</bean>
 	
 	<bean id="roleDao" class="org.springframework.data.jpa.repository.support.JpaRepositoryFactoryBean">
 		<property name="repositoryInterface" value="org.springframework.data.jpa.repository.sample.RoleRepository" />


### PR DESCRIPTION
This is a binary compatible change with no functional side effects.

In an ideal world, `JpaRepository` would have extended `CrudRepository` and a hypothetical `PagingAndSortingJpaRepository` would have extended `JpaRepository` and `PagingAndSortingRepository`. However, that would be a breaking change to make now, so it's not an option.

This change created a new interface named `CrudJpaRepository`. It extends `CrudRepository`. All of the methods currently in `JpaRepository` were moved to `CrudJpaRepository` except for `findAll(Sort)` (a paging method), and `JpaRepository` was changed to extend `CrudJpaRepository` and `PagingAndSortingRepository`.
