### PR TITLE
DATAJPA-396 - CriteriaQuery caching causes problems with Hibernate name generation in threaded environments.

### DIFF
--- a/src/main/java/org/springframework/data/jpa/repository/query/PartTreeJpaQuery.java
+++ b/src/main/java/org/springframework/data/jpa/repository/query/PartTreeJpaQuery.java
@@ -130,7 +130,7 @@ public class PartTreeJpaQuery extends AbstractJpaQuery {
 			 *  
 			 *  @see https://jira.springsource.org/browse/DATAJPA-396
 			 */
-			if (this.cachedQuery == criteriaQuery) {
+			if (this.cachedQuery != null) {
 				synchronized (this.cachedQuery) {
 					return getEntityManager().createQuery(criteriaQuery);
 				}


### PR DESCRIPTION
Renamed field "query" in QueryPreparer to "cachedQuery" to make it's purpose more clear. Extracted EntityManager query creation into new  QueryPreparer.createQuery(CriteriaQuery) method to deal with the conditional synchronization.
