### PR TITLE
DATAJPA-601 - Improve performance with Propagation.SUPPORTS for readOnly operation.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-jpa</artifactId>
-	<version>1.8.0.BUILD-SNAPSHOT</version>
+	<version>1.8.0.DATAJPA-601-SNAPSHOT</version>
 
 	<name>Spring Data JPA</name>
 	<description>Spring Data module for JPA repositories.</description>

--- a/src/main/java/org/springframework/data/jpa/repository/support/SimpleJpaRepository.java
+++ b/src/main/java/org/springframework/data/jpa/repository/support/SimpleJpaRepository.java
@@ -48,6 +48,7 @@ import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.jpa.repository.query.Jpa21Utils;
 import org.springframework.data.jpa.repository.query.QueryUtils;
 import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.Assert;
 
@@ -62,7 +63,7 @@ import org.springframework.util.Assert;
  * @param <ID> the type of the entity's identifier
  */
 @Repository
-@Transactional(readOnly = true)
+@Transactional(readOnly = true, propagation = Propagation.SUPPORTS)
 public class SimpleJpaRepository<T, ID extends Serializable> implements JpaRepository<T, ID>,
 		JpaSpecificationExecutor<T> {
 


### PR DESCRIPTION
Changed default propagation for read-only operations from REQUIRED to SUPPORTS.
This avoids creating unnecessary transaction synchronisations.

This change uses a different code path in than before. We now hit the case:
"// Create "empty" transaction" in which avoids the creation of a new tx.
org.springframework.transaction.support.AbstractPlatformTransactionManager.getTransaction(TransactionDefinition).

I verified this with an external example app.