### PR TITLE
Add documentation on how to use the @EntityListeners annotation

### DIFF
--- a/src/main/asciidoc/jpa.adoc
+++ b/src/main/asciidoc/jpa.adoc
@@ -744,6 +744,19 @@ Note that the auditing feature requires `spring-aspects.jar` to be on the classp
 ----
 ====
 
+You can also enable the `AuditingEntityListener` per entity using the `@EntityListeners` annotation:
+
+====
+[source, java]
+----
+@Entity
+@EntityListeners(AuditingEntityListener.class)
+public class MyEntity {
+
+}
+----
+====
+
 Now activating auditing functionality is just a matter of adding the Spring Data JPA `auditing` namespace element to your configuration:
 
 .Activating auditing using XML configuration


### PR DESCRIPTION
I was trying out the auditing support, but I did not get it working from the documentation alone. Luckily, I found http://www.petrikainulainen.net/programming/spring-framework/spring-data-jpa-tutorial-auditing-part-one/ that explained I neede the `@EntityListeners` annotation (I am not using an `orm.xml`). I think it would be good to add this to the official docs as well.