### PR TITLE
1.8.x

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
 	<modelVersion>4.0.0</modelVersion>
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.springframework.data.build</groupId>
 		<artifactId>spring-data-parent</artifactId>
-		<version>1.6.0.RELEASE</version>
+		<version>1.6.1.BUILD-SNAPSHOT</version>
 		<relativePath>../spring-data-build/parent/pom.xml</relativePath>
 	</parent>
 
@@ -27,7 +27,7 @@
 		<hsqldb1>1.8.0.10</hsqldb1>
 		<jpa>2.0.0</jpa>
 		<openjpa>2.3.0</openjpa>
-		<springdata.commons>1.10.0.RELEASE</springdata.commons>
+		<springdata.commons>1.10.1.BUILD-SNAPSHOT</springdata.commons>
 
 		<sonar.dynamicAnalysis>reuseReports</sonar.dynamicAnalysis>
 
@@ -449,8 +449,8 @@
 
 	<repositories>
 		<repository>
-			<id>spring-libs-release</id>
-			<url>https://repo.spring.io/libs-release</url>
+			<id>spring-libs-snapshot</id>
+			<url>https://repo.spring.io/libs-snapshot</url>
 		</repository>
 	</repositories>
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-jpa</artifactId>
-	<version>1.8.0.RELEASE</version>
+	<version>1.8.1.BUILD-SNAPSHOT</version>
 
 	<name>Spring Data JPA</name>
 	<description>Spring Data module for JPA repositories.</description>

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
 
 		<dist.key>DATAJPA</dist.key>
 
-		<eclipselink>2.5.1</eclipselink>
+		<eclipselink>2.5.2</eclipselink>
 		<hibernate>3.6.10.Final</hibernate>
 		<hsqldb1>1.8.0.10</hsqldb1>
 		<jpa>2.0.0</jpa>
@@ -259,11 +259,6 @@
 						<scope>runtime</scope>
 					</dependency>
 				</dependencies>
-				<configuration>
-					<excludes>
-						<exclude>**/infrastructure/*</exclude>
-					</excludes>
-				</configuration>
 				<executions>
 					<execution>
 						<id>default-test</id>
@@ -300,7 +295,6 @@
 								<exclude>**/*UnitTests.java</exclude>
 								<exclude>**/OpenJpa*</exclude>
 								<exclude>**/EclipseLink*</exclude>
-								<exclude>**/infrastructure/*</exclude>
 							</excludes>
 							<argLine>-javaagent:${settings.localRepository}/org/springframework/spring-instrument/${spring}/spring-instrument-${spring}.jar</argLine>
 						</configuration>

--- a/src/main/java/org/springframework/data/jpa/convert/threeten/Jsr310JpaConverters.java
+++ b/src/main/java/org/springframework/data/jpa/convert/threeten/Jsr310JpaConverters.java
@@ -37,7 +37,7 @@ import org.springframework.orm.jpa.LocalContainerEntityManagerFactoryBean;
 /**
  * JPA 2.1 converters to turn JSR-310 types into legacy {@link Date}s. To activate these converters make sure your
  * persistence provider detects them by including this class in the list of mapped classes. In Spring environments, you
- * can simply register the package of this class (i.e. {@code org.springframework.data.jpa.domain.support}) as package
+ * can simply register the package of this class (i.e. {@code org.springframework.data.jpa.convert.threeten}) as package
  * to be scanned on e.g. the {@link LocalContainerEntityManagerFactoryBean}.
  * 
  * @author Oliver Gierke

--- a/src/main/java/org/springframework/data/jpa/convert/threetenbp/ThreeTenBackPortJpaConverters.java
+++ b/src/main/java/org/springframework/data/jpa/convert/threetenbp/ThreeTenBackPortJpaConverters.java
@@ -37,7 +37,7 @@ import org.threeten.bp.LocalTime;
 /**
  * JPA 2.1 converters to turn ThreeTen back port types into legacy {@link Date}s. To activate these converters make sure
  * your persistence provider detects them by including this class in the list of mapped classes. In Spring environments,
- * you can simply register the package of this class (i.e. {@code org.springframework.data.jpa.domain.support}) as
+ * you can simply register the package of this class (i.e. {@code org.springframework.data.jpa.convert.threetenbp}) as
  * package to be scanned on e.g. the {@link LocalContainerEntityManagerFactoryBean}.
  * 
  * @author Oliver Gierke

--- a/src/test/java/org/springframework/data/jpa/infrastructure/HibernateMetamodelIntegrationTests.java
+++ b/src/test/java/org/springframework/data/jpa/infrastructure/HibernateMetamodelIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2014 the original author or authors.
+ * Copyright 2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,29 +17,22 @@ package org.springframework.data.jpa.infrastructure;
 
 import org.junit.Ignore;
 import org.junit.Test;
-import org.springframework.test.context.ContextConfiguration;
 
 /**
- * Metamodel tests using OpenJPA.
+ * Hibernate-specific integration test using the JPA metamodel.
  * 
  * @author Oliver Gierke
+ * @soundtrack Umphrey's McGee - Intentions Clear (Safety In Numbers)
  */
