### PR TITLE
DATAJPA-147: add first and max result to query annotation

### DIFF
--- a/src/main/java/org/springframework/data/jpa/repository/Query.java
+++ b/src/main/java/org/springframework/data/jpa/repository/Query.java
@@ -74,4 +74,22 @@ public @interface Query {
 	 * @return
 	 */
 	String countName() default "";
+
+	/**
+	 * Skip the first number of records JPA query will return. Default to {@literal 0} which means don't skip any
+	 * records.
+	 * 
+	 * @see #firstResult()
+	 * @return
+	 */
+	int firstResult() default 0;
+
+	/**
+	 * Returns the maximum number of records JPA query will return. Default to {@literal -1} which means return all the
+	 * records.
+	 * 
+	 * @see #maxResult()
+	 * @return
+	 */
+	int maxResult() default -1;
 }

--- a/src/main/java/org/springframework/data/jpa/repository/query/AbstractJpaQuery.java
+++ b/src/main/java/org/springframework/data/jpa/repository/query/AbstractJpaQuery.java
@@ -42,6 +42,8 @@ public abstract class AbstractJpaQuery implements RepositoryQuery {
 
 	private final JpaQueryMethod method;
 	private final EntityManager em;
+	protected int firstResult = 0;
+	protected int maxResult = -1;
 
 	/**
 	 * Creates a new {@link AbstractJpaQuery} from the given {@link JpaQueryMethod}.
@@ -57,6 +59,40 @@ public abstract class AbstractJpaQuery implements RepositoryQuery {
 		this.method = method;
 		this.em = em;
 	}
+	
+
+	/**
+	 * @return the firstResult
+	 */
+	public int getFirstResult() {
+		return firstResult;
+	}
+
+
+	/**
+	 * @param firstResult the firstResult to set
+	 */
+	public void setFirstResult(int firstResult) {
+		this.firstResult = firstResult;
+	}
+
+
+	/**
+	 * @return the maxResult
+	 */
+	public int getMaxResult() {
+		return maxResult;
+	}
+
+
+	/**
+	 * @param maxResult the maxResult to set
+	 */
+	public void setMaxResult(int maxResult) {
+		this.maxResult = maxResult;
+	}
+
+
 
 	/*
 	 * (non-Javadoc)

--- a/src/main/java/org/springframework/data/jpa/repository/query/JpaQueryExecution.java
+++ b/src/main/java/org/springframework/data/jpa/repository/query/JpaQueryExecution.java
@@ -143,7 +143,6 @@ public abstract class JpaQueryExecution {
 		protected Object doExecute(AbstractJpaQuery query, Object[] values) {
 			ParametersParameterAccessor accessor = new ParametersParameterAccessor(parameters, values);
 			Pageable pageable = accessor.getPageable();
-			
 			Query createQuery = query.createQuery(values);
 			int pageSize = pageable.getPageSize();
 			createQuery.setMaxResults(pageSize + 1);

--- a/src/main/java/org/springframework/data/jpa/repository/query/JpaQueryExecution.java
+++ b/src/main/java/org/springframework/data/jpa/repository/query/JpaQueryExecution.java
@@ -28,6 +28,7 @@ import org.springframework.core.convert.ConversionService;
 import org.springframework.core.convert.support.ConfigurableConversionService;
 import org.springframework.core.convert.support.GenericConversionService;
 import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.SliceImpl;
@@ -107,7 +108,10 @@ public abstract class JpaQueryExecution {
 
 		@Override
 		protected Object doExecute(AbstractJpaQuery query, Object[] values) {
-			return query.createQuery(values).getResultList();
+			List resultList = query.createQuery(values).getResultList();
+			int firstResult = query.getFirstResult() > 0 ? query.getFirstResult() - 1: 0;
+			int maxResult = query.getMaxResult() != -1 ? firstResult + query.getMaxResult(): resultList.size();
+			return resultList.subList(firstResult, maxResult);
 		}
 	}
 
@@ -137,10 +141,9 @@ public abstract class JpaQueryExecution {
 		@Override
 		@SuppressWarnings("unchecked")
 		protected Object doExecute(AbstractJpaQuery query, Object[] values) {
-
 			ParametersParameterAccessor accessor = new ParametersParameterAccessor(parameters, values);
 			Pageable pageable = accessor.getPageable();
-
+			
 			Query createQuery = query.createQuery(values);
 			int pageSize = pageable.getPageSize();
 			createQuery.setMaxResults(pageSize + 1);

--- a/src/main/java/org/springframework/data/jpa/repository/query/JpaQueryFactory.java
+++ b/src/main/java/org/springframework/data/jpa/repository/query/JpaQueryFactory.java
@@ -48,9 +48,29 @@ enum JpaQueryFactory {
 			EvaluationContextProvider evaluationContextProvider) {
 
 		LOG.debug("Looking up query for method {}", queryMethod.getName());
-		return fromMethodWithQueryString(queryMethod, em, queryMethod.getAnnotatedQuery(), evaluationContextProvider);
+		return fromMethodWithQueryString(queryMethod, em, queryMethod.getAnnotatedQuery(), evaluationContextProvider, queryMethod.getAnnotatedFirstResult(), queryMethod.getAnnotatedMaxResult());
 	}
 
+	/**
+	 * Creates a {@link RepositoryQuery} from the given {@link String} query.
+	 * 
+	 * @param method must not be {@literal null}.
+	 * @param em must not be {@literal null}.
+	 * @param queryString must not be {@literal null} or empty.
+	 * @param evaluationContextProvider
+	 * @return
+	 */
+	AbstractJpaQuery fromMethodWithQueryString(JpaQueryMethod method, EntityManager em, String queryString,
+			EvaluationContextProvider evaluationContextProvider, int firstResult, int maxResult) {
+
+		if (queryString == null) {
+			return null;
+		}
+
+		return method.isNativeQuery() ? new NativeJpaQuery(method, em, queryString, evaluationContextProvider) : //
+				new SimpleJpaQuery(method, em, queryString, evaluationContextProvider, firstResult, maxResult);
+	}
+	
 	/**
 	 * Creates a {@link RepositoryQuery} from the given {@link String} query.
 	 * 

--- a/src/main/java/org/springframework/data/jpa/repository/query/JpaQueryMethod.java
+++ b/src/main/java/org/springframework/data/jpa/repository/query/JpaQueryMethod.java
@@ -265,6 +265,31 @@ public class JpaQueryMethod extends QueryMethod {
 		String annotatedName = getAnnotationValue("name", String.class);
 		return StringUtils.hasText(annotatedName) ? annotatedName : super.getNamedQueryName();
 	}
+	
+	/**
+	 * Returns the first result declared in a {@link Query} annotation or {@literal 0} if neither the annotation found
+	 * nor the attribute was specified.
+	 * 
+	 * @return
+	 */
+	int getAnnotatedFirstResult() {
+
+		Integer query = getAnnotationValue("firstResult", Integer.class);
+		return query != null ? query : 0;
+	}
+
+	/**
+	 * Returns the max result declared in a {@link Query} annotation or {@literal -1} if neither the annotation found
+	 * nor the attribute was specified.
+	 * 
+	 * @return
+	 */
+	int getAnnotatedMaxResult() {
+
+		Integer query = getAnnotationValue("maxResult", Integer.class);
+		return query != null ? query : -1;
+	}
+	
 
 	/**
 	 * Returns the name of the {@link NamedQuery} that shall be used for count queries.

--- a/src/main/java/org/springframework/data/jpa/repository/query/JpaQueryMethod.java
+++ b/src/main/java/org/springframework/data/jpa/repository/query/JpaQueryMethod.java
@@ -273,7 +273,6 @@ public class JpaQueryMethod extends QueryMethod {
 	 * @return
 	 */
 	int getAnnotatedFirstResult() {
-
 		Integer query = getAnnotationValue("firstResult", Integer.class);
 		return query != null ? query : 0;
 	}
@@ -285,7 +284,6 @@ public class JpaQueryMethod extends QueryMethod {
 	 * @return
 	 */
 	int getAnnotatedMaxResult() {
-
 		Integer query = getAnnotationValue("maxResult", Integer.class);
 		return query != null ? query : -1;
 	}

--- a/src/main/java/org/springframework/data/jpa/repository/query/SimpleJpaQuery.java
+++ b/src/main/java/org/springframework/data/jpa/repository/query/SimpleJpaQuery.java
@@ -30,6 +30,7 @@ import org.springframework.data.repository.query.RepositoryQuery;
  * @author Thomas Darimont
  */
 final class SimpleJpaQuery extends AbstractStringBasedJpaQuery {
+	
 
 	/**
 	 * Creates a new {@link SimpleJpaQuery} encapsulating the query annotated on the given {@link JpaQueryMethod}.
@@ -48,11 +49,16 @@ final class SimpleJpaQuery extends AbstractStringBasedJpaQuery {
 	 * @param method must not be {@literal null}.
 	 * @param em must not be {@literal null}.
 	 * @param queryString must not be {@literal null} or empty.
+	 * @param firstResult default 0
+	 * @param maxResult default -1
 	 */
 	public SimpleJpaQuery(JpaQueryMethod method, EntityManager em, String queryString,
-			EvaluationContextProvider evaluationContextProvider) {
+			EvaluationContextProvider evaluationContextProvider, int firstResult, int maxResult) {
 
 		super(method, em, queryString, evaluationContextProvider);
+		
+		this.firstResult = firstResult;
+		this.maxResult = maxResult;
 
 		validateQuery(getQuery().getQueryString(), String.format("Validation failed for query for method %s!", method));
 
@@ -60,6 +66,18 @@ final class SimpleJpaQuery extends AbstractStringBasedJpaQuery {
 			validateQuery(getCountQuery().getQueryString(),
 					String.format("Count query validation failed for method %s!", method));
 		}
+	}
+
+	/**
+	 * Creates a new {@link SimpleJpaQuery} that encapsulates a simple query string.
+	 * 
+	 * @param method must not be {@literal null}.
+	 * @param em must not be {@literal null}.
+	 * @param queryString must not be {@literal null} or empty.
+	 */
+	public SimpleJpaQuery(JpaQueryMethod method, EntityManager em, String queryString,
+			EvaluationContextProvider evaluationContextProvider) {
+		this(method, em, queryString, evaluationContextProvider, 0, -1);
 	}
 
 	/**

--- a/src/test/java/org/springframework/data/jpa/repository/UserRepositoryTests.java
+++ b/src/test/java/org/springframework/data/jpa/repository/UserRepositoryTests.java
@@ -1752,6 +1752,45 @@ public class UserRepositoryTests {
 		assertThat(users.getContent().get(0), is(thirdUser));
 		assertThat(users.getContent().get(1), is(fourthUser));
 	}
+	
+	/**
+	 * @see DATAJPA-564
+	 */
+	@Test
+	public void findUsersByFirstnameForSpELExpressionWithFirstAndMax() {
+
+		flushTestUsers();
+		List<User> user = repository.findUsersByEmailAddressForSpELExpressionWithFirstAndMax("no@email.com");
+		assertThat(user, is(notNullValue()));
+		assertThat(user.size(), is(1));
+		assertThat(user, hasItems(secondUser));
+	}
+	
+	/**
+	 * @see DATAJPA-564
+	 */
+	@Test
+	public void findUsersByFirstnameForSpELExpressionWithFirst() {
+
+		flushTestUsers();
+		List<User> user = repository.findUsersByEmailAddressForSpELExpressionWithFirst("no@email.com");
+		assertThat(user, is(notNullValue()));
+		assertThat(user.size(), is(2));
+		assertThat(user, hasItems(secondUser, fourthUser));
+	}
+	
+	/**
+	 * @see DATAJPA-564
+	 */
+	@Test
+	public void findUsersByFirstnameForSpELExpressionWithMax() {
+
+		flushTestUsers();
+		List<User> user = repository.findUsersByEmailAddressForSpELExpressionWithMax("no@email.com");
+		assertThat(user, is(notNullValue()));
+		assertThat(user.size(), is(2));
+		assertThat(user, hasItems(firstUser, secondUser));
+	}
 
 	private Page<User> executeSpecWithSort(Sort sort) {
 

--- a/src/test/java/org/springframework/data/jpa/repository/UserRepositoryTests.java
+++ b/src/test/java/org/springframework/data/jpa/repository/UserRepositoryTests.java
@@ -1754,11 +1754,10 @@ public class UserRepositoryTests {
 	}
 	
 	/**
-	 * @see DATAJPA-564
+	 * @see DATAJPA-414
 	 */
 	@Test
 	public void findUsersByFirstnameForSpELExpressionWithFirstAndMax() {
-
 		flushTestUsers();
 		List<User> user = repository.findUsersByEmailAddressForSpELExpressionWithFirstAndMax("no@email.com");
 		assertThat(user, is(notNullValue()));
@@ -1767,11 +1766,10 @@ public class UserRepositoryTests {
 	}
 	
 	/**
-	 * @see DATAJPA-564
+	 * @see DATAJPA-414
 	 */
 	@Test
 	public void findUsersByFirstnameForSpELExpressionWithFirst() {
-
 		flushTestUsers();
 		List<User> user = repository.findUsersByEmailAddressForSpELExpressionWithFirst("no@email.com");
 		assertThat(user, is(notNullValue()));
@@ -1780,11 +1778,10 @@ public class UserRepositoryTests {
 	}
 	
 	/**
-	 * @see DATAJPA-564
+	 * @see DATAJPA-414
 	 */
 	@Test
 	public void findUsersByFirstnameForSpELExpressionWithMax() {
-
 		flushTestUsers();
 		List<User> user = repository.findUsersByEmailAddressForSpELExpressionWithMax("no@email.com");
 		assertThat(user, is(notNullValue()));

--- a/src/test/java/org/springframework/data/jpa/repository/sample/UserRepository.java
+++ b/src/test/java/org/springframework/data/jpa/repository/sample/UserRepository.java
@@ -527,4 +527,22 @@ public interface UserRepository extends JpaRepository<User, Integer>, JpaSpecifi
 			value = "select * from (select rownum() as RN, u.* from User u) where RN between ?#{ #pageable.offset -1} and ?#{#pageable.offset + #pageable.pageSize}",
 			countQuery = "select count(u.id) from User u", nativeQuery = true)
 	Page<User> findUsersInNativeQueryWithPagination(Pageable pageable);
+	
+	/**
+	 * @see DATAJPA-414
+	 */
+	@Query(value = "select u from User u where u.emailAddress != :#{#emailAddress}", firstResult = 2, maxResult = 1)
+	List<User> findUsersByEmailAddressForSpELExpressionWithFirstAndMax(@Param("emailAddress")String emailAddress);
+	
+	/**
+	 * @see DATAJPA-414
+	 */
+	@Query(value = "select u from User u where u.emailAddress != :#{#emailAddress}", firstResult = 2)
+	List<User> findUsersByEmailAddressForSpELExpressionWithFirst(@Param("emailAddress")String emailAddress);
+	
+	/**
+	 * @see DATAJPA-414
+	 */
+	@Query(value = "select u from User u where u.emailAddress != :#{#emailAddress}", maxResult = 2)
+	List<User> findUsersByEmailAddressForSpELExpressionWithMax(@Param("emailAddress")String emailAddress);
 }


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/DATAJPA-414

user can add firstResult and maxResult to @Query, meaning the first index of result to fetch and the number of results to fetch
