### PR TITLE
DATAJPA-412 - Add refresh method to SimpleJPARepository.

### DIFF
--- a/src/main/java/org/springframework/data/jpa/repository/JpaRepository.java
+++ b/src/main/java/org/springframework/data/jpa/repository/JpaRepository.java
@@ -28,6 +28,7 @@ import org.springframework.data.repository.PagingAndSortingRepository;
  * JPA specific extension of {@link org.springframework.data.repository.Repository}.
  * 
  * @author Oliver Gierke
+ * @author Eugene McKissick
  */
 @NoRepositoryBean
 public interface JpaRepository<T, ID extends Serializable> extends PagingAndSortingRepository<T, ID> {
@@ -90,4 +91,11 @@ public interface JpaRepository<T, ID extends Serializable> extends PagingAndSort
 	 * @see EntityManager#getReference(Class, Object)
 	 */
 	T getOne(ID id);
+
+    /**
+     *Refresh the state of the instance from the database, overwriting changes made to the entity, if any.
+     * @param entity
+     * @see EntityManager#refresh(Object)
+     */
+    void refresh(T entity);
 }

--- a/src/main/java/org/springframework/data/jpa/repository/support/SimpleJpaRepository.java
+++ b/src/main/java/org/springframework/data/jpa/repository/support/SimpleJpaRepository.java
@@ -58,6 +58,7 @@ import org.springframework.util.Assert;
  * @author Oliver Gierke
  * @author Eberhard Wolff
  * @author Thomas Darimont
+ * @author Eugene McKissick
  * @param <T> the type of the entity to handle
  * @param <ID> the type of the entity's identifier
  */
@@ -454,6 +455,21 @@ public class SimpleJpaRepository<T, ID extends Serializable> implements JpaRepos
 
 		em.flush();
 	}
+
+    /**
+     * Refresh the state of the instance from the database
+     * @param entity
+     */
+    @Override
+    public void refresh(T entity) {
+        LockModeType type = metadata == null ? null : metadata.getLockModeType();
+        if (type == null) {
+            em.refresh(entity);
+        }
+        else {
+            em.refresh(entity,type);
+        }
+    }
 
 	/**
 	 * Reads the given {@link TypedQuery} into a {@link Page} applying the given {@link Pageable} and


### PR DESCRIPTION
Exposed entity manager refresh method the JpaRepository interface and an implementation to SimpleJpaRepository.  Also added a locked mode type check for refresh. 

Cleaned up commits from original branch.