### PR TITLE
DATAJPA-389 - Introduce NativeSqlQuery type for native sql queries.

### DIFF
--- a/src/main/java/org/springframework/data/jpa/repository/query/AbstractJpaQuery.java
+++ b/src/main/java/org/springframework/data/jpa/repository/query/AbstractJpaQuery.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2008-2011 the original author or authors.
+ * Copyright 2008-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,6 +32,7 @@ import org.springframework.util.Assert;
  * Abstract base class to implement {@link RepositoryQuery}s.
  * 
  * @author Oliver Gierke
+ * @author Thomas Darimont
  */
 public abstract class AbstractJpaQuery implements RepositoryQuery {
 

--- a/src/main/java/org/springframework/data/jpa/repository/query/ExpressionBasedStringQuery.java
+++ b/src/main/java/org/springframework/data/jpa/repository/query/ExpressionBasedStringQuery.java
@@ -59,10 +59,10 @@ class ExpressionBasedStringQuery extends StringQuery {
 	 * @see org.springframework.data.jpa.repository.query.StringQuery#getQuery()
 	 */
 	@Override
-	public String getQuery() {
+	public String getQueryString() {
 
 		if (parsedQuery == null) {
-			String rawQuery = super.getQuery();
+			String rawQuery = super.getQueryString();
 			this.parsedQuery = renderQueryIfExpressionOrReturnQuery(rawQuery);
 		}
 

--- a/src/main/java/org/springframework/data/jpa/repository/query/JpaQueryFactory.java
+++ b/src/main/java/org/springframework/data/jpa/repository/query/JpaQueryFactory.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.jpa.repository.query;
+
+import javax.persistence.EntityManager;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.data.repository.query.RepositoryQuery;
+
+/**
+ * @author Thomas Darimont
+ */
+enum JpaQueryFactory {
+	INSTANCE;
+
+	private static final Logger LOG = LoggerFactory.getLogger(JpaQueryFactory.class);
+
+	/**
+	 * Creates a {@link RepositoryQuery} from the given {@link org.springframework.data.repository.query.QueryMethod} that
+	 * is potentially annotated with {@link org.springframework.data.jpa.repository.Query}.
+	 * 
+	 * @param queryMethod
+	 * @param em
+	 * @return the {@link RepositoryQuery} derived from the annotation or {@code null} if no annotation found.
+	 */
+	RepositoryQuery fromQueryAnnotation(JpaQueryMethod queryMethod, EntityManager em) {
+
+		LOG.debug("Looking up query for method {}", queryMethod.getName());
+
+		return fromMethodWithQueryString(queryMethod, em, queryMethod.getAnnotatedQuery());
+	}
+
+	/**
+	 * @param method
+	 * @param em
+	 * @param queryString
+	 * @return
+	 */
+	RepositoryQuery fromMethodWithQueryString(JpaQueryMethod method, EntityManager em, String queryString) {
+
+		if (queryString == null) {
+			return null;
+		}
+
+		if (method.isNativeQuery()) {
+			return new NativeJpaQuery(method, em, queryString);
+		}
+
+		return new SimpleJpaQuery(method, em, queryString);
+	}
+}

--- a/src/main/java/org/springframework/data/jpa/repository/query/JpaQueryLookupStrategy.java
+++ b/src/main/java/org/springframework/data/jpa/repository/query/JpaQueryLookupStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2008-2012 the original author or authors.
+ * Copyright 2008-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,6 +29,7 @@ import org.springframework.data.repository.query.RepositoryQuery;
  * Query lookup strategy to execute finders.
  * 
  * @author Oliver Gierke
+ * @author Thomas Darimont
  */
 public final class JpaQueryLookupStrategy {
 
@@ -111,7 +112,7 @@ public final class JpaQueryLookupStrategy {
 		@Override
 		protected RepositoryQuery resolveQuery(JpaQueryMethod method, EntityManager em, NamedQueries namedQueries) {
 
-			RepositoryQuery query = SimpleJpaQuery.fromQueryAnnotation(method, em);
+			RepositoryQuery query = JpaQueryFactory.INSTANCE.fromQueryAnnotation(method, em);
 
 			if (null != query) {
 				return query;
@@ -119,7 +120,7 @@ public final class JpaQueryLookupStrategy {
 
 			String name = method.getNamedQueryName();
 			if (namedQueries.hasQuery(name)) {
-				return new SimpleJpaQuery(method, em, namedQueries.getQuery(name));
+				return JpaQueryFactory.INSTANCE.fromMethodWithQueryString(method, em, namedQueries.getQuery(name));
 			}
 
 			query = NamedQuery.lookupFrom(method, em);
@@ -178,14 +179,14 @@ public final class JpaQueryLookupStrategy {
 		}
 
 		switch (key) {
-		case CREATE:
-			return new CreateQueryLookupStrategy(em, extractor);
-		case USE_DECLARED_QUERY:
-			return new DeclaredQueryLookupStrategy(em, extractor);
-		case CREATE_IF_NOT_FOUND:
-			return new CreateIfNotFoundQueryLookupStrategy(em, extractor);
-		default:
-			throw new IllegalArgumentException(String.format("Unsupported query lookup strategy %s!", key));
+			case CREATE:
+				return new CreateQueryLookupStrategy(em, extractor);
+			case USE_DECLARED_QUERY:
+				return new DeclaredQueryLookupStrategy(em, extractor);
+			case CREATE_IF_NOT_FOUND:
+				return new CreateIfNotFoundQueryLookupStrategy(em, extractor);
+			default:
+				throw new IllegalArgumentException(String.format("Unsupported query lookup strategy %s!", key));
 		}
 	}
 }

--- a/src/main/java/org/springframework/data/jpa/repository/query/NativeJpaQuery.java
+++ b/src/main/java/org/springframework/data/jpa/repository/query/NativeJpaQuery.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.jpa.repository.query;
+
+import javax.persistence.EntityManager;
+import javax.persistence.Query;
+
+import org.springframework.data.repository.query.Parameters;
+import org.springframework.data.repository.query.RepositoryQuery;
+
+/**
+ * {@link RepositoryQuery} implementation that inspects a {@link org.springframework.data.repository.query.QueryMethod}
+ * for the existence of an {@link org.springframework.data.jpa.repository.Query} annotation and creates a JPA native
+ * {@link Query} from it.
+ * 
+ * @author Thomas Darimont
+ */
+final class NativeJpaQuery extends AbstractStringBasedJpaQuery {
+
+	/**
+	 * Creates a new {@link NativeJpaQuery} encapsulating the query annotated on the given {@link JpaQueryMethod}.
+	 * 
+	 * @param method
+	 * @param em
+	 * @param queryString
+	 */
+	public NativeJpaQuery(JpaQueryMethod method, EntityManager em, String queryString) {
+
+		super(method, em, queryString);
+
+		Parameters<?, ?> parameters = method.getParameters();
+		boolean hasPagingOrSortingParameter = parameters.hasPageableParameter() || parameters.hasSortParameter();
+
+		if (hasPagingOrSortingParameter) {
+			throw new IllegalStateException("Cannot use native queries with dynamic sorting and/or pagination!");
+		}
+	}
+
+	/* (non-Javadoc)
+	 * @see org.springframework.data.jpa.repository.query.BasicJpaQuery#createJpaQuery(javax.persistence.EntityManager, java.lang.String)
+	 */
+	@Override
+	Query createJpaQuery(String queryString) {
+		return getQueryMethod().isQueryForEntity() ? getEntityManager().createNativeQuery(queryString,
+				getQueryMethod().getReturnedObjectType()) : getEntityManager().createNativeQuery(queryString);
+	}
+}

--- a/src/main/java/org/springframework/data/jpa/repository/query/StringQuery.java
+++ b/src/main/java/org/springframework/data/jpa/repository/query/StringQuery.java
@@ -32,6 +32,7 @@ import org.springframework.util.StringUtils;
  * Encapsulation of a String JPA query.
  * 
  * @author Oliver Gierke
+ * @author Thomas Darimont
  */
 class StringQuery {
 
@@ -88,11 +89,11 @@ class StringQuery {
 	}
 
 	/**
-	 * Returns the JPQL query.
+	 * Returns the query string.
 	 * 
 	 * @return
 	 */
-	public String getQuery() {
+	public String getQueryString() {
 		return query;
 	}
 

--- a/src/test/java/org/springframework/data/jpa/repository/query/ExpressionBasedStringQueryUnitTests.java
+++ b/src/test/java/org/springframework/data/jpa/repository/query/ExpressionBasedStringQueryUnitTests.java
@@ -46,6 +46,6 @@ public class ExpressionBasedStringQueryUnitTests {
 
 		String source = "select from #{#entityName} u where u.firstname like :firstname";
 		StringQuery query = new ExpressionBasedStringQuery(source, metadata);
-		assertThat(query.getQuery(), is("select from User u where u.firstname like :firstname"));
+		assertThat(query.getQueryString(), is("select from User u where u.firstname like :firstname"));
 	}
 }

--- a/src/test/java/org/springframework/data/jpa/repository/query/StringQueryUnitTests.java
+++ b/src/test/java/org/springframework/data/jpa/repository/query/StringQueryUnitTests.java
@@ -41,7 +41,7 @@ public class StringQueryUnitTests {
 		StringQuery query = new StringQuery(source);
 
 		assertThat(query.hasLikeBindings(), is(true));
-		assertThat(query.getQuery(), is(source));
+		assertThat(query.getQueryString(), is(source));
 
 		List<LikeBinding> bindings = query.getLikeBindings();
 		assertThat(bindings, hasSize(1));
@@ -57,7 +57,7 @@ public class StringQueryUnitTests {
 		StringQuery query = new StringQuery("select u from User u where u.firstname like %?1% or u.lastname like %?2");
 
 		assertThat(query.hasLikeBindings(), is(true));
-		assertThat(query.getQuery(), is("select u from User u where u.firstname like ?1 or u.lastname like ?2"));
+		assertThat(query.getQueryString(), is("select u from User u where u.firstname like ?1 or u.lastname like ?2"));
 
 		List<LikeBinding> bindings = query.getLikeBindings();
 		assertThat(bindings, hasSize(2));
@@ -79,7 +79,7 @@ public class StringQueryUnitTests {
 		StringQuery query = new StringQuery("select u from User u where u.firstname like %:firstname");
 
 		assertThat(query.hasLikeBindings(), is(true));
-		assertThat(query.getQuery(), is("select u from User u where u.firstname like :firstname"));
+		assertThat(query.getQueryString(), is("select u from User u where u.firstname like :firstname"));
 
 		List<LikeBinding> bindings = query.getLikeBindings();
 		assertThat(bindings, hasSize(1));


### PR DESCRIPTION
Extracted the functionality specific to the handling of native queries out of SimpleJpaQuery and moved that to the new NativeJpaQuery type. Moved common functionality to AbstractStringBasedJpaQuery and used that as a new base class for SimpleJpaQuery and NativeJpaQuery. Introduced JpqQueryFactory to centralise construction of JpaQuery objects. Renamed getQuery() method in StringQuery to getQueryString().
