### PR TITLE
DATAJPA-658 - Improve metadata detection for xml based entity mappings.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-jpa</artifactId>
-	<version>1.9.0.BUILD-SNAPSHOT</version>
+	<version>1.9.0.DATAJPA-658-SNAPSHOT</version>
 
 	<name>Spring Data JPA</name>
 	<description>Spring Data module for JPA repositories.</description>

--- a/src/test/java/org/springframework/data/jpa/domain/sample/OrmXmlEntity.java
+++ b/src/test/java/org/springframework/data/jpa/domain/sample/OrmXmlEntity.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.jpa.domain.sample;
+
+/**
+ * This entity serves as a test object for orm.xml configuration and MUST NOT be configured via annotations!
+ * 
+ * @author Thomas Darimont
+ */
+public class OrmXmlEntity {
+
+	private Long id;
+
+	private String property1;
+
+	public Long getId() {
+		return id;
+	}
+
+	public void setId(Long id) {
+		this.id = id;
+	}
+
+	public String getProperty1() {
+		return property1;
+	}
+
+	public void setProperty1(String property1) {
+		this.property1 = property1;
+	}
+
+}

--- a/src/test/java/org/springframework/data/jpa/mapping/JpaMetamodelMappingContextIntegrationTests.java
+++ b/src/test/java/org/springframework/data/jpa/mapping/JpaMetamodelMappingContextIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2014 the original author or authors.
+ * Copyright 2012-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,6 +32,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.FilterType;
 import org.springframework.context.annotation.ImportResource;
 import org.springframework.data.jpa.domain.sample.Category;
+import org.springframework.data.jpa.domain.sample.OrmXmlEntity;
 import org.springframework.data.jpa.domain.sample.Product;
 import org.springframework.data.jpa.domain.sample.User;
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
@@ -49,6 +50,7 @@ import org.springframework.transaction.support.TransactionTemplate;
  * Integration tests for {@link JpaMetamodelMappingContext}.
  * 
  * @author Oliver Gierke
+ * @author Thomas Darimont
  * @since 1.3
  */
 @RunWith(SpringJUnit4ClassRunner.class)
@@ -155,5 +157,16 @@ public class JpaMetamodelMappingContextIntegrationTests {
 				return null;
 			}
 		});
+	}
+
+	/**
+	 * @see DATAJPA-658
+	 */
+	@Test
+	public void shouldDetectIdPropertyForEntityConfiguredViaOrmXmlWithoutAnyAnnotations() {
+
+		JpaPersistentEntity<?> entity = context.getPersistentEntity(OrmXmlEntity.class);
+
+		assertThat(entity.getIdProperty(), is(notNullValue()));
 	}
 }

--- a/src/test/resources/META-INF/orm.xml
+++ b/src/test/resources/META-INF/orm.xml
@@ -1,19 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<entity-mappings xmlns="http://java.sun.com/xml/ns/persistence/orm" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://java.sun.com/xml/ns/persistence/orm http://java.sun.com/xml/ns/persistence/orm_2_0.xsd" version="2.0">
+<entity-mappings xmlns="http://java.sun.com/xml/ns/persistence/orm"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://java.sun.com/xml/ns/persistence/orm http://java.sun.com/xml/ns/persistence/orm_2_0.xsd"
+	version="2.0">
 
-    <persistence-unit-metadata>
-        <persistence-unit-defaults>
-            <entity-listeners>
-                <entity-listener class="org.springframework.data.jpa.domain.support.AuditingEntityListener" />
-            </entity-listeners>
-        </persistence-unit-defaults>
-    </persistence-unit-metadata>
+	<persistence-unit-metadata>
+		<persistence-unit-defaults>
+			<entity-listeners>
+				<entity-listener
+					class="org.springframework.data.jpa.domain.support.AuditingEntityListener" />
+			</entity-listeners>
+		</persistence-unit-defaults>
+	</persistence-unit-metadata>
 
 	<named-query name="User.findByLastname">
 		<query>SELECT u FROM User u WHERE u.lastname = ?1</query>
 	</named-query>
-	
-	<entity class="org.springframework.data.jpa.domain.sample.Role" access="FIELD" name="ROLE">
+
+	<entity class="org.springframework.data.jpa.domain.sample.Role"
+		access="FIELD" name="ROLE">
 		<attributes>
 			<id name="id">
 				<generated-value strategy="AUTO" />
@@ -21,5 +26,14 @@
 			<basic name="name" />
 		</attributes>
 	</entity>
-	
+
+	<entity class="org.springframework.data.jpa.domain.sample.OrmXmlEntity">
+		<attributes>
+			<id name="id">
+				<generated-value strategy="AUTO" />
+			</id>
+			<basic name="property1" />
+		</attributes>
+	</entity>
+
 </entity-mappings>


### PR DESCRIPTION
We now honour purely xml based entity definitions via orm.xml.
Previously we only checked the annotations for id properties.
