### PR TITLE
DATAJPA-696 - Support locally declared EntityGraphs for repository finder methods.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -309,7 +309,7 @@
 							<includes>
 								<include>**/EclipseLink*Tests.java</include>
 							</includes>
-							<argLine>-javaagent:${settings.localRepository}/org/springframework/spring-instrument/${spring}/spring-instrument-${spring}.jar</argLine>
+							<argLine>-javaagent:${settings.localRepository}/org/eclipse/persistence/org.eclipse.persistence.jpa/${eclipselink}/org.eclipse.persistence.jpa-${eclipselink}.jar -javaagent:${settings.localRepository}/org/springframework/spring-instrument/${spring}/spring-instrument-${spring}.jar</argLine>
 						</configuration>
 					</execution>
 					<execution>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-jpa</artifactId>
-	<version>1.9.0.BUILD-SNAPSHOT</version>
+	<version>1.9.0.DATAJPA-696-SNAPSHOT</version>
 
 	<name>Spring Data JPA</name>
 	<description>Spring Data module for JPA repositories.</description>

--- a/src/main/java/org/springframework/data/jpa/provider/PersistenceProvider.java
+++ b/src/main/java/org/springframework/data/jpa/provider/PersistenceProvider.java
@@ -15,8 +15,17 @@
  */
 package org.springframework.data.jpa.provider;
 
-import static org.springframework.data.jpa.provider.JpaClassUtils.*;
-import static org.springframework.data.jpa.provider.PersistenceProvider.Constants.*;
+import static org.springframework.data.jpa.provider.JpaClassUtils.isEntityManagerOfType;
+import static org.springframework.data.jpa.provider.JpaClassUtils.isMetamodelOfType;
+import static org.springframework.data.jpa.provider.PersistenceProvider.Constants.ECLIPSELINK_ENTITY_MANAGER_INTERFACE;
+import static org.springframework.data.jpa.provider.PersistenceProvider.Constants.ECLIPSELINK_JPA_METAMODEL_TYPE;
+import static org.springframework.data.jpa.provider.PersistenceProvider.Constants.GENERIC_JPA_ENTITY_MANAGER_INTERFACE;
+import static org.springframework.data.jpa.provider.PersistenceProvider.Constants.HIBERNATE43_ENTITY_MANAGER_INTERFACE;
+import static org.springframework.data.jpa.provider.PersistenceProvider.Constants.HIBERNATE43_JPA_METAMODEL_TYPE;
+import static org.springframework.data.jpa.provider.PersistenceProvider.Constants.HIBERNATE_ENTITY_MANAGER_INTERFACE;
+import static org.springframework.data.jpa.provider.PersistenceProvider.Constants.HIBERNATE_JPA_METAMODEL_TYPE;
+import static org.springframework.data.jpa.provider.PersistenceProvider.Constants.OPENJPA_ENTITY_MANAGER_INTERFACE;
+import static org.springframework.data.jpa.provider.PersistenceProvider.Constants.OPENJPA_JPA_METAMODEL_TYPE;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -24,8 +33,10 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 
+import javax.persistence.EntityGraph;
 import javax.persistence.EntityManager;
 import javax.persistence.Query;
+import javax.persistence.Subgraph;
 import javax.persistence.metamodel.Metamodel;
 
 import org.apache.openjpa.enhance.PersistenceCapable;
@@ -42,10 +53,12 @@ import org.hibernate.ScrollableResults;
 import org.hibernate.ejb.HibernateQuery;
 import org.hibernate.proxy.HibernateProxy;
 import org.springframework.beans.DirectFieldAccessor;
+import org.springframework.data.jpa.repository.query.JpaEntityGraph;
 import org.springframework.data.util.CloseableIterator;
 import org.springframework.transaction.support.TransactionSynchronizationManager;
 import org.springframework.util.Assert;
 import org.springframework.util.ClassUtils;
