### PR TITLE
DATAJPA-514 - Make query hints and lock support more open

### DIFF
--- a/src/main/java/org/springframework/data/jpa/repository/query/JpaQueryMethod.java
+++ b/src/main/java/org/springframework/data/jpa/repository/query/JpaQueryMethod.java
@@ -138,7 +138,7 @@ public class JpaQueryMethod extends QueryMethod {
 	 * 
 	 * @return
 	 */
-	List<QueryHint> getHints() {
+	protected List<QueryHint> getHints() {
 
 		List<QueryHint> result = new ArrayList<QueryHint>();
 
@@ -155,7 +155,7 @@ public class JpaQueryMethod extends QueryMethod {
 	 * 
 	 * @return
 	 */
-	LockModeType getLockModeType() {
+	protected LockModeType getLockModeType() {
 
 		Lock annotation = findAnnotation(method, Lock.class);
 		return (LockModeType) AnnotationUtils.getValue(annotation);

--- a/src/main/java/org/springframework/data/jpa/repository/query/JpaQueryMethodFactory.java
+++ b/src/main/java/org/springframework/data/jpa/repository/query/JpaQueryMethodFactory.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2011-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.jpa.repository.query;
+
+import java.lang.reflect.Method;
+
+import org.springframework.data.repository.core.RepositoryMetadata;
+import org.springframework.data.repository.query.QueryLookupStrategy;
+
+/**
+ * Factory to create the {@link JpaQueryMethod} in {@link QueryLookupStrategy}.
+ * Allows to create instances of sub-classes of {@link JpaQueryMethod}, to
+ * customize behavior like the lookup of query hints or lock mode.
+ * 
+ * @author Arnaud Cogoluègnes
+ */
+public interface JpaQueryMethodFactory {
+
+	JpaQueryMethod create(Method method, RepositoryMetadata metadata, QueryExtractor extractor);
+	
+}

--- a/src/main/java/org/springframework/data/jpa/repository/support/CrudMethodMetadataPostProcessor.java
+++ b/src/main/java/org/springframework/data/jpa/repository/support/CrudMethodMetadataPostProcessor.java
@@ -43,7 +43,7 @@ import org.springframework.util.Assert;
  * 
  * @author Oliver Gierke
  */
-enum CrudMethodMetadataPostProcessor implements RepositoryProxyPostProcessor {
+enum CrudMethodMetadataPostProcessor implements CrudMethodMetadataProvider {
 
 	INSTANCE;
 
@@ -58,9 +58,9 @@ enum CrudMethodMetadataPostProcessor implements RepositoryProxyPostProcessor {
 		factory.addAdvice(CrudMethodMetadataPopulatingMethodIntercceptor.INSTANCE);
 	}
 
-	/**
-	 * Returns a {@link CrudMethodMetadata} proxy that will lookup the actual target object by obtaining a thread bound
-	 * instance from the {@link TransactionSynchronizationManager} later.
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.jpa.repository.support.CrudMethodMetadataProvider#getLockMetadataProvider()
 	 */
 	public CrudMethodMetadata getLockMetadataProvider() {
 

--- a/src/main/java/org/springframework/data/jpa/repository/support/CrudMethodMetadataProvider.java
+++ b/src/main/java/org/springframework/data/jpa/repository/support/CrudMethodMetadataProvider.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2011-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.jpa.repository.support;
+
+import org.springframework.data.repository.core.support.RepositoryProxyPostProcessor;
+
+/**
+ * Contract to redeclare CRUD methods in repository interfaces.
+ * Allows to configure locking information or query hints on the repository methods.
+ * Extends {@link RepositoryProxyPostProcessor} to be able to set up interceptors
+ * to read metadata information from the invoked method.
+ * 
+ * @author Arnaud Cogoluègnes
+ */
+public interface CrudMethodMetadataProvider extends RepositoryProxyPostProcessor {
+
+	/**
+	 * Returns a {@link CrudMethodMetadata} for the method that is currently invoked.
+	 * The implementation is thus supposed to know about this method.
+	 * @return
+	 */
+	public CrudMethodMetadata getLockMetadataProvider();
+	
+}

--- a/src/main/java/org/springframework/data/jpa/repository/support/JpaRepositoryFactory.java
+++ b/src/main/java/org/springframework/data/jpa/repository/support/JpaRepositoryFactory.java
@@ -40,7 +40,7 @@ public class JpaRepositoryFactory extends RepositoryFactorySupport {
 
 	private final EntityManager entityManager;
 	private final QueryExtractor extractor;
-	private final CrudMethodMetadataPostProcessor lockModePostProcessor;
+	private final CrudMethodMetadataProvider lockModePostProcessor;
 
 	/**
 	 * Creates a new {@link JpaRepositoryFactory}.
@@ -48,12 +48,22 @@ public class JpaRepositoryFactory extends RepositoryFactorySupport {
 	 * @param entityManager must not be {@literal null}
 	 */
 	public JpaRepositoryFactory(EntityManager entityManager) {
-
+		this(entityManager,CrudMethodMetadataPostProcessor.INSTANCE);
+	}
+	
+	/**
+	 * Creates a new {@link JpaRepositoryFactory}.
+	 * 
+	 * @param entityManager must not be {@literal null}
+	 * @param crudMethodMetadataPostProcessor must not be {@literal null}
+	 */
+	public JpaRepositoryFactory(EntityManager entityManager, CrudMethodMetadataProvider crudMethodMetadataProvider) {
 		Assert.notNull(entityManager);
+		Assert.notNull(crudMethodMetadataProvider);
 
 		this.entityManager = entityManager;
 		this.extractor = PersistenceProvider.fromEntityManager(entityManager);
-		this.lockModePostProcessor = CrudMethodMetadataPostProcessor.INSTANCE;
+		this.lockModePostProcessor = crudMethodMetadataProvider;
 
 		addRepositoryProxyPostProcessor(lockModePostProcessor);
 	}


### PR DESCRIPTION
Introduced a couple of interfaces and made 2 methods (query hints and lock mode lookup) protected in JpaQueryMethod. This allows for enough customization to centralize the lookup of query hints and
lock mode.
