### PR TITLE
DATAJPA-665 - Add exists method wich accepts a Predicate to QueryDslJpaRepository.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-jpa</artifactId>
-	<version>1.8.0.BUILD-SNAPSHOT</version>
+	<version>1.8.0.DATAJPA-665-SNAPSHOT</version>
 
 	<name>Spring Data JPA</name>
 	<description>Spring Data module for JPA repositories.</description>

--- a/src/main/java/org/springframework/data/jpa/repository/support/QueryDslJpaRepository.java
+++ b/src/main/java/org/springframework/data/jpa/repository/support/QueryDslJpaRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2008-2012 the original author or authors.
+ * Copyright 2008-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -46,6 +46,7 @@ import com.mysema.query.types.path.PathBuilder;
  * {@link QueryDslPredicateExecutor}.
  * 
  * @author Oliver Gierke
+ * @author Thomas Darimont
  */
 public class QueryDslJpaRepository<T, ID extends Serializable> extends SimpleJpaRepository<T, ID> implements
 		QueryDslPredicateExecutor<T> {
@@ -140,6 +141,13 @@ public class QueryDslJpaRepository<T, ID extends Serializable> extends SimpleJpa
 	 */
 	public long count(Predicate predicate) {
 		return createQuery(predicate).count();
+	}
+
+	/* (non-Javadoc)
+	 * @see org.springframework.data.querydsl.QueryDslPredicateExecutor#exists(com.mysema.query.types.Predicate)
+	 */
+	public boolean exists(Predicate predicate) {
+		return createQuery(predicate).exists();
 	}
 
 	/**

--- a/src/test/java/org/springframework/data/jpa/repository/support/QueryDslJpaRepositoryTests.java
+++ b/src/test/java/org/springframework/data/jpa/repository/support/QueryDslJpaRepositoryTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2008-2014 the original author or authors.
+ * Copyright 2008-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -324,5 +324,16 @@ public class QueryDslJpaRepositoryTests {
 
 		assertThat(users, hasSize(3));
 		assertThat(users, hasItems(dave, carter, oliver));
+	}
+
+	/**
+	 * @see DATAJPA-665
+	 */
+	@Test
+	public void shouldSupportExistsWithPredicate() throws Exception {
+
+		assertThat(repository.exists(user.firstname.eq("Dave")), is(true));
+		assertThat(repository.exists(user.firstname.eq("Unknown")), is(false));
+		assertThat(repository.exists((Predicate) null), is(true));
 	}
 }


### PR DESCRIPTION
Introduced exists(Predicate) method to QueryDslJpaRepository. Until this becomes available in SD Commons QueryDslPredicateExecutor users can declare the method themselves in their repositories.