+import org.springframework.util.StringUtils;
 
 /**
  * Enumeration representing persistence providers to be used.
@@ -352,6 +365,69 @@ public enum PersistenceProvider implements QueryExtractor, ProxyIdAccessor {
 	public CloseableIterator<Object> executeQueryWithResultStream(Query jpaQuery) {
 		throw new UnsupportedOperationException("Streaming results is not implement for this PersistenceProvider: "
 				+ name());
+	}
+
+	/**
+	 * Creates a dynamic {@link EntityGraph} from the given {@link JpaEntityGraph} information. 
+	 * 
+	 * @param em
+	 * @param jpaEntityGraph
+	 * @param entityType
+	 * @return
+	 * 
+	 * @since 1.9
+	 */
+	public EntityGraph<?> createDynamicEntityGraph(EntityManager em, JpaEntityGraph jpaEntityGraph, Class<?> entityType) {
+
+		Assert.isTrue(jpaEntityGraph.isDynamicEntityGraph(), "The given " + jpaEntityGraph + " is not dynamic!");
+
+		EntityGraph<?> entityGraph = em.createEntityGraph(entityType);
+
+		configureFetchGraphFrom(jpaEntityGraph, entityGraph);
+
+		return entityGraph;
+	}
+
+	
+	/**
+	 * Configures the given {@link EntityGraph} with the fetch graph information stored in {@link JpaEntityGraph}.
+	 * 
+	 * @param jpaEntityGraph
+	 * @param entityGraph
+	 */
+	/* visible for testing */
+	void configureFetchGraphFrom(JpaEntityGraph jpaEntityGraph, EntityGraph<?> entityGraph) {
+
+		String[] attributePaths = jpaEntityGraph.getAttributePaths().clone();
+
+		// sort to ensure that the intermediate entity subgraphs are created accordingly.
+		Arrays.sort(attributePaths);
+
+		// we build the entity graph based on the paths with highest depth first
+		for (int i = attributePaths.length - 1; i >= 0; i--) {
+
+			String path = attributePaths[i];
+			
+			//fast path just single attribute
+			if (!path.contains(".")) {
+				entityGraph.addAttributeNodes(path);
+				continue;
+			}
+
+			//we need to build nested sub fetch graphs
+			String[] pathComponents = StringUtils.delimitedListToStringArray(path, ".");
+
+			Subgraph<?> parent = null;
+			for (int c = 0; c < pathComponents.length - 1; c++) {
+
+				if (c == 0) {
+					parent = entityGraph.addSubgraph(pathComponents[c]);
+				} else {
+					parent = parent.addSubgraph(pathComponents[c]);
+				}
+			}
+			parent.addAttributeNodes(pathComponents[pathComponents.length - 1]);
+		}
 	}
 
 	/**

--- a/src/main/java/org/springframework/data/jpa/repository/EntityGraph.java
+++ b/src/main/java/org/springframework/data/jpa/repository/EntityGraph.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Copyright 2014-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,8 +21,18 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+import javax.persistence.NamedAttributeNode;
+
+import org.springframework.data.jpa.repository.query.JpaQueryMethod;
+
 /**
  * Annotation to configure the JPA 2.1 {@link javax.persistence.EntityGraph}s that should be used on repository methods.
+ * 
+ * Since 1.9 we support the definition of dynamic {@link EntityGraph}s by allowing to customize the fetch-graph via 
+ * via {@link #attributePaths()} ad-hoc fetch-graph configuration.
+ * 
+ * If {@link #attributePaths()} are specified then we ignore the entity-graph name {@link #value()}
+ * and treat this {@link EntityGraph} as dynamic.
  * 
  * @author Thomas Darimont
  * @since 1.6
@@ -34,10 +44,11 @@ public @interface EntityGraph {
 
 	/**
 	 * The name of the EntityGraph to use.
+	 * If empty we fall-back to {@link JpaQueryMethod#getNamedQueryName()} as the value.
 	 * 
 	 * @return
 	 */
-	String value();
+	String value() default "";
 
 	/**
 	 * The {@link Type} of the EntityGraph to use, defaults to {@link Type#FETCH}.
@@ -45,6 +56,16 @@ public @interface EntityGraph {
 	 * @return
 	 */
 	EntityGraphType type() default EntityGraphType.FETCH;
+	
+	/**
+	 * The paths of attributes of this {@link EntityGraph} to use, empty by default.
+	 * 
+	 * You can refer to direct properties of the entity or nested properties via a {@code property.nestedProperty}. 
+	 * 
+	 * @return
+	 * @since 1.9
+	 */
+	String[] attributePaths() default {};
 
 	/**
 	 * Enum for JPA 2.1 {@link javax.persistence.EntityGraph} types.

--- a/src/main/java/org/springframework/data/jpa/repository/query/AbstractJpaQuery.java
+++ b/src/main/java/org/springframework/data/jpa/repository/query/AbstractJpaQuery.java
@@ -182,7 +182,7 @@ public abstract class AbstractJpaQuery implements RepositoryQuery {
 		Assert.notNull(query, "Query must not be null!");
 		Assert.notNull(method, "JpaQueryMethod must not be null!");
 
-		Map<String, Object> hints = Jpa21Utils.tryGetFetchGraphHints(em, method.getEntityGraph());
+		Map<String, Object> hints = Jpa21Utils.tryGetFetchGraphHints(em, method.getEntityGraph(), getQueryMethod().getEntityInformation().getJavaType());
 
 		for (Map.Entry<String, Object> hint : hints.entrySet()) {
 			query.setHint(hint.getKey(), hint.getValue());

--- a/src/main/java/org/springframework/data/jpa/repository/query/JpaEntityGraph.java
+++ b/src/main/java/org/springframework/data/jpa/repository/query/JpaEntityGraph.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Copyright 2014-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,10 +15,12 @@
  */
 package org.springframework.data.jpa.repository.query;
 
-import javax.persistence.EntityGraph;
+import java.util.Arrays;
 
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.EntityGraph.EntityGraphType;
 import org.springframework.util.Assert;
