### PR TITLE
DATAJPA-677 - Add support for Java 8 Stream in Repository finder methods.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-jpa</artifactId>
-	<version>1.8.0.BUILD-SNAPSHOT</version>
+	<version>1.8.0.DATAJPA-677-SNAPSHOT</version>
 
 	<name>Spring Data JPA</name>
 	<description>Spring Data module for JPA repositories.</description>
@@ -27,7 +27,7 @@
 		<hsqldb1>1.8.0.10</hsqldb1>
 		<jpa>2.0.0</jpa>
 		<openjpa>2.3.0</openjpa>
-		<springdata.commons>1.10.0.BUILD-SNAPSHOT</springdata.commons>
+		<springdata.commons>1.10.0.DATACMNS-650-SNAPSHOT</springdata.commons>
 
 		<sonar.dynamicAnalysis>reuseReports</sonar.dynamicAnalysis>
 

--- a/src/main/java/org/springframework/data/jpa/provider/PersistenceProvider.java
+++ b/src/main/java/org/springframework/data/jpa/provider/PersistenceProvider.java
@@ -43,6 +43,7 @@ import org.hibernate.ejb.HibernateQuery;
 import org.hibernate.proxy.HibernateProxy;
 import org.springframework.beans.DirectFieldAccessor;
 import org.springframework.data.util.CloseableIterator;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 import org.springframework.util.Assert;
 import org.springframework.util.ClassUtils;
 
@@ -364,7 +365,8 @@ public enum PersistenceProvider implements QueryExtractor, ProxyIdAccessor {
 
 			org.hibernate.Query qry = IS_HIBERNATE3 ? extractHibernate3QueryFrom(jpaQuery) : extractHibernate4Query(jpaQuery);
 
-			ScrollableResults scrollableResults = qry.setReadOnly(true).scroll(ScrollMode.FORWARD_ONLY);
+			ScrollableResults scrollableResults = qry.setReadOnly(
+					TransactionSynchronizationManager.isCurrentTransactionReadOnly()).scroll(ScrollMode.FORWARD_ONLY);
 
 			this.scrollableResults = scrollableResults;
 		}

--- a/src/main/java/org/springframework/data/jpa/repository/query/AbstractJpaQuery.java
+++ b/src/main/java/org/springframework/data/jpa/repository/query/AbstractJpaQuery.java
@@ -28,6 +28,7 @@ import org.springframework.data.jpa.repository.query.JpaQueryExecution.PagedExec
 import org.springframework.data.jpa.repository.query.JpaQueryExecution.ProcedureExecution;
 import org.springframework.data.jpa.repository.query.JpaQueryExecution.SingleEntityExecution;
 import org.springframework.data.jpa.repository.query.JpaQueryExecution.SlicedExecution;
+import org.springframework.data.jpa.repository.query.JpaQueryExecution.StreamExecution;
 import org.springframework.data.repository.query.RepositoryQuery;
 import org.springframework.util.Assert;
 
