### PR TITLE
DATAJPA-410 - Improved documentation on jpa:repository namespace.

### DIFF
--- a/src/docbkx/jpa.xml
+++ b/src/docbkx/jpa.xml
@@ -90,6 +90,11 @@
             </tbody>
           </tgroup>
         </table>
+
+        <para>Note that we require a
+        <classname>PlatformTransactionManager</classname> bean named
+        <code>transactionManager</code> to be present if no explicit
+        <code>transaction-manager-ref</code> is defined.</para>
       </simplesect>
     </section>
 


### PR DESCRIPTION
We now mention that we require a bean with name transactionManager to be present if no transaction-manager-ref is defined.