+import org.springframework.util.StringUtils;
 
 /**
  * EntityGraph configuration for JPA 2.1 {@link EntityGraph}s.
@@ -28,22 +30,38 @@ import org.springframework.util.Assert;
  */
 public class JpaEntityGraph {
 
+	private static String[] EMPTY_ATTRIBUTE_PATHS = {};
+
 	private final String name;
 	private final EntityGraphType type;
+	private final String[] attributePaths;
 
 	/**
 	 * Creates an {@link JpaEntityGraph}.
 	 * 
-	 * @param name must not be {@null} or empty.
-	 * @param type must not be {@null}.
+	 * @param entityGraph must not be {@literal null}.
+	 * @param nameFallback must not be {@literal null} or empty.
 	 */
-	public JpaEntityGraph(String name, EntityGraphType type) {
+	public JpaEntityGraph(EntityGraph entityGraph, String nameFallback) {
+		this(StringUtils.hasText(entityGraph.value()) ? entityGraph.value() : nameFallback, entityGraph.type(), entityGraph
+				.attributePaths());
+	}
+
+	/**
+	 * Creates an {@link JpaEntityGraph}.
+	 * 
+	 * @param name must not be {@literal null} or empty.
+	 * @param type must not be {@literal null}.
+	 * @param attributePaths may be {@literal null}.
+	 */
+	public JpaEntityGraph(String name, EntityGraphType type, String[] attributePaths) {
 
 		Assert.hasText(name, "The name of an EntityGraph must not be null or empty!");
 		Assert.notNull(type, "FetchGraphType must not be null!");
 
 		this.name = name;
 		this.type = type;
+		this.attributePaths = attributePaths == null ? EMPTY_ATTRIBUTE_PATHS : attributePaths;
 	}
 
 	/**
@@ -64,12 +82,32 @@ public class JpaEntityGraph {
 		return type;
 	}
 
+	/**
+	 * Returns the attribute node names to be used for this {@link JpaEntityGraph}.
+	 * 
+	 * @return
+	 * @since 1.9
+	 */
+	public String[] getAttributePaths() {
+		return attributePaths;
+	}
+
+	/**
+	 * Return {@literal true} if this {@link JpaEntityGraph} needs to be generated on-the-fly.
+	 * 
+	 * @return
+	 */
+	public boolean isDynamicEntityGraph() {
+		return this.attributePaths.length > 0;
+	}
+
 	/* 
 	 * (non-Javadoc)
 	 * @see java.lang.Object#toString()
 	 */
 	@Override
 	public String toString() {
-		return "JpaEntityGraph [name=" + name + ", type=" + type + "]";
+		return "JpaEntityGraph [name=" + name + ", type=" + type + ", attributePaths=" + Arrays.toString(attributePaths)
+				+ "]";
 	}
 }

--- a/src/main/java/org/springframework/data/jpa/repository/query/JpaQueryMethod.java
+++ b/src/main/java/org/springframework/data/jpa/repository/query/JpaQueryMethod.java
@@ -15,7 +15,8 @@
  */
 package org.springframework.data.jpa.repository.query;
 
-import static org.springframework.core.annotation.AnnotationUtils.*;
+import static org.springframework.core.annotation.AnnotationUtils.findAnnotation;
+import static org.springframework.core.annotation.AnnotationUtils.getAnnotation;
 
 import java.lang.reflect.Method;
 import java.util.ArrayList;
@@ -173,7 +174,7 @@ public class JpaQueryMethod extends QueryMethod {
 	JpaEntityGraph getEntityGraph() {
 
 		EntityGraph annotation = findAnnotation(method, EntityGraph.class);
-		return annotation == null ? null : new JpaEntityGraph(annotation.value(), annotation.type());
+		return annotation == null ? null : new JpaEntityGraph(annotation, getNamedQueryName());
 	}
 
 	/**

--- a/src/main/java/org/springframework/data/jpa/repository/support/CrudMethodMetadata.java
+++ b/src/main/java/org/springframework/data/jpa/repository/support/CrudMethodMetadata.java
@@ -15,10 +15,12 @@
  */
 package org.springframework.data.jpa.repository.support;
 
+import java.lang.reflect.Method;
 import java.util.Map;
 
 import javax.persistence.LockModeType;
 
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.query.JpaEntityGraph;
 
 /**
@@ -45,10 +47,18 @@ public interface CrudMethodMetadata {
 	Map<String, Object> getQueryHints();
 
 	/**
-	 * Returns the {@link JpaEntityGraph} to be used.
+	 * Returns the {@link EntityGraph} to be used.
 	 * 
 	 * @return
-	 * @since 1.8
+	 * @since 1.9
 	 */
-	JpaEntityGraph getEntityGraph();
+	EntityGraph getEntityGraph();
+	
+	/**
+	 * Returns the {@link Method} to be used.
+	 * 
+	 * @return
+	 * @since 1.9
+	 */
+	Method getMethod();
 }

--- a/src/main/java/org/springframework/data/jpa/repository/support/CrudMethodMetadata.java
+++ b/src/main/java/org/springframework/data/jpa/repository/support/CrudMethodMetadata.java
@@ -47,18 +47,10 @@ public interface CrudMethodMetadata {
 	Map<String, Object> getQueryHints();
 
 	/**
-	 * Returns the {@link EntityGraph} to be used.
+	 * Returns the {@link JpaEntityGraph} to be used.
 	 * 
 	 * @return
-	 * @since 1.9
+	 * @since 1.8
 	 */
-	EntityGraph getEntityGraph();
-	
-	/**
-	 * Returns the {@link Method} to be used.
-	 * 
-	 * @return
-	 * @since 1.9
-	 */
-	Method getMethod();
+	JpaEntityGraph getEntityGraph();
 }

--- a/src/main/java/org/springframework/data/jpa/repository/support/SimpleJpaRepository.java
+++ b/src/main/java/org/springframework/data/jpa/repository/support/SimpleJpaRepository.java
@@ -15,7 +15,11 @@
  */
 package org.springframework.data.jpa.repository.support;
 
-import static org.springframework.data.jpa.repository.query.QueryUtils.*;
+import static org.springframework.data.jpa.repository.query.QueryUtils.COUNT_QUERY_STRING;
+import static org.springframework.data.jpa.repository.query.QueryUtils.DELETE_ALL_QUERY_STRING;
+import static org.springframework.data.jpa.repository.query.QueryUtils.applyAndBind;
+import static org.springframework.data.jpa.repository.query.QueryUtils.getQueryString;
+import static org.springframework.data.jpa.repository.query.QueryUtils.toOrders;
 
 import java.io.Serializable;
 import java.util.ArrayList;
@@ -49,6 +53,7 @@ import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.jpa.repository.query.Jpa21Utils;
+import org.springframework.data.jpa.repository.query.JpaEntityGraph;
 import org.springframework.data.jpa.repository.query.QueryUtils;
 import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
@@ -248,9 +253,16 @@ public class SimpleJpaRepository<T, ID extends Serializable> implements JpaRepos
 
 		Map<String, Object> hints = new HashMap<String, Object>();
 		hints.putAll(metadata.getQueryHints());
-		hints.putAll(Jpa21Utils.tryGetFetchGraphHints(em, metadata.getEntityGraph()));
+
+		hints.putAll(Jpa21Utils.tryGetFetchGraphHints(em, getEntityGraph(), getDomainClass()));
 
 		return hints;
+	}
+
+	private JpaEntityGraph getEntityGraph() {
+		
+		String fallbackName = this.entityInformation.getEntityName() + "." + metadata.getMethod().getName();
+		return new JpaEntityGraph(metadata.getEntityGraph(), fallbackName);
 	}
 
 	/* 

--- a/src/main/java/org/springframework/data/jpa/repository/support/SimpleJpaRepository.java
+++ b/src/main/java/org/springframework/data/jpa/repository/support/SimpleJpaRepository.java
@@ -254,17 +254,11 @@ public class SimpleJpaRepository<T, ID extends Serializable> implements JpaRepos
 		Map<String, Object> hints = new HashMap<String, Object>();
 		hints.putAll(metadata.getQueryHints());
 
-		hints.putAll(Jpa21Utils.tryGetFetchGraphHints(em, getEntityGraph(), getDomainClass()));
+		hints.putAll(Jpa21Utils.tryGetFetchGraphHints(em, metadata.getEntityGraph(), getDomainClass()));
 
 		return hints;
 	}
-
-	private JpaEntityGraph getEntityGraph() {
-		
-		String fallbackName = this.entityInformation.getEntityName() + "." + metadata.getMethod().getName();
-		return new JpaEntityGraph(metadata.getEntityGraph(), fallbackName);
-	}
-
+	
 	/* 
 	 * (non-Javadoc)
 	 * @see org.springframework.data.jpa.repository.JpaRepository#getOne(java.io.Serializable)

--- a/src/test/java/org/springframework/data/jpa/domain/sample/User.java
+++ b/src/test/java/org/springframework/data/jpa/domain/sample/User.java
@@ -52,6 +52,8 @@ import javax.persistence.TemporalType;
 @NamedEntityGraphs({
 		@NamedEntityGraph(name = "User.overview", attributeNodes = { @NamedAttributeNode("roles") }),
 		@NamedEntityGraph(name = "User.detail", attributeNodes = { @NamedAttributeNode("roles"),
+				@NamedAttributeNode("manager"), @NamedAttributeNode("colleagues") }),
+		@NamedEntityGraph(name = "User.getOneWithDefinedEntityGraphById", attributeNodes = { @NamedAttributeNode("roles"),
 				@NamedAttributeNode("manager"), @NamedAttributeNode("colleagues") }) })
 @NamedQuery(name = "User.findByEmailAddress", query = "SELECT u FROM User u WHERE u.emailAddress = ?1")
 @NamedStoredProcedureQueries({ //

--- a/src/test/java/org/springframework/data/jpa/provider/PersistenceProviderUnitTests.java
+++ b/src/test/java/org/springframework/data/jpa/provider/PersistenceProviderUnitTests.java
@@ -15,22 +15,37 @@
  */
 package org.springframework.data.jpa.provider;
 
