### PR TITLE
Better error message. If a param is not annotated with @Param it is now ...

### DIFF
--- a/src/main/java/org/springframework/data/jpa/repository/query/StringQuery.java
+++ b/src/main/java/org/springframework/data/jpa/repository/query/StringQuery.java
@@ -102,7 +102,7 @@ class StringQuery {
 	 */
 	public ParameterBinding getBindingFor(String name) {
 
-		Assert.hasText(name, "Name must not be null or empty!");
+		Assert.hasText(name, "Name for parameter binding must not be null or empty!");
 
 		for (ParameterBinding binding : bindings) {
 			if (binding.hasName(name)) {


### PR DESCRIPTION
...easier to see the problem. It took me some time to figure out where the error message came from. So this should be make it a bit more clearer.