@@ -99,7 +100,9 @@ public abstract class AbstractJpaQuery implements RepositoryQuery {
 
 	protected JpaQueryExecution getExecution() {
 
-		if (method.isProcedureQuery()) {
+		if (method.isStreamQuery()) {
+			return new StreamExecution();
+		} else if (method.isProcedureQuery()) {
 			return new ProcedureExecution();
 		} else if (method.isCollectionQuery()) {
 			return new CollectionExecution();

--- a/src/main/java/org/springframework/data/jpa/repository/query/JpaQueryExecution.java
+++ b/src/main/java/org/springframework/data/jpa/repository/query/JpaQueryExecution.java
@@ -15,9 +15,7 @@
  */
 package org.springframework.data.jpa.repository.query;
 
-import java.lang.reflect.Field;
 import java.util.Collections;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Spliterator;
 import java.util.Spliterators;
@@ -29,9 +27,6 @@ import javax.persistence.Query;
 import javax.persistence.StoredProcedureQuery;
 import javax.persistence.TypedQuery;
 
-import org.hibernate.ScrollMode;
-import org.hibernate.ScrollableResults;
-import org.hibernate.ejb.QueryImpl;
 import org.springframework.core.convert.ConversionService;
 import org.springframework.core.convert.support.ConfigurableConversionService;
 import org.springframework.core.convert.support.GenericConversionService;
@@ -39,13 +34,13 @@ import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.SliceImpl;
+import org.springframework.data.jpa.provider.PersistenceProvider;
 import org.springframework.data.repository.query.ParameterAccessor;
 import org.springframework.data.repository.query.Parameters;
 import org.springframework.data.repository.query.ParametersParameterAccessor;
 import org.springframework.data.util.CloseableIterator;
 import org.springframework.data.util.CloseableIteratorDisposingRunnable;
 import org.springframework.util.Assert;
-import org.springframework.util.ReflectionUtils;
 
 /**
  * Set of classes to contain query execution strategies. Depending (mostly) on the return type of a
@@ -313,41 +308,13 @@ public abstract class JpaQueryExecution {
 	static class StreamExecution extends JpaQueryExecution {
 
 		@Override
-		protected Object doExecute(AbstractJpaQuery query, Object[] values) {
+		protected Object doExecute(final AbstractJpaQuery query, Object[] values) {
+
+			PersistenceProvider persistenceProvider = PersistenceProvider.fromEntityManager(query.getEntityManager());
 
 			Query jpaQuery = query.createQuery(values);
-
-			QueryImpl<Object> queryImpl = (QueryImpl<Object>) jpaQuery;
-
-			Field field = ReflectionUtils.findField(QueryImpl.class, "query");
-			ReflectionUtils.makeAccessible(field);
-
-			org.hibernate.Query qry = (org.hibernate.Query) ReflectionUtils.getField(field, queryImpl);
-
-			final ScrollableResults scrollableResults = qry.scroll(ScrollMode.FORWARD_ONLY);
-
-			CloseableIterator<Object> iter = new CloseableIterator<Object>() {
-
-				@Override
-				public Iterator<Object> iterator() {
-					return this;
-				}
-
-				@Override
-				public Object next() {
-					return scrollableResults.get()[0];
-				}
-
-				@Override
-				public boolean hasNext() {
-					return scrollableResults.next();
-				}
-
-				@Override
-				public void close() {
-					scrollableResults.close();
-				}
-			};
+			CloseableIterator<Object> iter = persistenceProvider.executeQueryWithResultStream(jpaQuery,
+					query.getEntityManager());
 
 			Spliterator<Object> spliterator = Spliterators.spliteratorUnknownSize(iter, Spliterator.NONNULL);
 			return StreamSupport.stream(spliterator, false).onClose(new CloseableIteratorDisposingRunnable(iter));

--- a/src/main/java/org/springframework/data/jpa/repository/query/JpaQueryExecution.java
+++ b/src/main/java/org/springframework/data/jpa/repository/query/JpaQueryExecution.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2008-2014 the original author or authors.
+ * Copyright 2008-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -310,11 +310,9 @@ public abstract class JpaQueryExecution {
 		@Override
 		protected Object doExecute(final AbstractJpaQuery query, Object[] values) {
 
-			PersistenceProvider persistenceProvider = PersistenceProvider.fromEntityManager(query.getEntityManager());
-
 			Query jpaQuery = query.createQuery(values);
-			CloseableIterator<Object> iter = persistenceProvider.executeQueryWithResultStream(jpaQuery,
-					query.getEntityManager());
+			CloseableIterator<Object> iter = PersistenceProvider.fromEntityManager(query.getEntityManager())
+					.executeQueryWithResultStream(jpaQuery);
 
 			Spliterator<Object> spliterator = Spliterators.spliteratorUnknownSize(iter, Spliterator.NONNULL);
 			return StreamSupport.stream(spliterator, false).onClose(new CloseableIteratorDisposingRunnable(iter));

--- a/src/test/java/org/springframework/data/jpa/repository/UserRepositoryTests.java
+++ b/src/test/java/org/springframework/data/jpa/repository/UserRepositoryTests.java
@@ -1826,20 +1826,26 @@ public class UserRepositoryTests {
 
 		flushTestUsers();
 
-		Stream<User> users = repository.findAllByCustomQueryAndStream();
+		Stream<User> stream = repository.findAllByCustomQueryAndStream();
+
+		final List<User> users = new ArrayList<User>();
 
 		try {
-			users.forEach(new Consumer<User>() {
+			stream.forEach(new Consumer<User>() {
 
 				@Override
 				public void accept(User user) {
-					System.out.printf("%s%n", user);
+
+					// System.out.printf("%s%n", user);
+					users.add(user);
 				}
 
 			});
 		} finally {
-			users.close();
+			stream.close();
 		}
+
+		assertThat(users, hasSize(4));
 	}
 
 	private Page<User> executeSpecWithSort(Sort sort) {

--- a/src/test/java/org/springframework/data/jpa/repository/UserRepositoryTests.java
+++ b/src/test/java/org/springframework/data/jpa/repository/UserRepositoryTests.java
@@ -1822,11 +1822,41 @@ public class UserRepositoryTests {
 	 * @see DATAJPA-677
 	 */
 	@Test
-	public void shouldSupportJava8StreamsForRepositoryFinderMethods() throws Exception {
+	public void shouldSupportJava8StreamsForRepositoryFinderMethods() {
 
 		flushTestUsers();
 
 		Stream<User> stream = repository.findAllByCustomQueryAndStream();
+
+		final List<User> users = new ArrayList<User>();
+
+		try {
+			stream.forEach(new Consumer<User>() {
+
+				@Override
+				public void accept(User user) {
+
+					// System.out.printf("%s%n", user);
+					users.add(user);
+				}
+
+			});
+		} finally {
+			stream.close();
+		}
+
+		assertThat(users, hasSize(4));
+	}
+
+	/**
+	 * @see DATAJPA-677
+	 */
+	@Test
+	public void shouldSupportJava8StreamsForRepositoryDerivedFinderMethods() {
+
+		flushTestUsers();
+
+		Stream<User> stream = repository.readAllByFirstnameNotNull();
 
 		final List<User> users = new ArrayList<User>();
 

--- a/src/test/java/org/springframework/data/jpa/repository/UserRepositoryTests.java
+++ b/src/test/java/org/springframework/data/jpa/repository/UserRepositoryTests.java
@@ -28,6 +28,8 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.function.Consumer;
+import java.util.stream.Stream;
 
 import javax.persistence.EntityManager;
 import javax.persistence.PersistenceContext;
@@ -1814,6 +1816,30 @@ public class UserRepositoryTests {
 		List<User> users = repository.queryByAgeInOrFirstname(new Integer[0], secondUser.getFirstname());
 		assertThat(users, hasSize(1));
 		assertThat(users.get(0), is(secondUser));
+	}
+
+	/**
+	 * @see DATAJPA-677
+	 */
+	@Test
+	public void shouldSupportJava8StreamsForRepositoryFinderMethods() throws Exception {
+
+		flushTestUsers();
+
+		Stream<User> users = repository.findAllByCustomQueryAndStream();
+
+		try {
+			users.forEach(new Consumer<User>() {
+
+				@Override
+				public void accept(User user) {
+					System.out.printf("%s%n", user);
+				}
+
+			});
+		} finally {
+			users.close();
+		}
 	}
 
 	private Page<User> executeSpecWithSort(Sort sort) {

--- a/src/test/java/org/springframework/data/jpa/repository/sample/UserRepository.java
+++ b/src/test/java/org/springframework/data/jpa/repository/sample/UserRepository.java
@@ -19,6 +19,7 @@ import java.util.Collection;
 import java.util.Date;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Stream;
 
 import javax.persistence.EntityManager;
 import javax.persistence.QueryHint;
@@ -557,4 +558,10 @@ public interface UserRepository extends JpaRepository<User, Integer>, JpaSpecifi
 	 * DATAJPA-606
 	 */
 	List<User> queryByAgeInOrFirstname(Integer[] ages, String firstname);
+
+	/**
+	 * DATAJPA-677
+	 */
+	@Query("select u from User u")
+	Stream<User> findAllByCustomQueryAndStream();
 }

--- a/src/test/java/org/springframework/data/jpa/repository/sample/UserRepository.java
+++ b/src/test/java/org/springframework/data/jpa/repository/sample/UserRepository.java
@@ -564,4 +564,9 @@ public interface UserRepository extends JpaRepository<User, Integer>, JpaSpecifi
 	 */
 	@Query("select u from User u")
 	Stream<User> findAllByCustomQueryAndStream();
+
+	/**
+	 * DATAJPA-677
+	 */
+	Stream<User> readAllByFirstnameNotNull();
 }


### PR DESCRIPTION
Just a quick PoC for Java 8 Stream support for JPA Repository finder methods based on hibernate.
I think we could add (provider specific) support for Java 8 Streams here but we probably have to fiddle a bit with the particular PersistenceProvider internals to make it work.

This is builds on top of spring-data-commons DATACMNS-650-SNAPSHOT.