### PR TITLE
Populate the delegatee's root object

### DIFF
--- a/src/main/java/org/springframework/data/jpa/repository/query/ExpressionAwareParameterBinder.java
+++ b/src/main/java/org/springframework/data/jpa/repository/query/ExpressionAwareParameterBinder.java
@@ -168,6 +168,7 @@ class ExpressionAwareParameterBinder extends ParameterBinder {
 			Assert.notNull(delegatee, "EvaluationContext delegatee must not be null!");
 
 			this.delegatee = delegatee;
+			setRootObject(delegatee.getRootObject().getValue(), delegatee.getRootObject().getTypeDescriptor());
 		}
 
 		/* (non-Javadoc)


### PR DESCRIPTION
This allows the root object from ExpressionEvaluationContextProvider to
be used.
