### PR TITLE
DATAJPA-398 - Naming a finder findAll injects the one from SimpleJpaRepo...

### DIFF
--- a/src/main/java/org/springframework/data/jpa/repository/Query.java
+++ b/src/main/java/org/springframework/data/jpa/repository/Query.java
@@ -21,6 +21,8 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+import org.springframework.data.annotation.QueryAnnotation;
+
 /**
  * Annotation to declare finder queries directly on repository methods.
  * 
@@ -28,6 +30,7 @@ import java.lang.annotation.Target;
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.METHOD)
+@QueryAnnotation
 @Documented
 public @interface Query {
 

--- a/src/test/java/org/springframework/data/jpa/repository/RedeclaringRepositoryMethodsTests.java
+++ b/src/test/java/org/springframework/data/jpa/repository/RedeclaringRepositoryMethodsTests.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.jpa.repository;
+
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.*;
+
+import java.util.List;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.ImportResource;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.jpa.domain.sample.User;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+import org.springframework.data.jpa.repository.sample.RedeclaringRepositoryMethodsRepository;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * @author Thomas Darimont
+ */
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration
+@Transactional
+public class RedeclaringRepositoryMethodsTests {
+
+	@Configuration
+	@ImportResource("classpath:infrastructure.xml")
+	@EnableJpaRepositories
+	static class Config {}
+
+	@Autowired RedeclaringRepositoryMethodsRepository repository;
+
+	User olli;
+	User tom;
+
+	@Before
+	public void setup() {
+		olli = new User("Oliver", "Gierke", "ogierke@gopivotal.com");
+		tom = new User("Thomas", "Darimont", "tdarimont@gopivotal.com");
+	}
+
+	/**
+	 * @see DATAJPA-398
+	 */
+	@Test
+	public void adjustedWellKnownPagedFindAllMethodShouldReturnOnlyTheUserWithFirstnameOliver() {
+
+		olli = repository.save(olli);
+		tom = repository.save(tom);
+
+		Page<User> page = repository.findAll(new PageRequest(0, 2));
+
+		assertThat(page.getNumberOfElements(), is(1));
+		assertThat(page.getContent().get(0).getFirstname(), is("Oliver"));
+	}
+
+	/**
+	 * @see DATAJPA-398
+	 */
+	@Test
+	public void adjustedWllKnownFindAllMethodShouldReturnAnEmptyList() {
+
+		olli = repository.save(olli);
+		tom = repository.save(tom);
+
+		List<User> result = repository.findAll();
+
+		assertThat(result.isEmpty(), is(true));
+	}
+
+}

--- a/src/test/java/org/springframework/data/jpa/repository/sample/RedeclaringRepositoryMethodsRepository.java
+++ b/src/test/java/org/springframework/data/jpa/repository/sample/RedeclaringRepositoryMethodsRepository.java
@@ -1,0 +1,33 @@
+package org.springframework.data.jpa.repository.sample;
+
+import java.util.List;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.domain.sample.User;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.CrudRepository;
+
+/**
+ * Custom Repository Interface that adjusts the querys of well known repository interface Methods via {@link Query}
+ * annotation.
+ * 
+ * @author Thomas Darimont
+ */
+public interface RedeclaringRepositoryMethodsRepository extends CrudRepository<User, Long> {
+
+	/**
+	 * Should not find any users at all.
+	 */
+	@Query("SELECT u FROM User u where u.id = -1")
+	List<User> findAll();
+
+	/**
+	 * Should only find users with the firstname 'Oliver'.
+	 * 
+	 * @param page
+	 * @return
+	 */
+	@Query("SELECT u FROM User u where u.firstname = 'Oliver'")
+	Page<User> findAll(Pageable page);
+}


### PR DESCRIPTION
...sitory instead of my own.

Added test case to verify that it is possible to adjust the query of well known repository interface methods like findAll() via @Query.

Note: This requires DATACMNS-364 to be merged into master.
