### PR TITLE
DATAJPA-679 - Add 'findAll' method to QueryDslJpaRepository which accepts a querydsl Predicate and a Sort.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-jpa</artifactId>
-	<version>1.8.0.BUILD-SNAPSHOT</version>
+	<version>1.8.0.DATAJPA-679-SNAPSHOT</version>
 
 	<name>Spring Data JPA</name>
 	<description>Spring Data module for JPA repositories.</description>
@@ -27,7 +27,7 @@
 		<hsqldb1>1.8.0.10</hsqldb1>
 		<jpa>2.0.0</jpa>
 		<openjpa>2.3.0</openjpa>
-		<springdata.commons>1.10.0.BUILD-SNAPSHOT</springdata.commons>
+		<springdata.commons>1.10.0.DATACMNS-554-SNAPSHOT</springdata.commons>
 
 		<sonar.dynamicAnalysis>reuseReports</sonar.dynamicAnalysis>
 

--- a/src/main/java/org/springframework/data/jpa/repository/support/QueryDslJpaRepository.java
+++ b/src/main/java/org/springframework/data/jpa/repository/support/QueryDslJpaRepository.java
@@ -27,6 +27,7 @@ import javax.persistence.LockModeType;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.data.jpa.repository.query.Jpa21Utils;
 import org.springframework.data.jpa.repository.query.JpaEntityGraph;
 import org.springframework.data.querydsl.EntityPathResolver;
@@ -112,6 +113,14 @@ public class QueryDslJpaRepository<T, ID extends Serializable> extends SimpleJpa
 	@Override
 	public List<T> findAll(Predicate predicate, OrderSpecifier<?>... orders) {
 		return executeSorted(createQuery(predicate), orders);
+	}
+
+	/* (non-Javadoc)
+	 * @see org.springframework.data.querydsl.QueryDslPredicateExecutor#findAll(com.mysema.query.types.Predicate, org.springframework.data.domain.Sort)
+	 */
+	@Override
+	public List<T> findAll(Predicate predicate, Sort sort) {
+		return executeSorted(createQuery(predicate), sort);
 	}
 
 	/* 
@@ -204,6 +213,17 @@ public class QueryDslJpaRepository<T, ID extends Serializable> extends SimpleJpa
 	 * @return
 	 */
 	private List<T> executeSorted(JPQLQuery query, OrderSpecifier<?>... orders) {
-		return querydsl.applySorting(new QSort(orders), query).list(path);
+		return executeSorted(query, new QSort(orders));
+	}
+
+	/**
+	 * Executes the given {@link JPQLQuery} after applying the given {@link Sort}.
+	 * 
+	 * @param query must not be {@literal null}.
+	 * @param sort must not be {@literal null}.
+	 * @return
+	 */
+	private List<T> executeSorted(JPQLQuery query, Sort sort) {
+		return querydsl.applySorting(sort, query).list(path);
 	}
 }

--- a/src/test/java/org/springframework/data/jpa/repository/support/QueryDslJpaRepositoryTests.java
+++ b/src/test/java/org/springframework/data/jpa/repository/support/QueryDslJpaRepositoryTests.java
@@ -336,4 +336,18 @@ public class QueryDslJpaRepositoryTests {
 		assertThat(repository.exists(user.firstname.eq("Unknown")), is(false));
 		assertThat(repository.exists((Predicate) null), is(true));
 	}
+
+	/**
+	 * @see DATAJPA-679
+	 */
+	@Test
+	public void shouldSupportFindAllWithPredicateAndSort() {
+
+		List<User> users = repository.findAll(user.dateOfBirth.isNull(), new Sort(Direction.ASC, "firstname"));
+
+		assertThat(users, hasSize(3));
+		assertThat(users.get(0).getFirstname(), is(carter.getFirstname()));
+		assertThat(users.get(2).getFirstname(), is(oliver.getFirstname()));
+		assertThat(users, hasItems(carter, dave, oliver));
+	}
 }


### PR DESCRIPTION
We now support findAll on QueryDslJpaRepository that accepts a Querydsl Predicate and a Sort and returns a List<T>.