### PR TITLE
DATAJPA-218 - Support extracting parameters from a bean parameter.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-jpa</artifactId>
-	<version>1.9.0.BUILD-SNAPSHOT</version>
+	<version>1.9.0.DATAJPA-218-SNAPSHOT</version>
 
 	<name>Spring Data JPA</name>
 	<description>Spring Data module for JPA repositories.</description>

--- a/src/main/java/org/springframework/data/jpa/domain/Example.java
+++ b/src/main/java/org/springframework/data/jpa/domain/Example.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.jpa.domain;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.springframework.util.Assert;
+
+/**
+ * A wrapper around a prototype object that can be used in <quote>Query by Example<quote> queries
+ * 
+ * @author Thomas Darimont
+ * @param <T>
+ */
+public class Example<T> {
+
+	private final T prototype;
+	private final Set<String> ignoredAttributes;
+
+	/**
+	 * Creates a new {@link Example} with the given {@code prototype}.
+	 * 
+	 * @param prototype must not be {@literal null}
+	 */
+	public Example(T prototype) {
+		this(prototype, Collections.<String> emptySet());
+	}
+
+	/**
+	 * Creates a new {@link Example} with the given {@code prototype} ignoring the given attributes.
+	 * 
+	 * @param prototype prototype must not be {@literal null}
+	 * @param attributeNames prototype must not be {@literal null}
+	 */
+	public Example(T prototype, Set<String> attributeNames) {
+
+		Assert.notNull(prototype, "Prototype must not be null!");
+		Assert.notNull(attributeNames, "attributeNames must not be null!");
+
+		this.prototype = prototype;
+		this.ignoredAttributes = attributeNames;
+	}
+
+	public T getPrototype() {
+		return prototype;
+	}
+
+	public Set<String> getIgnoredAttributes() {
+		return Collections.unmodifiableSet(ignoredAttributes);
+	}
+
+	public boolean isAttributeIgnored(String attributePath) {
+		return ignoredAttributes.contains(attributePath);
+	}
+
+	public static <T> Example<T> exampleOf(T prototype) {
+		return new Example<T>(prototype);
+	}
+
+	public static <T> Builder<T> newExample(T prototype) {
+		return new Builder<T>(prototype);
+	}
+
+	/**
+	 * A {@link Builder} for {@link Example}s.
+	 * 
+	 * @author Thomas Darimont
+	 * @param <T>
+	 */
+	public static class Builder<T> {
+
+		private final T prototype;
+		private Set<String> ignoredAttributeNames;
+
+		/**
+		 * @param prototype
+		 */
+		public Builder(T prototype) {
+
+			Assert.notNull(prototype, "Prototype must not be null!");
+
+			this.prototype = prototype;
+		}
+
+		/**
+		 * Allows to specify attribute names that should be ignored.
+		 * 
+		 * @param attributeNames
+		 * @return
+		 */
+		public Builder<T> ignoring(String... attributeNames) {
+			
+			Assert.notNull(attributeNames, "attributeNames must not be null!");
+			
+			return ignoring(Arrays.asList(attributeNames));
+		}
+
+		/**
+		 * Allows to specify attribute names that should be ignored.
+		 * 
+		 * @param attributeNames
+		 * @return
+		 */
+		public Builder<T> ignoring(Collection<String> attributeNames) {
+
+			Assert.notNull(attributeNames, "attributeNames must not be null!");
+
+			this.ignoredAttributeNames = new HashSet<String>(attributeNames);
+			return this;
+		}
+
+		/**
+		 * Constructs the actual {@link Example} instance.
+		 * 
+		 * @return
+		 */
+		public Example<T> build() {
+			return new Example<T>(prototype, ignoredAttributeNames);
+		}
+	}
+}

--- a/src/main/java/org/springframework/data/jpa/repository/JpaRepository.java
+++ b/src/main/java/org/springframework/data/jpa/repository/JpaRepository.java
@@ -21,6 +21,7 @@ import java.util.List;
 import javax.persistence.EntityManager;
 
 import org.springframework.data.domain.Sort;