-import static org.hamcrest.CoreMatchers.*;
-import static org.junit.Assert.*;
-import static org.springframework.data.jpa.provider.PersistenceProvider.*;
-import static org.springframework.data.jpa.provider.PersistenceProvider.Constants.*;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.springframework.data.jpa.provider.PersistenceProvider.ECLIPSELINK;
+import static org.springframework.data.jpa.provider.PersistenceProvider.GENERIC_JPA;
+import static org.springframework.data.jpa.provider.PersistenceProvider.HIBERNATE;
+import static org.springframework.data.jpa.provider.PersistenceProvider.OPEN_JPA;
+import static org.springframework.data.jpa.provider.PersistenceProvider.fromEntityManager;
+import static org.springframework.data.jpa.provider.PersistenceProvider.Constants.ECLIPSELINK_ENTITY_MANAGER_INTERFACE;
+import static org.springframework.data.jpa.provider.PersistenceProvider.Constants.HIBERNATE43_ENTITY_MANAGER_INTERFACE;
+import static org.springframework.data.jpa.provider.PersistenceProvider.Constants.HIBERNATE_ENTITY_MANAGER_INTERFACE;
+import static org.springframework.data.jpa.provider.PersistenceProvider.Constants.OPENJPA_ENTITY_MANAGER_INTERFACE;
 
 import java.util.ArrayList;
 import java.util.List;
 
+import javax.persistence.EntityGraph;
 import javax.persistence.EntityManager;
+import javax.persistence.Subgraph;
 
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
 import org.springframework.asm.ClassWriter;
 import org.springframework.asm.Opcodes;
-import org.springframework.data.jpa.provider.PersistenceProvider;
+import org.springframework.data.jpa.repository.EntityGraph.EntityGraphType;
+import org.springframework.data.jpa.repository.query.JpaEntityGraph;
 import org.springframework.instrument.classloading.ShadowingClassLoader;
 import org.springframework.util.ClassUtils;
 
