### PR TITLE
DATAJPA-605 - Add javax persistence Version annotation to JpaPersistentP...

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-jpa</artifactId>
-	<version>1.7.0.BUILD-SNAPSHOT</version>
+	<version>1.8.0.BUILD-SNAPSHOT</version>
 
 	<name>Spring Data JPA</name>
 	<description>Spring Data module for JPA repositories.</description>
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.springframework.data.build</groupId>
 		<artifactId>spring-data-parent</artifactId>
-		<version>1.5.0.BUILD-SNAPSHOT</version>
+		<version>1.5.1.BUILD-SNAPSHOT</version>
 		<relativePath>../spring-data-build/parent/pom.xml</relativePath>
 	</parent>
 
@@ -27,7 +27,7 @@
 		<hsqldb1>1.8.0.10</hsqldb1>
 		<jpa>2.0.0</jpa>
 		<openjpa>2.3.0</openjpa>
-		<springdata.commons>1.9.0.BUILD-SNAPSHOT</springdata.commons>
+		<springdata.commons>1.9.1.BUILD-SNAPSHOT</springdata.commons>
 
 		<sonar.dynamicAnalysis>reuseReports</sonar.dynamicAnalysis>
 

--- a/src/main/resources/changelog.txt
+++ b/src/main/resources/changelog.txt
@@ -1,6 +1,28 @@
 Spring Data JPA Changelog
 =========================
 
+Changes in version 1.7.0.RELEASE (2014-09-05)
+---------------------------------------------
+* DATAJPA-604 - Release 1.7 GA.
+* DATAJPA-603 - Update Travis build profiles to build against Spring 4.0 and 4.1 snapshots.
+* DATAJPA-602 - Upgrade to AspectJ Maven Plugin 1.6.
+* DATAJPA-597 - Saving detatched entity breaks when moving from Spring Data JPA 1.5.3 to 1.6.2.
+* DATAJPA-596 - Allow sorting by querydsl operator expression.
+* DATAJPA-594 - Polish Asciidoctor rerefernce documentation.
+* DATAJPA-593 - Custom repository implementations are not picked up when using CDI.
+
+
+Changes in version 1.6.4.RELEASE (2014-08-27)
+---------------------------------------------
+* DATAJPA-597 - Saving detatched entity breaks when moving from Spring Data JPA 1.5.3 to 1.6.2.
+* DATAJPA-596 - Allow sorting by querydsl operator expression.
+* DATAJPA-595 - Release 1.6.4.
+* DATAJPA-592 - Auditing annotations not working when applied to methods.
+* DATAJPA-590 - @Version implementation changes from 1.6.0 to 1.6.2 is a breaking change that doesn't make much sense.
+* DATAJPA-582 - JpaMetamodelEntityInformation.isNew(…) throws ClassCastException for @Version of type Calendar.
+* DATAJPA-581 - Can no longer call save() with a @Version'ed detached entity in 1.6.2.
+
+
 Changes in version 1.7.0.RC1 (2014-08-13)
 -----------------------------------------
 * DATAJPA-587 - Release 1.7 RC1.

--- a/src/main/resources/notice.txt
+++ b/src/main/resources/notice.txt
@@ -1,4 +1,4 @@
-Spring Data JPA 1.7 RC1
+Spring Data JPA 1.7 GA
 Copyright (c) [2011-2014] Pivotal Software, Inc.
 
 This product is licensed to you under the Apache License, Version 2.0 (the "License").  


### PR DESCRIPTION
Correctly detect the javax.persistence.Version annotation of an Entity by Spring Data.

An override was missing from JpaPersistentPropertyImpl.java for it to handle it correctly.