+import org.springframework.data.jpa.domain.Example;
 import org.springframework.data.repository.NoRepositoryBean;
 import org.springframework.data.repository.PagingAndSortingRepository;
 
@@ -78,7 +79,7 @@ public interface JpaRepository<T, ID extends Serializable> extends PagingAndSort
 	void deleteInBatch(Iterable<T> entities);
 
 	/**
-	 * Deletes all entites in a batch call.
+	 * Deletes all entities in a batch call.
 	 */
 	void deleteAllInBatch();
 
@@ -90,4 +91,15 @@ public interface JpaRepository<T, ID extends Serializable> extends PagingAndSort
 	 * @see EntityManager#getReference(Class, Object)
 	 */
 	T getOne(ID id);
+	
+	/**
+	 * Returns all instances of the type specified by the given {@link Example}.
+	 * 
+	 * This method is deliberately <b>not<b> named {@code findByExample} to not interfere
+	 * with existing repository methods that rely on query derivation. 
+	 * 
+	 * @param example must not be {@literal null}.
+	 * @return
+	 */
+	List<T> findWithExample(Example<T> example);
 }

--- a/src/test/java/org/springframework/data/jpa/domain/sample/User.java
+++ b/src/test/java/org/springframework/data/jpa/domain/sample/User.java
@@ -377,6 +377,10 @@ public class User {
 	public void setDateOfBirth(Date dateOfBirth) {
 		this.dateOfBirth = dateOfBirth;
 	}
+	
+	public void setCreatedAt(Date createdAt) {
+		this.createdAt = createdAt;
+	}
 
 	/*
 	 * (non-Javadoc)

--- a/src/test/java/org/springframework/data/jpa/repository/UserRepositoryTests.java
+++ b/src/test/java/org/springframework/data/jpa/repository/UserRepositoryTests.java
@@ -16,9 +16,11 @@
 package org.springframework.data.jpa.repository;
 
 import static org.hamcrest.Matchers.*;
+import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.*;
 import static org.springframework.data.domain.Sort.Direction.*;
 import static org.springframework.data.jpa.domain.Specifications.*;
+import static org.springframework.data.jpa.domain.Specifications.not;
 import static org.springframework.data.jpa.domain.sample.UserSpecifications.*;
 
 import java.util.ArrayList;
@@ -55,6 +57,7 @@ import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.domain.Sort.Direction;
 import org.springframework.data.domain.Sort.Order;
+import org.springframework.data.jpa.domain.Example;
 import org.springframework.data.jpa.domain.Specification;
 import org.springframework.data.jpa.domain.sample.Address;
 import org.springframework.data.jpa.domain.sample.Role;
@@ -1903,6 +1906,41 @@ public class UserRepositoryTests {
 		}
 
 		assertThat(users, hasSize(2));
+	}
+	
+	/**
+	 * @see DATAJPA-218 
+	 */
+	@Test
+	public void queryByExample() {
+		
+		flushTestUsers();
+		
+		User prototype = new User();
+		prototype.setAge(28);
+		prototype.setCreatedAt(null);
+		
+		List<User> users = repository.findWithExample(Example.exampleOf(prototype));
+		
+		assertThat(users, hasSize(1));
+		assertThat(users.get(0), is(firstUser));
+	}
+	
+	/**
+	 * @see DATAJPA-218 
+	 */
+	@Test
+	public void queryByExampleWithExcludedAttributes() {
+		
+		flushTestUsers();
+		
+		User prototype = new User();
+		prototype.setAge(28);
+		
+		List<User> users = repository.findWithExample(Example.newExample(prototype).ignoring("createdAt").build());
+		
+		assertThat(users, hasSize(1));
+		assertThat(users.get(0), is(firstUser));
 	}
 
 	private Page<User> executeSpecWithSort(Sort sort) {


### PR DESCRIPTION
Added prototypic support for query by example queries to 
SimpleJpaRepositories. Clients can use an Example Object to
wrap an existing prototype entity instance that will be used to 
derive a query from.
The example wrapper allows us to customize the parameter extraction / generation 
from the provided prototype bean.

Would be great if we could unify this effort with the infrastructure
from DATAMONGO-1245.