-@ContextConfiguration("classpath:eclipselink.xml")
-public class EclipseLinkMetamodelIntegrationTests extends MetamodelIntegrationTests {
+public class HibernateMetamodelIntegrationTests extends MetamodelIntegrationTests {
 
-	/**
-	 * TODO: Remove, once https://bugs.eclipse.org/bugs/show_bug.cgi?id=427892 is fixed.
-	 */
-	@Test
-	@Ignore
-	@Override
-	public void canAccessParametersByIndexForNativeQueries() {}
-
-	/**
-	 * TODO: Remove, once https://bugs.eclipse.org/bugs/show_bug.cgi?id=463663 is fixed.
-	 */
 	@Test
 	@Ignore
 	@Override
 	public void pathToEntityIsOfBindableTypeEntityType() {}
+
+	@Test
+	@Ignore
+	@Override
+	public void considersOneToOneAttributeAnAssociation() {}
 }

--- a/src/test/java/org/springframework/data/jpa/infrastructure/MetamodelIntegrationTests.java
+++ b/src/test/java/org/springframework/data/jpa/infrastructure/MetamodelIntegrationTests.java
@@ -41,7 +41,7 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
  */
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration({ "classpath:infrastructure.xml" })
-public class MetamodelIntegrationTests {
+public abstract class MetamodelIntegrationTests {
 
 	@PersistenceContext EntityManager em;
 

--- a/src/test/java/org/springframework/data/jpa/infrastructure/OpenJpaMetamodelIntegrationTests.java
+++ b/src/test/java/org/springframework/data/jpa/infrastructure/OpenJpaMetamodelIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 the original author or authors.
+ * Copyright 2013-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,6 +15,8 @@
  */
 package org.springframework.data.jpa.infrastructure;
 
+import org.junit.Ignore;
+import org.junit.Test;
 import org.springframework.test.context.ContextConfiguration;
 
 /**
@@ -25,4 +27,8 @@ import org.springframework.test.context.ContextConfiguration;
 @ContextConfiguration("classpath:openjpa.xml")
 public class OpenJpaMetamodelIntegrationTests extends MetamodelIntegrationTests {
 
+	@Test
+	@Ignore
+	@Override
+	public void canAccessParametersByIndexForNativeQueries() {}
 }

--- a/src/test/java/org/springframework/data/jpa/repository/EclipseLinkUserRepositoryFinderTests.java
+++ b/src/test/java/org/springframework/data/jpa/repository/EclipseLinkUserRepositoryFinderTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011 the original author or authors.
+ * Copyright 2011-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,11 +29,9 @@ public class EclipseLinkUserRepositoryFinderTests extends UserRepositoryFinderTe
 
 	@Ignore
 	@Override
-	public void executesNotInQueryCorrectly() throws Exception {
-	}
+	public void executesNotInQueryCorrectly() throws Exception {}
 
 	@Ignore
 	@Override
-	public void executesInKeywordForPageCorrectly() {
-	}
+	public void executesInKeywordForPageCorrectly() {}
 }


### PR DESCRIPTION
 spring data jpa have sort bug in oracle database , because oracle rownum .
spring data jpa generate pageable sql eg:

select *
  from (select row_.*, rownum rownum_
          from (select product0_.id                    as id1_8_,    
                       product0_.name                  as name,
                        product0_.code                  as code
                  from crm_product product0_
                 where product0_.status = 1
                 order by product0_.fxrq desc) row_
         where rownum &lt;= 30)
 where rownum_ &gt;= 1
 ---
correct pageable sql : 
 select m.* from (
            select t.*,rownum ind from (
                select * from CRM_PRODUCT where status=1 order by fxrq desc 
            ) t
        ) m
  where m.ind between 1 and 30