### PR TITLE
Wrong package reference in Jsr310JpaConverters 

### DIFF
--- a/src/main/java/org/springframework/data/jpa/convert/threeten/Jsr310JpaConverters.java
+++ b/src/main/java/org/springframework/data/jpa/convert/threeten/Jsr310JpaConverters.java
@@ -37,9 +37,9 @@ import org.springframework.orm.jpa.LocalContainerEntityManagerFactoryBean;
 /**
  * JPA 2.1 converters to turn JSR-310 types into legacy {@link Date}s. To activate these converters make sure your
  * persistence provider detects them by including this class in the list of mapped classes. In Spring environments, you
- * can simply register the package of this class (i.e. {@code org.springframework.data.jpa.domain.support}) as package
+ * can simply register the package of this class (i.e. {@code org.springframework.data.jpa.convert.threeten}) as package
  * to be scanned on e.g. the {@link LocalContainerEntityManagerFactoryBean}.
- * 
+ *
  * @author Oliver Gierke
  */
 public class Jsr310JpaConverters {

--- a/src/main/java/org/springframework/data/jpa/convert/threetenbp/ThreeTenBackPortJpaConverters.java
+++ b/src/main/java/org/springframework/data/jpa/convert/threetenbp/ThreeTenBackPortJpaConverters.java
@@ -37,9 +37,9 @@ import org.threeten.bp.LocalTime;
 /**
  * JPA 2.1 converters to turn ThreeTen back port types into legacy {@link Date}s. To activate these converters make sure
  * your persistence provider detects them by including this class in the list of mapped classes. In Spring environments,
- * you can simply register the package of this class (i.e. {@code org.springframework.data.jpa.domain.support}) as
+ * you can simply register the package of this class (i.e. {@code org.springframework.data.jpa.convert.threetenbp}) as
  * package to be scanned on e.g. the {@link LocalContainerEntityManagerFactoryBean}.
- * 
+ *
  * @author Oliver Gierke
  * @see http://www.threeten.org/threetenbp
  * @since 1.8


### PR DESCRIPTION
In both classes Jsr310JpaConverters and ThreeTenBackPortJpaConverters the javadoc states:

In Spring environments, you can simply register the package of this class (i.e. \{@code org.springframework.data.jpa.domain.support}) as package to be scanned

The correct ones are org.springframework.data.jpa.convert.threeten and org.springframework.data.jpa.convert.threetenbp respectively