### PR TITLE
DATAJPA-712 - Fix binding of SpEL parameters with IN-clause.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-jpa</artifactId>
-	<version>1.9.0.BUILD-SNAPSHOT</version>
+	<version>1.9.0.DATAJPA-712-SNAPSHOT</version>
 
 	<name>Spring Data JPA</name>
 	<description>Spring Data module for JPA repositories.</description>

--- a/src/main/java/org/springframework/data/jpa/repository/query/StringQuery.java
+++ b/src/main/java/org/springframework/data/jpa/repository/query/StringQuery.java
@@ -255,7 +255,6 @@ class StringQuery {
 							checkAndRegister(new InParameterBinding(parameterName, expression), bindings);
 						}
 
-						result = query;
 						break;
 
 					case AS_IS: // fall-through we don't need a special parameter binding for the given parameter.

--- a/src/test/java/org/springframework/data/jpa/repository/query/StringQueryUnitTests.java
+++ b/src/test/java/org/springframework/data/jpa/repository/query/StringQueryUnitTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2014 the original author or authors.
+ * Copyright 2013-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -312,7 +312,31 @@ public class StringQueryUnitTests {
 	public void rejectsDifferentBindingsForRepeatedParameter2() {
 		new StringQuery("select u from User u where u.firstname like ?1 and u.lastname like %?1");
 	}
+	
+	/**
+	 * @see @DATAJPA-712
+	 */
+	@Test
+	public void shouldReplaceAllNamedExpressionParametersWithInClause() {
+		
+		StringQuery query = new StringQuery("select a from A a where a.b in :#{#bs} and a.c in :#{#cs}");
+		String queryString = query.getQueryString();
+		
+		assertThat(queryString, is("select a from A a where a.b in :__$synthetic$__1 and a.c in :__$synthetic$__2"));
+	}
 
+	/**
+	 * @see @DATAJPA-712
+	 */
+	@Test
+	public void shouldReplaceAllPositionExpressionParametersWithInClause() {
+		
+		StringQuery query = new StringQuery("select a from A a where a.b in ?#{#bs} and a.c in ?#{#cs}");
+		String queryString = query.getQueryString();
+		
+		assertThat(queryString, is("select a from A a where a.b in ?1 and a.c in ?2"));
+	}
+	
 	private void assertPositionalBinding(Class<? extends ParameterBinding> bindingType, Integer position,
 			ParameterBinding expectedBinding) {
 


### PR DESCRIPTION
We now ensure that all the SpEL parameters are correctly substituted when used together with an IN-clause. Previously we incorrectly used the initial query as the result again which then only substituted the very last parameter correctly.