### PR TITLE
DATAJPA-704 Allow specifying/providing query strings programatically

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-jpa</artifactId>
-	<version>1.9.0.BUILD-SNAPSHOT</version>
+	<version>1.9.0.DATAJPA-704-SNAPSHOT</version>
 
 	<name>Spring Data JPA</name>
 	<description>Spring Data module for JPA repositories.</description>

--- a/src/main/java/org/springframework/data/jpa/repository/JpaCountQueryProvider.java
+++ b/src/main/java/org/springframework/data/jpa/repository/JpaCountQueryProvider.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2008-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.jpa.repository;
+
+/**
+ * A {@link JpaQueryProvider} that also provides a count query or a count projection.
+ * 
+ * @see JpaQueryProvider
+ * 
+ * @author Nick Guletskii
+ */
+public interface JpaCountQueryProvider extends JpaQueryProvider {
+
+	/**
+	 * This method should return the countQuery string or null if {@link Query#countQuery()} should be used.
+	 * 
+	 * @see Query#countQuery()
+	 */
+	public String getCountQuery();
+
+	/**
+	 * This method should return the countProjection string or null if {@link Query#countProjection()} should be used.
+	 * 
+	 * @see Query#countProjection()
+	 */
+	public String getCountProjection();
+}

--- a/src/main/java/org/springframework/data/jpa/repository/JpaQueryProvider.java
+++ b/src/main/java/org/springframework/data/jpa/repository/JpaQueryProvider.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2008-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.jpa.repository;
+
+/**
+ * Interface that should be implemented by classes that provide JPA queries.
+ * 
+ * @author Nick Guletskii
+ */
+public interface JpaQueryProvider {
+
+	/**
+	 * This method should return the query string or null if {@link Query#value()} should be used.
+	 * 
+	 * @see Query#value()
+	 */
+	public String getQuery();
+
+}

--- a/src/main/java/org/springframework/data/jpa/repository/MethodAwareJpaQueryProvider.java
+++ b/src/main/java/org/springframework/data/jpa/repository/MethodAwareJpaQueryProvider.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2008-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.jpa.repository;
+
+import java.lang.reflect.Method;
+
+/**
+ * An extension over {@link JpaQueryProvider} that should be implemented by any {@link JpaQueryProvider} that wants to
+ * be aware of the method it is providing the query for.
+ * 
+ * @author Nick Guletskii
+ */
+public interface MethodAwareJpaQueryProvider extends JpaQueryProvider {
+
+	/**
+	 * This method will be called before methods declared in {@link JpaQueryProvider} and {@link JpaCountQueryProvider}
+	 * are called.
+	 * 
+	 * @param The method for which the query is being provided.
+	 */
+	public void setMethod(Method method);
+
+}

--- a/src/main/java/org/springframework/data/jpa/repository/Query.java
+++ b/src/main/java/org/springframework/data/jpa/repository/Query.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2008-2014 the original author or authors.
+ * Copyright 2008-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,18 +37,24 @@ public @interface Query {
 
 	/**
 	 * Defines the JPA query to be executed when the annotated method is called.
+	 * 
+	 * Can be overruled by the {@link #queryProvider()}.
 	 */
 	String value() default "";
 
 	/**
 	 * Defines a special count query that shall be used for pagination queries to lookup the total number of elements for
 	 * a page. If non is configured we will derive the count query from the method name.
+	 * 
+	 * Can be overruled by the {@link #queryProvider()}.
 	 */
 	String countQuery() default "";
 
 	/**
 	 * Defines the projection part of the count query that is generated for pagination. If neither {@link #countQuery()}
 	 * not {@link #countProjection()} is configured we will derive the count query from the method name.
+	 * 
+	 * Can be overruled by the {@link #queryProvider()}.
 	 * 
 	 * @return
 	 * @since 1.6
@@ -74,4 +80,18 @@ public @interface Query {
 	 * @return
 	 */
 	String countName() default "";
+
+	/**
+	 * Returns the class that provides the JPA queries to be executed.
+	 * 
+	 * @see #value()
+	 * @see #countQuery()
+	 * @see #countProjection()
+	 * 
+	 * @see JpaQueryProvider
+	 * @see JpaCountQueryProvider
+	 * @see MethodAwareJpaQueryProvider
+	 */
+	Class<? extends JpaQueryProvider> queryProvider() default JpaQueryProvider.class;
+
 }


### PR DESCRIPTION
https://jira.spring.io/browse/DATAJPA-704
## Summary

Query providers are classes that implement the JpaQueryProvider interface. They serve as a way to set the queries at runtime, meaning that you can load queries from files, build them using a DSL, etc...
instead of putting them into the Query annotations as constants. This is better than using named queries because named queries force you to use either the NamedQuery annotation (same problem as above) or orm.xml (editing SQL in XML is inconvenient).
## Notes

At first, I wanted to implement query loading using Spring resource locations, but I realised that the current architecture of the internals of Spring Data is going to make that quite difficult to do, since this would require implementing ResourceLoaderAware.

I also considered just adding support for custom query annotations, but 
## Examples

Simple query provider that also provides the count query and projection:

``` java
static class ValidCountQueryProvider implements JpaQueryProvider, JpaCountQueryProvider {

    @Override
    public String getQuery() {
        return "query";
    }

    @Override
    public String getCountQuery() {
        return "countQuery";
    }

    @Override
    public String getCountProjection() {
        return "countProjection";
    }
}

@Query(queryProvider = ValidCountQueryProvider.class)
List<User> queryMethodUsingCountQueryProvider(String lastname);
```

The MethodAwareQueryProvider interface can be implemented to make a more powerful, generic query provider:

``` java
static class MethodAwareQueryProvider implements JpaQueryProvider, MethodAwareJpaQueryProvider {

    private Method method;

    // Will be called before getQuery and other methods
    @Override
    public void setMethod(Method method) {
            this.method = method;
    }

    @Override
    public String getQuery() {
           ...
    }

}
```
