### PR TITLE
DATAJPA-862 - fixed Query parameter index in adoc.

### DIFF
--- a/src/main/asciidoc/jpa.adoc
+++ b/src/main/asciidoc/jpa.adoc
@@ -273,7 +273,7 @@ Native queriesThe `@Query` annotation allows to execute native queries by settin
 ----
 public interface UserRepository extends JpaRepository<User, Long> {
 
-  @Query(value = "SELECT * FROM USERS WHERE EMAIL_ADDRESS = ?0", nativeQuery = true)
+  @Query(value = "SELECT * FROM USERS WHERE EMAIL_ADDRESS = ?1", nativeQuery = true)
   User findByEmailAddress(String emailAddress);
 }
 ----


### PR DESCRIPTION
One Query annotation used an parameter index of ?0 instead of ?1.