### PR TITLE
DATAJPA-382 - Demonstrate that dynamic SpEL parameters work in update queries.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-jpa</artifactId>
-	<version>1.9.0.BUILD-SNAPSHOT</version>
+	<version>1.9.0.DATAJPA-382-SNAPSHOT</version>
 
 	<name>Spring Data JPA</name>
 	<description>Spring Data module for JPA repositories.</description>

--- a/src/test/java/org/springframework/data/jpa/domain/sample/AuditableUser.java
+++ b/src/test/java/org/springframework/data/jpa/domain/sample/AuditableUser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2008-2011 the original author or authors.
+ * Copyright 2008-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,6 +30,7 @@ import org.springframework.data.jpa.domain.AbstractAuditable;
  * necessary. Furthermore no auditing information has to be declared explicitly.
  * 
  * @author Oliver Gierke
+ * @author Thomas Darimont
  */
 @Entity
 @NamedQuery(name = "AuditableUser.findByFirstname", query = "SELECT u FROM AuditableUser u WHERE u.firstname = ?1")
@@ -39,16 +40,20 @@ public class AuditableUser extends AbstractAuditable<AuditableUser, Integer> {
 
 	private String firstname;
 
-	@ManyToMany(cascade = { CascadeType.PERSIST, CascadeType.MERGE }) private Set<AuditableRole> roles = new HashSet<AuditableRole>();
+	@ManyToMany(cascade = { CascadeType.PERSIST,
+			CascadeType.MERGE }) private Set<AuditableRole> roles = new HashSet<AuditableRole>();
 
 	public AuditableUser() {
-
 		this(null);
 	}
 
 	public AuditableUser(Integer id) {
+		this(id, null);
+	}
 
-		this.setId(id);
+	public AuditableUser(Integer id, String firstname) {
+		setId(id);
+		this.firstname = firstname;
 	}
 
 	/**

--- a/src/test/java/org/springframework/data/jpa/repository/sample/AuditableUserRepository.java
+++ b/src/test/java/org/springframework/data/jpa/repository/sample/AuditableUserRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2008-2011 the original author or authors.
+ * Copyright 2008-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,11 +19,14 @@ import java.util.List;
 
 import org.springframework.data.jpa.domain.sample.AuditableUser;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 
 /**
  * Repository interface for {@code AuditableUser}.
  * 
  * @author Oliver Gierke
+ * @author Thomas Darimont
  */
 public interface AuditableUserRepository extends JpaRepository<AuditableUser, Long> {
 
@@ -33,5 +36,9 @@ public interface AuditableUserRepository extends JpaRepository<AuditableUser, Lo
 	 * @param firstname
 	 * @return all users with the given firstname.
 	 */
-	public List<AuditableUser> findByFirstname(final String firstname);
+	List<AuditableUser> findByFirstname(final String firstname);
+
+	@Modifying
+	@Query("update AuditableUser a set a.firstname = upper(a.firstname), a.lastModifiedBy = :#{#security.principal}, a.lastModifiedDate = :#{T(org.springframework.data.jpa.util.FixedDate).INSTANCE.getDate()}")
+	void updateAllNamesToUpperCase();
 }

--- a/src/test/java/org/springframework/data/jpa/util/FixedDate.java
+++ b/src/test/java/org/springframework/data/jpa/util/FixedDate.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.jpa.util;
+
+import java.util.Date;
+
+/**
+ * Holds a fixed {@link Date} value to use in components that have no direct connection. 
+ * 
+ * @author Thomas Darimont
+ */
+public enum FixedDate {
+
+	INSTANCE;
+
+	private Date fixedDate;
+
+	public void setDate(Date date) {
+		this.fixedDate = date;
+	}
+
+	public Date getDate() {
+		return fixedDate;
+	} 
+}


### PR DESCRIPTION
Added test case to AbstractAuditingViaJavaConfigRepositoryTests that uses the SampleEvaluationContextExtension
to demonstarte access of "security" context objects as well as dynamic SpEL Expression binding.

Needed to add FixedDate helper class to ease checks for modification time stamps.