@@ -101,6 +116,26 @@ public class PersistenceProviderUnitTests {
 		EntityManager em = mockProviderSpecificEntityManagerInterface("foo.bar.unknown.jpa.JpaEntityManager");
 
 		assertThat(fromEntityManager(em), is(GENERIC_JPA));
+	}
+
+	/**
+	 * @see DATAJPA-696
+	 */
+	@Test
+	public void shouldBuildCorrectSubgraphForJpaEntityGraph() throws Exception {
+
+		EntityGraph<?> entityGraph = mock(EntityGraph.class);
+		Subgraph<?> subgraph = mock(Subgraph.class);
+		doReturn(subgraph).when(entityGraph).addSubgraph(anyString());
+
+		JpaEntityGraph jpaEntityGraph = new JpaEntityGraph("foo", EntityGraphType.FETCH,
+				new String[] { "foo", "gugu.gaga" });
+
+		PersistenceProvider.GENERIC_JPA.configureFetchGraphFrom(jpaEntityGraph, entityGraph);
+
+		verify(entityGraph, times(1)).addAttributeNodes("foo");
+		verify(entityGraph, times(1)).addSubgraph("gugu");
+		verify(subgraph, times(1)).addAttributeNodes("gaga");
 	}
 
 	private EntityManager mockProviderSpecificEntityManagerInterface(String interfaceName) throws ClassNotFoundException {

--- a/src/test/java/org/springframework/data/jpa/provider/PersistenceProviderUnitTests.java
+++ b/src/test/java/org/springframework/data/jpa/provider/PersistenceProviderUnitTests.java
@@ -15,22 +15,11 @@
  */
 package org.springframework.data.jpa.provider;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
-import static org.mockito.Matchers.anyString;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.springframework.data.jpa.provider.PersistenceProvider.ECLIPSELINK;
-import static org.springframework.data.jpa.provider.PersistenceProvider.GENERIC_JPA;
-import static org.springframework.data.jpa.provider.PersistenceProvider.HIBERNATE;
-import static org.springframework.data.jpa.provider.PersistenceProvider.OPEN_JPA;
-import static org.springframework.data.jpa.provider.PersistenceProvider.fromEntityManager;
-import static org.springframework.data.jpa.provider.PersistenceProvider.Constants.ECLIPSELINK_ENTITY_MANAGER_INTERFACE;
-import static org.springframework.data.jpa.provider.PersistenceProvider.Constants.HIBERNATE43_ENTITY_MANAGER_INTERFACE;
-import static org.springframework.data.jpa.provider.PersistenceProvider.Constants.HIBERNATE_ENTITY_MANAGER_INTERFACE;
-import static org.springframework.data.jpa.provider.PersistenceProvider.Constants.OPENJPA_ENTITY_MANAGER_INTERFACE;
+import static org.hamcrest.CoreMatchers.*;
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+import static org.springframework.data.jpa.provider.PersistenceProvider.*;
+import static org.springframework.data.jpa.provider.PersistenceProvider.Constants.*;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -125,17 +114,20 @@ public class PersistenceProviderUnitTests {
 	public void shouldBuildCorrectSubgraphForJpaEntityGraph() throws Exception {
 
 		EntityGraph<?> entityGraph = mock(EntityGraph.class);
-		Subgraph<?> subgraph = mock(Subgraph.class);
-		doReturn(subgraph).when(entityGraph).addSubgraph(anyString());
+		Subgraph<?> guguSubgraph = mock(Subgraph.class);
+		Subgraph<?> blaSubgraph = mock(Subgraph.class);
+		doReturn(guguSubgraph).when(entityGraph).addSubgraph("gugu");
+		doReturn(blaSubgraph).when(entityGraph).addSubgraph("bla");
 
-		JpaEntityGraph jpaEntityGraph = new JpaEntityGraph("foo", EntityGraphType.FETCH,
-				new String[] { "foo", "gugu.gaga" });
+		JpaEntityGraph jpaEntityGraph = new JpaEntityGraph("foo", EntityGraphType.FETCH, new String[] { "foo", "gugu.gaga",
+				"bar", "gugu.fugu", "bla.fasel" });
 
 		PersistenceProvider.GENERIC_JPA.configureFetchGraphFrom(jpaEntityGraph, entityGraph);
 
-		verify(entityGraph, times(1)).addAttributeNodes("foo");
+		verify(entityGraph, times(1)).addAttributeNodes(new String[] { "foo", "bar" });
 		verify(entityGraph, times(1)).addSubgraph("gugu");
-		verify(subgraph, times(1)).addAttributeNodes("gaga");
+		verify(guguSubgraph, times(1)).addAttributeNodes(new String[] { "gaga", "fugu" });
+		verify(blaSubgraph, times(1)).addAttributeNodes("fasel");
 	}
 
 	private EntityManager mockProviderSpecificEntityManagerInterface(String interfaceName) throws ClassNotFoundException {

--- a/src/test/java/org/springframework/data/jpa/provider/PersistenceProviderUnitTests.java
+++ b/src/test/java/org/springframework/data/jpa/provider/PersistenceProviderUnitTests.java
@@ -17,24 +17,19 @@ package org.springframework.data.jpa.provider;
 
 import static org.hamcrest.CoreMatchers.*;
 import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
 import static org.springframework.data.jpa.provider.PersistenceProvider.*;
 import static org.springframework.data.jpa.provider.PersistenceProvider.Constants.*;
 
 import java.util.ArrayList;
 import java.util.List;
 
-import javax.persistence.EntityGraph;
 import javax.persistence.EntityManager;
-import javax.persistence.Subgraph;
 
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
 import org.springframework.asm.ClassWriter;
 import org.springframework.asm.Opcodes;
-import org.springframework.data.jpa.repository.EntityGraph.EntityGraphType;
-import org.springframework.data.jpa.repository.query.JpaEntityGraph;
 import org.springframework.instrument.classloading.ShadowingClassLoader;
 import org.springframework.util.ClassUtils;
 
@@ -105,29 +100,6 @@ public class PersistenceProviderUnitTests {
 		EntityManager em = mockProviderSpecificEntityManagerInterface("foo.bar.unknown.jpa.JpaEntityManager");
 
 		assertThat(fromEntityManager(em), is(GENERIC_JPA));
-	}
-
-	/**
-	 * @see DATAJPA-696
-	 */
-	@Test
-	public void shouldBuildCorrectSubgraphForJpaEntityGraph() throws Exception {
-
-		EntityGraph<?> entityGraph = mock(EntityGraph.class);
-		Subgraph<?> guguSubgraph = mock(Subgraph.class);
-		Subgraph<?> blaSubgraph = mock(Subgraph.class);
-		doReturn(guguSubgraph).when(entityGraph).addSubgraph("gugu");
-		doReturn(blaSubgraph).when(entityGraph).addSubgraph("bla");
-
-		JpaEntityGraph jpaEntityGraph = new JpaEntityGraph("foo", EntityGraphType.FETCH, new String[] { "foo", "gugu.gaga",
-				"bar", "gugu.fugu", "bla.fasel" });
-
-		PersistenceProvider.GENERIC_JPA.configureFetchGraphFrom(jpaEntityGraph, entityGraph);
-
-		verify(entityGraph, times(1)).addAttributeNodes(new String[] { "foo", "bar" });
-		verify(entityGraph, times(1)).addSubgraph("gugu");
-		verify(guguSubgraph, times(1)).addAttributeNodes(new String[] { "gaga", "fugu" });
-		verify(blaSubgraph, times(1)).addAttributeNodes("fasel");
 	}
 
 	private EntityManager mockProviderSpecificEntityManagerInterface(String interfaceName) throws ClassNotFoundException {

--- a/src/test/java/org/springframework/data/jpa/repository/query/Jpa21UtilsTests.java
+++ b/src/test/java/org/springframework/data/jpa/repository/query/Jpa21UtilsTests.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.jpa.repository.query;
+
+import static org.mockito.Mockito.*;
+
+import javax.persistence.EntityGraph;
+import javax.persistence.Subgraph;
+
+import org.junit.Test;
+import org.springframework.data.jpa.repository.EntityGraph.EntityGraphType;
+
+/**
+ * Tests for {@link Jpa21Utils}.
+ * 
+ * @author Thomas Darimont
+ */
+public class Jpa21UtilsTests {
+
+	/**
+	 * @see DATAJPA-696
+	 */
+	@Test
+	public void shouldBuildCorrectSubgraphForJpaEntityGraph() throws Exception {
+
+		EntityGraph<?> entityGraph = mock(EntityGraph.class);
+		Subgraph<?> guguSubgraph = mock(Subgraph.class);
+		Subgraph<?> blaSubgraph = mock(Subgraph.class);
+		doReturn(guguSubgraph).when(entityGraph).addSubgraph("gugu");
+		doReturn(blaSubgraph).when(entityGraph).addSubgraph("bla");
+
+		JpaEntityGraph jpaEntityGraph = new JpaEntityGraph("foo", EntityGraphType.FETCH, new String[] { "foo", "gugu.gaga",
+				"bar", "gugu.fugu", "bla.fasel" });
+
+		Jpa21Utils.configureFetchGraphFrom(jpaEntityGraph, entityGraph);
+
+		verify(entityGraph, times(1)).addAttributeNodes(new String[] { "foo", "bar" });
+		verify(entityGraph, times(1)).addSubgraph("gugu");
+		verify(guguSubgraph, times(1)).addAttributeNodes(new String[] { "gaga", "fugu" });
+		verify(blaSubgraph, times(1)).addAttributeNodes("fasel");
+	}
+}

--- a/src/test/java/org/springframework/data/jpa/repository/query/Jpa21UtilsTests.java
+++ b/src/test/java/org/springframework/data/jpa/repository/query/Jpa21UtilsTests.java
@@ -17,6 +17,8 @@ package org.springframework.data.jpa.repository.query;
 
 import static org.mockito.Mockito.*;
 
+import java.util.List;
+
 import javax.persistence.EntityGraph;
 import javax.persistence.Subgraph;
 
@@ -45,11 +47,30 @@ public class Jpa21UtilsTests {
 		JpaEntityGraph jpaEntityGraph = new JpaEntityGraph("foo", EntityGraphType.FETCH, new String[] { "foo", "gugu.gaga",
 				"bar", "gugu.fugu", "bla.fasel" });
 
-		Jpa21Utils.configureFetchGraphFrom(jpaEntityGraph, entityGraph);
+		Jpa21Utils.configureFetchGraphFrom(jpaEntityGraph, entityGraph, RootEntity.class);
 
 		verify(entityGraph, times(1)).addAttributeNodes(new String[] { "foo", "bar" });
 		verify(entityGraph, times(1)).addSubgraph("gugu");
 		verify(guguSubgraph, times(1)).addAttributeNodes(new String[] { "gaga", "fugu" });
 		verify(blaSubgraph, times(1)).addAttributeNodes("fasel");
+	}
+
+	public static class RootEntity {
+
+		List<String> foo;
+		List<String> bar;
+		GuguNestedEntity gugu;
+		BlaNestedEntity bla;
+	}
+
+	public static class GuguNestedEntity {
+
+		List<String> gaga;
+		List<String> fugu;
+	}
+
+	public static class BlaNestedEntity {
+
+		List<String> fasel;
 	}
 }

--- a/src/test/java/org/springframework/data/jpa/repository/sample/RepositoryMethodsWithEntityGraphConfigJpaRepository.java
+++ b/src/test/java/org/springframework/data/jpa/repository/sample/RepositoryMethodsWithEntityGraphConfigJpaRepository.java
@@ -41,4 +41,16 @@ public interface RepositoryMethodsWithEntityGraphConfigJpaRepository extends Jpa
 	 */
 	@EntityGraph(type = EntityGraphType.FETCH, value = "User.detail")
 	User findOne(Integer id);
+
+	/**
+	 * @see DATAJPA-696
+	 */
+	@EntityGraph
+	User getOneWithDefinedEntityGraphById(Integer id);
+	
+	/**
+	 * @see DATAJPA-696
+	 */
+	@EntityGraph(attributePaths = { "roles", "colleagues.roles" })
+	User getOneWithAttributeNamesById(Integer id);
 }

--- a/src/test/java/org/springframework/data/jpa/repository/sample/RepositoryMethodsWithEntityGraphConfigJpaRepository.java
+++ b/src/test/java/org/springframework/data/jpa/repository/sample/RepositoryMethodsWithEntityGraphConfigJpaRepository.java
@@ -39,7 +39,7 @@ public interface RepositoryMethodsWithEntityGraphConfigJpaRepository extends Jpa
 	/**
 	 * Should fetch all user details
 	 */
-	@EntityGraph(type = EntityGraphType.FETCH, value = "User.detail")
+	@EntityGraph("User.detail")
 	User findOne(Integer id);
 
 	/**
@@ -51,6 +51,6 @@ public interface RepositoryMethodsWithEntityGraphConfigJpaRepository extends Jpa
 	/**
 	 * @see DATAJPA-696
 	 */
-	@EntityGraph(attributePaths = { "roles", "colleagues.roles" })
+	@EntityGraph(attributePaths = { "roles", "colleagues" })
 	User getOneWithAttributeNamesById(Integer id);
 }

--- a/src/test/java/org/springframework/data/jpa/repository/support/CrudMethodMetadataPopulatingMethodInterceptorUnitTests.java
+++ b/src/test/java/org/springframework/data/jpa/repository/support/CrudMethodMetadataPopulatingMethodInterceptorUnitTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2014 the original author or authors.
+ * Copyright 2012-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,17 +30,20 @@ import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.support.CrudMethodMetadataPostProcessor.CrudMethodMetadataPopulatingMethodInterceptor;
+import org.springframework.data.repository.core.RepositoryInformation;
 import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 /**
  * Unit tests for {@link CrudMethodMetadataPopulatingMethodInterceptor}.
  * 
  * @author Oliver Gierke
+ * @author Thomas Darimont
  */
 @RunWith(MockitoJUnitRunner.class)
 public class CrudMethodMetadataPopulatingMethodInterceptorUnitTests {
 
 	@Mock MethodInvocation invocation;
+	@Mock RepositoryInformation repositoryInformation;
 
 	/**
 	 * @see DATAJPA-268
@@ -51,7 +54,7 @@ public class CrudMethodMetadataPopulatingMethodInterceptorUnitTests {
 		Method method = Sample.class.getMethod("someMethod");
 		when(invocation.getMethod()).thenReturn(method);
 
-		CrudMethodMetadataPopulatingMethodInterceptor interceptor = CrudMethodMetadataPopulatingMethodInterceptor.INSTANCE;
+		CrudMethodMetadataPopulatingMethodInterceptor interceptor = new CrudMethodMetadataPopulatingMethodInterceptor(repositoryInformation);
 		interceptor.invoke(invocation);
 
 		assertThat(TransactionSynchronizationManager.getResource(method), is(nullValue()));

--- a/src/test/java/org/springframework/data/jpa/repository/support/CrudMethodMetadataPopulatingMethodInterceptorUnitTests.java
+++ b/src/test/java/org/springframework/data/jpa/repository/support/CrudMethodMetadataPopulatingMethodInterceptorUnitTests.java
@@ -29,11 +29,11 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 import org.springframework.data.jpa.repository.Lock;
-import org.springframework.data.jpa.repository.support.CrudMethodMetadataPostProcessor.CrudMethodMetadataPopulatingMethodIntercceptor;
+import org.springframework.data.jpa.repository.support.CrudMethodMetadataPostProcessor.CrudMethodMetadataPopulatingMethodInterceptor;
 import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 /**
- * Unit tests for {@link CrudMethodMetadataPopulatingMethodIntercceptor}.
+ * Unit tests for {@link CrudMethodMetadataPopulatingMethodInterceptor}.
  * 
  * @author Oliver Gierke
  */
@@ -51,7 +51,7 @@ public class CrudMethodMetadataPopulatingMethodInterceptorUnitTests {
 		Method method = Sample.class.getMethod("someMethod");
 		when(invocation.getMethod()).thenReturn(method);
 
-		CrudMethodMetadataPopulatingMethodIntercceptor interceptor = CrudMethodMetadataPopulatingMethodIntercceptor.INSTANCE;
+		CrudMethodMetadataPopulatingMethodInterceptor interceptor = CrudMethodMetadataPopulatingMethodInterceptor.INSTANCE;
 		interceptor.invoke(invocation);
 
 		assertThat(TransactionSynchronizationManager.getResource(method), is(nullValue()));

--- a/src/test/java/org/springframework/data/jpa/repository/support/SimpleJpaRepositoryUnitTests.java
+++ b/src/test/java/org/springframework/data/jpa/repository/support/SimpleJpaRepositoryUnitTests.java
@@ -15,8 +15,12 @@
  */
 package org.springframework.data.jpa.repository.support;
 
-import static java.util.Collections.*;
-import static org.mockito.Mockito.*;
+import static java.util.Collections.singletonMap;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.Serializable;
 
 import javax.persistence.EntityGraph;
 import javax.persistence.EntityManager;
@@ -33,7 +37,7 @@ import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.jpa.domain.sample.User;
 import org.springframework.data.jpa.repository.EntityGraph.EntityGraphType;
-import org.springframework.data.jpa.repository.query.JpaEntityGraph;
+import org.springframework.data.repository.CrudRepository;
 
 /**
  * Unit tests for {@link SimpleJpaRepository}.
@@ -55,6 +59,7 @@ public class SimpleJpaRepositoryUnitTests {
 	@Mock JpaEntityInformation<User, Long> information;
 	@Mock CrudMethodMetadata metadata;
 	@Mock EntityGraph<User> entityGraph;
+	@Mock org.springframework.data.jpa.repository.EntityGraph entityGraphAnnotation;
 
 	@Before
 	public void setUp() {
@@ -97,15 +102,20 @@ public class SimpleJpaRepositoryUnitTests {
 
 	/**
 	 * @see DATAJPA-689
+	 * @see DATAJPA-696
 	 */
 	@Test
 	@SuppressWarnings({ "rawtypes", "unchecked" })
-	public void shouldPropagateConfiguredEntityGraphToFindOne() {
+	public void shouldPropagateConfiguredEntityGraphToFindOne() throws Exception{
 
 		String entityGraphName = "User.detail";
-		when(metadata.getEntityGraph()).thenReturn(new JpaEntityGraph(entityGraphName, EntityGraphType.LOAD));
+		when(entityGraphAnnotation.value()).thenReturn(entityGraphName);
+		when(entityGraphAnnotation.type()).thenReturn(EntityGraphType.LOAD);
+		when(metadata.getEntityGraph()).thenReturn(entityGraphAnnotation);
 		when(em.getEntityGraph(entityGraphName)).thenReturn((EntityGraph) entityGraph);
-
+		when(information.getEntityName()).thenReturn("User");
+		when(metadata.getMethod()).thenReturn(CrudRepository.class.getMethod("findOne", Serializable.class));
+		
 		Integer id = 0;
 		repo.findOne(id);
 

--- a/src/test/java/org/springframework/data/jpa/repository/support/SimpleJpaRepositoryUnitTests.java
+++ b/src/test/java/org/springframework/data/jpa/repository/support/SimpleJpaRepositoryUnitTests.java
@@ -15,12 +15,8 @@
  */
 package org.springframework.data.jpa.repository.support;
 
-import static java.util.Collections.singletonMap;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-
-import java.io.Serializable;
+import static java.util.Collections.*;
+import static org.mockito.Mockito.*;
 
 import javax.persistence.EntityGraph;
 import javax.persistence.EntityManager;
@@ -37,7 +33,7 @@ import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.jpa.domain.sample.User;
 import org.springframework.data.jpa.repository.EntityGraph.EntityGraphType;
-import org.springframework.data.repository.CrudRepository;
+import org.springframework.data.jpa.repository.query.JpaEntityGraph;
 
 /**
  * Unit tests for {@link SimpleJpaRepository}.
@@ -105,17 +101,14 @@ public class SimpleJpaRepositoryUnitTests {
 	 * @see DATAJPA-696
 	 */
 	@Test
-	@SuppressWarnings({ "rawtypes", "unchecked" })
-	public void shouldPropagateConfiguredEntityGraphToFindOne() throws Exception{
+	public void shouldPropagateConfiguredEntityGraphToFindOne() throws Exception {
 
 		String entityGraphName = "User.detail";
 		when(entityGraphAnnotation.value()).thenReturn(entityGraphName);
 		when(entityGraphAnnotation.type()).thenReturn(EntityGraphType.LOAD);
-		when(metadata.getEntityGraph()).thenReturn(entityGraphAnnotation);
-		when(em.getEntityGraph(entityGraphName)).thenReturn((EntityGraph) entityGraph);
-		when(information.getEntityName()).thenReturn("User");
-		when(metadata.getMethod()).thenReturn(CrudRepository.class.getMethod("findOne", Serializable.class));
-		
+		when(metadata.getEntityGraph()).thenReturn(new JpaEntityGraph(entityGraphName, EntityGraphType.LOAD, null));
+		doReturn(entityGraph).when(em).getEntityGraph(entityGraphName);
+
 		Integer id = 0;
 		repo.findOne(id);
 


### PR DESCRIPTION
We now support the specification of dynamic EntityGraphs on repository finder methods by allowing to specify the fetch graph paths via the “attributePaths” attribute on the EntityGraph annotation.
Previously users had to specify the EntityGraph specifications upfront via `@NamedEntityGraph` on the entity-class.

Configured eclipse link tests to use dynamic weaving, required for dynamic entity fetch graphs.
Upgraded eclipse link to version 2.5.2 for full fetch-graph support.
Fixed typo in CrudMethodMetadataPopulatingMethodInterceptor.