### PR TITLE
DATAJPA-407 - ClasspathScanningPersistenceUnitPostProcessor throws Index...

### DIFF
--- a/src/main/java/org/springframework/data/jpa/support/ClasspathScanningPersistenceUnitPostProcessor.java
+++ b/src/main/java/org/springframework/data/jpa/support/ClasspathScanningPersistenceUnitPostProcessor.java
@@ -15,7 +15,6 @@
  */
 package org.springframework.data.jpa.support;
 
-import java.io.File;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.HashSet;
@@ -122,8 +121,15 @@ public class ClasspathScanningPersistenceUnitPostProcessor implements Persistenc
 			return Collections.emptySet();
 		}
 
-		String basePackagePathComponent = basePackage.replace('.', File.separatorChar);
-		String path = ResourcePatternResolver.CLASSPATH_ALL_URL_PREFIX + basePackagePathComponent + File.separator
+		/*
+		 * Note that we cannot use File.pathSeparator here since resourcePath uses a forward slash path ('/') separator 
+		 * being an URI, while basePackagePathComponent has system dependent separator (on windows it's the backslash separator). 
+		 * 
+		 * @see DATAJPA-407  
+		 */
+		char slash = '/';
+		String basePackagePathComponent = basePackage.replace('.', slash);
+		String path = ResourcePatternResolver.CLASSPATH_ALL_URL_PREFIX + basePackagePathComponent + slash
 				+ mappingFileNamePattern;
 		Set<String> mappingFileUris = new HashSet<String>();
 		Resource[] scannedResources = new Resource[0];

--- a/src/test/java/org/springframework/data/jpa/support/ClasspathScanningPersistenceUnitPostProcessorUnitTests.java
+++ b/src/test/java/org/springframework/data/jpa/support/ClasspathScanningPersistenceUnitPostProcessorUnitTests.java
@@ -72,6 +72,9 @@ public class ClasspathScanningPersistenceUnitPostProcessorUnitTests {
 		verify(pui).addManagedClassName(SampleEntity.class.getName());
 	}
 
+	/**
+	 * @see DATAJPA-407
+	 */
 	@Test
 	public void findsMappingFile() {
 
@@ -89,6 +92,7 @@ public class ClasspathScanningPersistenceUnitPostProcessorUnitTests {
 
 	/**
 	 * @see DATAJPA-353
+	 * @see DATAJPA-407
 	 */
 	@Test
 	public void shouldFindJpaMappingFilesFromMultipleLocationsOnClasspath() {


### PR DESCRIPTION
...OutOfBoundsException on Windows.

We cannot use File.pathSeparator here since it is platform dependent but the resource path is an URI that always uses forward slashes.
Modified scanForMappingFileLocations() to use '/' to build the resource path.
