### PR TITLE
DATAJPA-689 - Allow @EntityGraph on findOne method of CrudRepository.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-jpa</artifactId>
-	<version>1.8.0.BUILD-SNAPSHOT</version>
+	<version>1.8.0.DATAJPA-689-SNAPSHOT</version>
 
 	<name>Spring Data JPA</name>
 	<description>Spring Data module for JPA repositories.</description>

--- a/src/main/java/org/springframework/data/jpa/repository/query/AbstractJpaQuery.java
+++ b/src/main/java/org/springframework/data/jpa/repository/query/AbstractJpaQuery.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2008-2014 the original author or authors.
+ * Copyright 2008-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 package org.springframework.data.jpa.repository.query;
+
+import java.util.Map;
 
 import javax.persistence.EntityManager;
 import javax.persistence.LockModeType;
@@ -180,10 +182,10 @@ public abstract class AbstractJpaQuery implements RepositoryQuery {
 		Assert.notNull(query, "Query must not be null!");
 		Assert.notNull(method, "JpaQueryMethod must not be null!");
 
-		JpaEntityGraph entityGraph = method.getEntityGraph();
+		Map<String, Object> hints = Jpa21Utils.tryGetFetchGraphHints(em, method.getEntityGraph());
 
-		if (entityGraph != null) {
-			Jpa21Utils.tryConfigureFetchGraph(em, query, entityGraph);
+		for (Map.Entry<String, Object> hint : hints.entrySet()) {
+			query.setHint(hint.getKey(), hint.getValue());
 		}
 
 		return query;

--- a/src/main/java/org/springframework/data/jpa/repository/query/Jpa21Utils.java
+++ b/src/main/java/org/springframework/data/jpa/repository/query/Jpa21Utils.java
@@ -54,31 +54,12 @@ public class Jpa21Utils {
 	}
 
 	/**
-	 * Adds a JPA 2.1 fetch-graph or load-graph hint to the given {@link Query} if running under JPA 2.1.
-	 * 
-	 * @see JPA 2.1 Specfication 3.7.4 - Use of Entity Graphs in find and query operations P.117
-	 * @param em must not be {@literal null}
-	 * @param query must not be {@literal null}
-	 * @param entityGraph can be {@literal null}
-	 */
-	public static <T extends Query> T tryConfigureFetchGraph(EntityManager em, T query, JpaEntityGraph entityGraph) {
-
-		Map<String, Object> hints = tryGetFetchGraphHints(em, entityGraph);
-
-		for (Map.Entry<String, Object> hint : hints.entrySet()) {
-			query.setHint(hint.getKey(), hint.getValue());
-		}
-
-		return query;
-	}
-
-	/**
 	 * Returns a {@link Map} with hints for a JPA 2.1 fetch-graph or load-graph if running under JPA 2.1.
 	 * 
 	 * @param em must not be {@literal null}
 	 * @param query must not be {@literal null}
 	 * @param entityGraph can be {@literal null}
-	 * @return
+	 * @return a {@code Map} with the hints or an empty {@code Map} if no hints were found
 	 * @since 1.8
 	 */
 	public static Map<String, Object> tryGetFetchGraphHints(EntityManager em, JpaEntityGraph entityGraph) {

--- a/src/main/java/org/springframework/data/jpa/repository/support/QueryDslJpaRepository.java
+++ b/src/main/java/org/springframework/data/jpa/repository/support/QueryDslJpaRepository.java
@@ -20,7 +20,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map.Entry;
 
-import javax.persistence.EntityGraph;
 import javax.persistence.EntityManager;
 import javax.persistence.LockModeType;
 
@@ -28,8 +27,6 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
-import org.springframework.data.jpa.repository.query.Jpa21Utils;
-import org.springframework.data.jpa.repository.query.JpaEntityGraph;
 import org.springframework.data.querydsl.EntityPathResolver;
 import org.springframework.data.querydsl.QSort;
 import org.springframework.data.querydsl.QueryDslPredicateExecutor;
@@ -57,7 +54,6 @@ public class QueryDslJpaRepository<T, ID extends Serializable> extends SimpleJpa
 	private final EntityPath<T> path;
 	private final PathBuilder<T> builder;
 	private final Querydsl querydsl;
-	private final EntityManager em;
 
 	/**
 	 * Creates a new {@link QueryDslJpaRepository} from the given domain class and {@link EntityManager}. This will use
@@ -82,7 +78,6 @@ public class QueryDslJpaRepository<T, ID extends Serializable> extends SimpleJpa
 			EntityPathResolver resolver) {
 
 		super(entityInformation, entityManager);
-		this.em = entityManager;
 		this.path = resolver.createPath(entityInformation.getJavaType());
 		this.builder = new PathBuilder<T>(path.getType(), path.getMetadata());
 		this.querydsl = new Querydsl(entityManager, builder);
@@ -185,23 +180,9 @@ public class QueryDslJpaRepository<T, ID extends Serializable> extends SimpleJpa
 		LockModeType type = metadata.getLockModeType();
 		query = type == null ? query : query.setLockMode(type);
 
-		for (Entry<String, Object> hint : metadata.getQueryHints().entrySet()) {
+		for (Entry<String, Object> hint : getQueryHints().entrySet()) {
 			query.setHint(hint.getKey(), hint.getValue());
 		}
-
-		JpaEntityGraph jpaEntityGraph = metadata.getEntityGraph();
-
-		if (jpaEntityGraph == null) {
-			return query;
-		}
-
-		EntityGraph<?> entityGraph = Jpa21Utils.tryGetFetchGraph(em, jpaEntityGraph);
-
-		if (entityGraph == null) {
-			return query;
-		}
-
-		query.setHint(jpaEntityGraph.getType().getKey(), entityGraph);
 
 		return query;
 	}

--- a/src/test/java/org/springframework/data/jpa/repository/query/JpaQueryMethodUnitTests.java
+++ b/src/test/java/org/springframework/data/jpa/repository/query/JpaQueryMethodUnitTests.java
@@ -346,6 +346,19 @@ public class JpaQueryMethodUnitTests {
 	}
 
 	/**
+	 * @see DATAJPA-689
+	 */
+	@Test
+	public void shouldFindEntityGraphAnnotationOnOverriddenSimpleJpaRepositoryMethodFindOne() throws Exception {
+
+		JpaQueryMethod method = new JpaQueryMethod(JpaRepositoryOverride.class.getMethod("findOne"), metadata, extractor);
+
+		assertThat(method.getEntityGraph(), is(notNullValue()));
+		assertThat(method.getEntityGraph().getName(), is("User.detail"));
+		assertThat(method.getEntityGraph().getType(), is(EntityGraphType.FETCH));
+	}
+
+	/**
 	 * Interface to define invalid repository methods for testing.
 	 * 
 	 * @author Oliver Gierke
@@ -414,7 +427,13 @@ public class JpaQueryMethodUnitTests {
 		 */
 		@Override
 		@EntityGraph("User.detail")
-		public List<User> findAll();
+		List<User> findAll();
+
+		/**
+		 * DATAJPA-689
+		 */
+		@EntityGraph("User.detail")
+		User findOne();
 	}
 
 	@Lock(LockModeType.OPTIMISTIC_FORCE_INCREMENT)

--- a/src/test/java/org/springframework/data/jpa/repository/sample/RepositoryMethodsWithEntityGraphConfigJpaRepository.java
+++ b/src/test/java/org/springframework/data/jpa/repository/sample/RepositoryMethodsWithEntityGraphConfigJpaRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Copyright 2014-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,16 +23,22 @@ import org.springframework.data.jpa.repository.EntityGraph.EntityGraphType;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 /**
- * Custom repository interface that customizes the fetching behavior of querys of well known repository interface methods via {@link EntityGraph}
- * annotation.
+ * Custom repository interface that customizes the fetching behavior of querys of well known repository interface
+ * methods via {@link EntityGraph} annotation.
  * 
  * @author Thomas Darimont
  */
-public interface RepositoryMethodsWithEntityGraphConfigJpaRepository extends JpaRepository<User, Long> {
+public interface RepositoryMethodsWithEntityGraphConfigJpaRepository extends JpaRepository<User, Integer> {
 
 	/**
 	 * Should find all users.
 	 */
 	@EntityGraph(type = EntityGraphType.LOAD, value = "User.overview")
 	List<User> findAll();
+
+	/**
+	 * Should fetch all user details
+	 */
+	@EntityGraph(type = EntityGraphType.FETCH, value = "User.detail")
+	User findOne(Integer id);
 }

--- a/src/test/java/org/springframework/data/jpa/repository/support/SimpleJpaRepositoryUnitTests.java
+++ b/src/test/java/org/springframework/data/jpa/repository/support/SimpleJpaRepositoryUnitTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2014 the original author or authors.
+ * Copyright 2011-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,8 +15,10 @@
  */
 package org.springframework.data.jpa.repository.support;
 
+import static java.util.Collections.*;
 import static org.mockito.Mockito.*;
 
+import javax.persistence.EntityGraph;
 import javax.persistence.EntityManager;
 import javax.persistence.TypedQuery;
 import javax.persistence.criteria.CriteriaBuilder;
@@ -30,16 +32,19 @@ import org.mockito.runners.MockitoJUnitRunner;
 import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.jpa.domain.sample.User;
+import org.springframework.data.jpa.repository.EntityGraph.EntityGraphType;
+import org.springframework.data.jpa.repository.query.JpaEntityGraph;
 
 /**
  * Unit tests for {@link SimpleJpaRepository}.
  * 
  * @author Oliver Gierke
+ * @author Thomas Darimont
  */
 @RunWith(MockitoJUnitRunner.class)
 public class SimpleJpaRepositoryUnitTests {
 
-	SimpleJpaRepository<User, Long> repo;
+	SimpleJpaRepository<User, Integer> repo;
 
 	@Mock EntityManager em;
 	@Mock CriteriaBuilder builder;
@@ -49,6 +54,7 @@ public class SimpleJpaRepositoryUnitTests {
 	@Mock TypedQuery<Long> countQuery;
 	@Mock JpaEntityInformation<User, Long> information;
 	@Mock CrudMethodMetadata metadata;
+	@Mock EntityGraph<User> entityGraph;
 
 	@Before
 	public void setUp() {
@@ -64,7 +70,7 @@ public class SimpleJpaRepositoryUnitTests {
 		when(em.createQuery(criteriaQuery)).thenReturn(query);
 		when(em.createQuery(countCriteriaQuery)).thenReturn(countQuery);
 
-		repo = new SimpleJpaRepository<User, Long>(information, em);
+		repo = new SimpleJpaRepository<User, Integer>(information, em);
 		repo.setRepositoryMethodMetadata(metadata);
 	}
 
@@ -86,6 +92,23 @@ public class SimpleJpaRepositoryUnitTests {
 	@Test(expected = EmptyResultDataAccessException.class)
 	public void throwsExceptionIfEntityToDeleteDoesNotExist() {
 
-		repo.delete(4711L);
+		repo.delete(4711);
+	}
+
+	/**
+	 * @see DATAJPA-689
+	 */
+	@Test
+	@SuppressWarnings({ "rawtypes", "unchecked" })
+	public void shouldPropagateConfiguredEntityGraphToFindOne() {
+
+		String entityGraphName = "User.detail";
+		when(metadata.getEntityGraph()).thenReturn(new JpaEntityGraph(entityGraphName, EntityGraphType.LOAD));
+		when(em.getEntityGraph(entityGraphName)).thenReturn((EntityGraph) entityGraph);
+
+		Integer id = 0;
+		repo.findOne(id);
+
+		verify(em).find(User.class, id, singletonMap(EntityGraphType.LOAD.getKey(), (Object) entityGraph));
 	}
 }


### PR DESCRIPTION
We now honor @EntityGraph definitions on findOne methods - previously we only supported it on methods that created a Query explicitly.
Extracted tryGetFetchGraphHints method from tryConfigureFetchGraph method in Jpa21Utils to allow EntityGraph hints to be used in SimpleJpaRepository#findOne.
Construction of query hints from context information in SimpleJpaRepository is now performed via the getQueryHints method.
Adjusted QueryDslJpaRepository to use getQueryHints as well.