### PR TITLE
Fixed typo in jpaMappingContext (it had three Ps)

### DIFF
--- a/src/main/java/org/springframework/data/jpa/repository/config/BeanDefinitionNames.java
+++ b/src/main/java/org/springframework/data/jpa/repository/config/BeanDefinitionNames.java
@@ -23,5 +23,5 @@ package org.springframework.data.jpa.repository.config;
  */
 interface BeanDefinitionNames {
 
-	public static final String JPA_MAPPING_CONTEXT_BEAN_NAME = "jpaMapppingContext";
+	public static final String JPA_MAPPING_CONTEXT_BEAN_NAME = "jpaMappingContext";
 }


### PR DESCRIPTION
"jpa:repositories base-package" scanning stopped working because of this typo. Error message:

Multiple annotations found at this line:
    - Referenced bean 'jpaMapppingContext' not found [config set: platform-core/web-context]
