### PR TITLE
DATAJPA-416 - Add support for nested repositories.

### DIFF
--- a/src/main/java/org/springframework/data/jpa/repository/config/EnableJpaRepositories.java
+++ b/src/main/java/org/springframework/data/jpa/repository/config/EnableJpaRepositories.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012 the original author or authors.
+ * Copyright 2012-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,6 +37,7 @@ import org.springframework.transaction.PlatformTransactionManager;
  * repositories by default.
  * 
  * @author Oliver Gierke
+ * @author Thomas Darimont
  */
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)
@@ -108,7 +109,7 @@ public @interface EnableJpaRepositories {
 	 */
 	Class<?> repositoryFactoryBeanClass() default JpaRepositoryFactoryBean.class;
 
-	// JPA sepcific configuration
+	// JPA specific configuration
 	/**
 	 * Configures the name of the {@link EntityManagerFactory} bean definition to be used to create repositories
 	 * discovered through this annotation. Defaults to {@code entityManagerFactory}.
@@ -118,10 +119,16 @@ public @interface EnableJpaRepositories {
 	String entityManagerFactoryRef() default "entityManagerFactory";
 
 	/**
-	 * /** Configures the name of the {@link PlatformTransactionManager} bean definition to be used to create repositories
+	 * Configures the name of the {@link PlatformTransactionManager} bean definition to be used to create repositories
 	 * discovered through this annotation. Defaults to {@code transactionManager}.
 	 * 
 	 * @return
 	 */
 	String transactionManagerRef() default "transactionManager";
+
+	/**
+	 * Configures whether nested repository-interfaces (e.g. defined as inner classes) should be discovered by the
+	 * repositories infrastructure.
+	 */
+	boolean considerNestedRepositories() default false;
 }

--- a/src/test/java/org/springframework/data/jpa/repository/config/AllowNestedRepositoriesRepositoryConfigTests.java
+++ b/src/test/java/org/springframework/data/jpa/repository/config/AllowNestedRepositoriesRepositoryConfigTests.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2008-2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.jpa.repository.config;
+
+import static org.hamcrest.CoreMatchers.*;
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.jpa.repository.sample.ClassWithNestedRepository.NestedUserRepository;
+import org.springframework.test.context.ContextConfiguration;
+
+/**
+ * Integration test for repository name-space configuration with nested repositories.
+ * 
+ * @author Thomas Darimont
+ */
+@ContextConfiguration(locations = "classpath:config/namespace-nested-repositories-application-context.xml")
+public class AllowNestedRepositoriesRepositoryConfigTests extends AbstractRepositoryConfigTests {
+
+	@Autowired NestedUserRepository fooRepository;
+
+	/**
+	 * @see DATAJPA-416
+	 */
+	@Test
+	public void shouldFindNestedRepository() {
+
+		assertThat(fooRepository, is(notNullValue()));
+	}
+}

--- a/src/test/java/org/springframework/data/jpa/repository/config/NestedRepositoriesJavaConfigTests.java
+++ b/src/test/java/org/springframework/data/jpa/repository/config/NestedRepositoriesJavaConfigTests.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.jpa.repository.config;
+
+import static org.hamcrest.CoreMatchers.*;
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.ImportResource;
+import org.springframework.data.jpa.repository.sample.ClassWithNestedRepository.NestedUserRepository;
+import org.springframework.data.jpa.repository.sample.UserRepository;
+import org.springframework.data.repository.support.Repositories;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+/**
+ * Integration test for the combination of JavaConfig and an {@link Repositories} wrapper.
+ * 
+ * @author Thomas Darimont
+ */
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration
+public class NestedRepositoriesJavaConfigTests {
+
+	@Configuration
+	@EnableJpaRepositories(basePackageClasses = UserRepository.class, considerNestedRepositories = true)
+	@ImportResource("classpath:infrastructure.xml")
+	static class Config {}
+
+	@Autowired NestedUserRepository nestedUserRepository;
+
+	/**
+	 * @see DATAJPA-416
+	 */
+	@Test
+	public void shouldSupportNestedRepositories() {
+
+		assertThat(nestedUserRepository, is(notNullValue()));
+	}
+}

--- a/src/test/java/org/springframework/data/jpa/repository/sample/ClassWithNestedRepository.java
+++ b/src/test/java/org/springframework/data/jpa/repository/sample/ClassWithNestedRepository.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.jpa.repository.sample;
+
+import org.springframework.data.jpa.domain.sample.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+/**
+ * @see DATACMNS-90
+ * @author Thomas Darimont
+ */
+public class ClassWithNestedRepository {
+
+	public static interface NestedUserRepository extends JpaRepository<User, Integer> {}
+}

--- a/src/test/resources/config/namespace-nested-repositories-application-context.xml
+++ b/src/test/resources/config/namespace-nested-repositories-application-context.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:jpa="http://www.springframework.org/schema/data/jpa"
+	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/data/jpa http://www.springframework.org/schema/data/jpa/spring-jpa.xsd">
+
+	<import resource="../infrastructure.xml" />
+
+	<jpa:repositories base-package="org.springframework.**.repository.sample"  consider-nested-repositories="true"/>
+
+</beans>


### PR DESCRIPTION
Support for considering nested repository interfaces can now be configured on the EnableJpaRepositories annotation via the considerNestedRepositories property. Previously nested repository definitions were ignored by the repositories infrastructure.

This depends on DATACMNS-90.
