### PR TITLE
DATAJPA-666 - Limit maxResults in SingleEntityExecution to 1.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-jpa</artifactId>
-	<version>1.8.0.BUILD-SNAPSHOT</version>
+	<version>1.8.0.DATAJPA-666-SNAPSHOT</version>
 
 	<name>Spring Data JPA</name>
 	<description>Spring Data module for JPA repositories.</description>

--- a/src/main/java/org/springframework/data/jpa/repository/query/JpaQueryExecution.java
+++ b/src/main/java/org/springframework/data/jpa/repository/query/JpaQueryExecution.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2008-2014 the original author or authors.
+ * Copyright 2008-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -199,7 +199,19 @@ public abstract class JpaQueryExecution {
 		@Override
 		protected Object doExecute(AbstractJpaQuery query, Object[] values) {
 
-			return query.createQuery(values).getSingleResult();
+			/*
+			 * Setting maxResults to 1 has the effect that 
+			 * custom queries via @Query that return multiple results 
+			 * which previously resulted in a TooManyResultsException will now 
+			 * return the first result.
+			 * 
+			 * This enables some advanced use cases such as:
+			 * <pre>
+			 * @Query("FROM Image ORDER BY rand()")
+			 * Image findFirstRandomImage();
+			 * <pre>
+			 */
+			return query.createQuery(values).setMaxResults(1).getSingleResult();
 		}
 	}
 

--- a/src/test/java/org/springframework/data/jpa/repository/UserRepositoryTests.java
+++ b/src/test/java/org/springframework/data/jpa/repository/UserRepositoryTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2008-2014 the original author or authors.
+ * Copyright 2008-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -1814,6 +1814,21 @@ public class UserRepositoryTests {
 		List<User> users = repository.queryByAgeInOrFirstname(new Integer[0], secondUser.getFirstname());
 		assertThat(users, hasSize(1));
 		assertThat(users.get(0), is(secondUser));
+	}
+
+	/**
+	 * @see DATAJPA-666
+	 */
+	@Test
+	public void shouldLimitResultsToOneForCustomQuerySingeEntityExecution() {
+
+		flushTestUsers();
+
+		User rndUser = repository.findRandomUser();
+		assertThat(rndUser, is(notNullValue()));
+
+		rndUser = repository.findRandomUser();
+		assertThat(rndUser, is(notNullValue()));
 	}
 
 	private Page<User> executeSpecWithSort(Sort sort) {

--- a/src/test/java/org/springframework/data/jpa/repository/sample/UserRepository.java
+++ b/src/test/java/org/springframework/data/jpa/repository/sample/UserRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2008-2014 the original author or authors.
+ * Copyright 2008-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -549,4 +549,16 @@ public interface UserRepository extends JpaRepository<User, Integer>, JpaSpecifi
 	 * DATAJPA-606
 	 */
 	List<User> queryByAgeInOrFirstname(Integer[] ages, String firstname);
+
+	/**
+	 * @see DATAJPA-666
+	 * 
+	 * <pre>
+	 * @Query("FROM User ORDER BY rand()")
+	 * 
+	 * <pre>
+	 * Works with hibernate but neither with eclipse-link nor openjpa.
+	 */
+	@Query(value = "SELECT u.* FROM User u ORDER BY rand()", nativeQuery = true)
+	User findRandomUser();
 }


### PR DESCRIPTION
We now set maxResults to 1 on a JPA Query in case of a SingleEntityExecution.
Setting maxResults to 1 has the effect that custom queries via @Query that return multiple results which previously resulted in a TooManyResultsException will now 
return the first result.

This enables some advanced use cases such as:

``` java
@Query("FROM Image ORDER BY rand()")
Image findFirstRandomImage();
```
