### PR TITLE
DATAJPA-871 - Allow usage of composed annotations using @AliasFor.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-jpa</artifactId>
-	<version>1.10.0.BUILD-SNAPSHOT</version>
+	<version>1.10.0.DATAJPA-871-SNAPSHOT</version>
 
 	<name>Spring Data JPA</name>
 	<description>Spring Data module for JPA repositories.</description>
@@ -26,7 +26,7 @@
 		<hsqldb1>1.8.0.10</hsqldb1>
 		<jpa>2.0.0</jpa>
 		<openjpa>2.4.1</openjpa>
-		<springdata.commons>1.12.0.BUILD-SNAPSHOT</springdata.commons>
+		<springdata.commons>1.12.0.DATACMNS-825-SNAPSHOT</springdata.commons>
 
 		<sonar.dynamicAnalysis>reuseReports</sonar.dynamicAnalysis>
 

--- a/src/main/java/org/springframework/data/jpa/repository/EntityGraph.java
+++ b/src/main/java/org/springframework/data/jpa/repository/EntityGraph.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2015 the original author or authors.
+ * Copyright 2014-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,6 +30,7 @@ import org.springframework.data.jpa.repository.query.JpaQueryMethod;
  * 
  * Since 1.9 we support the definition of dynamic {@link EntityGraph}s by allowing to customize the fetch-graph via 
  * via {@link #attributePaths()} ad-hoc fetch-graph configuration.
+ * @author Christoph Strobl
  * 
  * If {@link #attributePaths()} are specified then we ignore the entity-graph name {@link #value()}
  * and treat this {@link EntityGraph} as dynamic.
@@ -38,7 +39,7 @@ import org.springframework.data.jpa.repository.query.JpaQueryMethod;
  * @since 1.6
  */
 @Retention(RetentionPolicy.RUNTIME)
-@Target(ElementType.METHOD)
+@Target({ ElementType.METHOD, ElementType.ANNOTATION_TYPE })
 @Documented
 public @interface EntityGraph {
 

--- a/src/main/java/org/springframework/data/jpa/repository/Modifying.java
+++ b/src/main/java/org/springframework/data/jpa/repository/Modifying.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2008-2015 the original author or authors.
+ * Copyright 2008-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,9 +25,10 @@ import java.lang.annotation.Target;
  * Indicates a method should be regarded as modifying query.
  * 
  * @author Oliver Gierke
+ * @author Christoph Strobl
  */
 @Retention(RetentionPolicy.RUNTIME)
-@Target(ElementType.METHOD)
+@Target({ ElementType.METHOD, ElementType.ANNOTATION_TYPE })
 @Documented
 public @interface Modifying {
 

--- a/src/main/java/org/springframework/data/jpa/repository/Query.java
+++ b/src/main/java/org/springframework/data/jpa/repository/Query.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2008-2014 the original author or authors.
+ * Copyright 2008-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,9 +28,10 @@ import org.springframework.data.annotation.QueryAnnotation;
  * 
  * @author Oliver Gierke
  * @author Thomas Darimont
+ * @author Christoph Strobl
  */
 @Retention(RetentionPolicy.RUNTIME)
-@Target(ElementType.METHOD)
+@Target({ ElementType.METHOD, ElementType.ANNOTATION_TYPE })
 @QueryAnnotation
 @Documented
 public @interface Query {

--- a/src/main/java/org/springframework/data/jpa/repository/query/DefaultJpaEntityMetadata.java
+++ b/src/main/java/org/springframework/data/jpa/repository/query/DefaultJpaEntityMetadata.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2014 the original author or authors.
+ * Copyright 2013-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@ package org.springframework.data.jpa.repository.query;
 
 import javax.persistence.Entity;
 
+import org.springframework.core.annotation.AnnotatedElementUtils;
 import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
 
@@ -24,6 +25,7 @@ import org.springframework.util.StringUtils;
  * Default implementation for {@link JpaEntityMetadata}.
  * 
  * @author Oliver Gierke
+ * @author Christoph Strobl
  */
 public class DefaultJpaEntityMetadata<T> implements JpaEntityMetadata<T> {
 
@@ -55,7 +57,7 @@ public class DefaultJpaEntityMetadata<T> implements JpaEntityMetadata<T> {
 	 */
 	public String getEntityName() {
 
-		Entity entity = domainType.getAnnotation(Entity.class);
+		Entity entity = AnnotatedElementUtils.findMergedAnnotation(domainType, Entity.class);
 		boolean hasName = null != entity && StringUtils.hasText(entity.name());
 
 		return hasName ? entity.name() : domainType.getSimpleName();

--- a/src/main/java/org/springframework/data/jpa/repository/query/Procedure.java
+++ b/src/main/java/org/springframework/data/jpa/repository/query/Procedure.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Copyright 2014-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,9 +25,10 @@ import java.lang.annotation.Target;
  * 
  * @author Thomas Darimont
  * @author Oliver Gierke
+ * @author Christoph Strobl
  * @since 1.6
  */
-@Target(ElementType.METHOD)
+@Target({ ElementType.METHOD, ElementType.ANNOTATION_TYPE })
 @Retention(RetentionPolicy.RUNTIME)
 public @interface Procedure {
 

--- a/src/main/java/org/springframework/data/jpa/repository/query/StoredProcedureAttributeSource.java
+++ b/src/main/java/org/springframework/data/jpa/repository/query/StoredProcedureAttributeSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2015 the original author or authors.
+ * Copyright 2014-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,6 +24,7 @@ import javax.persistence.NamedStoredProcedureQueries;
 import javax.persistence.NamedStoredProcedureQuery;
 import javax.persistence.StoredProcedureParameter;
 
+import org.springframework.core.annotation.AnnotatedElementUtils;
 import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
 
@@ -32,6 +33,7 @@ import org.springframework.util.StringUtils;
  * 
  * @author Thomas Darimont
  * @author Oliver Gierke
+ * @author Christoph Strobl
  * @since 1.6
  */
 enum StoredProcedureAttributeSource {
@@ -50,7 +52,7 @@ enum StoredProcedureAttributeSource {
 		Assert.notNull(method, "Method must not be null!");
 		Assert.notNull(entityMetadata, "EntityMetadata must not be null!");
 
-		Procedure procedure = method.getAnnotation(Procedure.class);
+		Procedure procedure = AnnotatedElementUtils.findMergedAnnotation(method, Procedure.class);
 		Assert.notNull(procedure, "Method must have an @Procedure annotation!");
 
 		NamedStoredProcedureQuery namedStoredProc = tryFindAnnotatedNamedStoredProcedureQuery(method, entityMetadata,
@@ -201,12 +203,14 @@ enum StoredProcedureAttributeSource {
 
 		List<NamedStoredProcedureQuery> queries = new ArrayList<NamedStoredProcedureQuery>();
 
-		NamedStoredProcedureQueries namedQueriesAnnotation = entityType.getAnnotation(NamedStoredProcedureQueries.class);
+		NamedStoredProcedureQueries namedQueriesAnnotation = AnnotatedElementUtils.findMergedAnnotation(entityType,
+				NamedStoredProcedureQueries.class);
 		if (namedQueriesAnnotation != null) {
 			queries.addAll(Arrays.asList(namedQueriesAnnotation.value()));
 		}
 
-		NamedStoredProcedureQuery namedQueryAnnotation = entityType.getAnnotation(NamedStoredProcedureQuery.class);
+		NamedStoredProcedureQuery namedQueryAnnotation = AnnotatedElementUtils.findMergedAnnotation(entityType,
+				NamedStoredProcedureQuery.class);
 		if (namedQueryAnnotation != null) {
 			queries.add(namedQueryAnnotation);
 		}

--- a/src/main/java/org/springframework/data/jpa/repository/support/CrudMethodMetadataPostProcessor.java
+++ b/src/main/java/org/springframework/data/jpa/repository/support/CrudMethodMetadataPostProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2015 the original author or authors.
+ * Copyright 2011-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,6 +31,7 @@ import org.springframework.aop.TargetSource;
 import org.springframework.aop.framework.ProxyFactory;
 import org.springframework.aop.interceptor.ExposeInvocationInterceptor;
 import org.springframework.beans.factory.BeanClassLoaderAware;
+import org.springframework.core.annotation.AnnotatedElementUtils;
 import org.springframework.core.annotation.AnnotationUtils;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.Lock;
@@ -48,6 +49,7 @@ import org.springframework.util.ClassUtils;
  * 
  * @author Oliver Gierke
  * @author Thomas Darimont
+ * @author Christoph Strobl
  */
 class CrudMethodMetadataPostProcessor implements RepositoryProxyPostProcessor, BeanClassLoaderAware {
 
@@ -164,19 +166,19 @@ class CrudMethodMetadataPostProcessor implements RepositoryProxyPostProcessor, B
 		}
 
 		private static EntityGraph findEntityGraph(Method method) {
-			return AnnotationUtils.findAnnotation(method, EntityGraph.class);
+			return AnnotatedElementUtils.findMergedAnnotation(method, EntityGraph.class);
 		}
 
 		private static LockModeType findLockModeType(Method method) {
 
-			Lock annotation = AnnotationUtils.findAnnotation(method, Lock.class);
+			Lock annotation = AnnotatedElementUtils.findMergedAnnotation(method, Lock.class);
 			return annotation == null ? null : (LockModeType) AnnotationUtils.getValue(annotation);
 		}
 
 		private static Map<String, Object> findQueryHints(Method method) {
 
 			Map<String, Object> queryHints = new HashMap<String, Object>();
-			QueryHints queryHintsAnnotation = AnnotationUtils.findAnnotation(method, QueryHints.class);
+			QueryHints queryHintsAnnotation = AnnotatedElementUtils.findMergedAnnotation(method, QueryHints.class);
 
 			if (queryHintsAnnotation != null) {
 

--- a/src/test/java/org/springframework/data/jpa/repository/query/StoredProcedureAttributeSourceUnitTests.java
+++ b/src/test/java/org/springframework/data/jpa/repository/query/StoredProcedureAttributeSourceUnitTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Copyright 2014-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,6 +20,8 @@ import static org.hamcrest.object.IsCompatibleType.*;
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
 
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
 import java.lang.reflect.Method;
 
 import javax.persistence.EntityManager;
@@ -29,6 +31,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
+import org.springframework.core.annotation.AliasFor;
 import org.springframework.data.jpa.domain.sample.User;
 import org.springframework.data.repository.query.Param;
 import org.springframework.util.ReflectionUtils;
@@ -38,6 +41,7 @@ import org.springframework.util.ReflectionUtils;
  * 
  * @author Thomas Darimont
  * @author Oliver Gierke
+ * @author Christoph Strobl
  * @since 1.6
  */
 @RunWith(MockitoJUnitRunner.class)
@@ -137,6 +141,34 @@ public class StoredProcedureAttributeSourceUnitTests {
 		assertThat(attr.getOutputParameterName(), is("res"));
 	}
 
+	/**
+	 * @see DATAJPA-871
+	 */
+	@Test
+	public void aliasedStoredProcedure() {
+
+		StoredProcedureAttributes attr = creator
+				.createFrom(method("plus1inoutWithComposedAnnotationOverridingProcedureName", Integer.class), entityMetadata);
+
+		assertThat(attr.getProcedureName(), is(equalTo("plus1inout")));
+		assertThat(attr.getOutputParameterType(), is(typeCompatibleWith(Integer.class)));
+		assertThat(attr.getOutputParameterName(), is(StoredProcedureAttributes.SYNTHETIC_OUTPUT_PARAMETER_NAME));
+	}
+
+	/**
+	 * @see DATAJPA-871
+	 */
+	@Test
+	public void aliasedStoredProcedure2() {
+
+		StoredProcedureAttributes attr = creator
+				.createFrom(method("plus1inoutWithComposedAnnotationOverridingName", Integer.class), entityMetadata);
+
+		assertThat(attr.getProcedureName(), is(equalTo("User.plus1")));
+		assertThat(attr.getOutputParameterType(), is(typeCompatibleWith(Integer.class)));
+		assertThat(attr.getOutputParameterName(), is(equalTo("res")));
+	}
+
 	private static Method method(String name, Class<?>... paramTypes) {
 		return ReflectionUtils.findMethod(DummyRepository.class, name, paramTypes);
 	}
@@ -185,5 +217,29 @@ public class StoredProcedureAttributeSourceUnitTests {
 		 */
 		@Procedure
 		Integer plus1(@Param("arg") Integer arg);
+
+		@ComposedProcedureUsingAliasFor(explicitProcedureName = "plus1inout")
+		Integer plus1inoutWithComposedAnnotationOverridingProcedureName(Integer arg);
+
+		@ComposedProcedureUsingAliasFor(emProcedureName = "User.plus1")
+		Integer plus1inoutWithComposedAnnotationOverridingName(Integer arg);
+	}
+
+	@Procedure
+	@Retention(RetentionPolicy.RUNTIME)
+	static @interface ComposedProcedureUsingAliasFor {
+
+		@AliasFor(annotation = Procedure.class, attribute = "value")
+		String dbProcedureName() default "";
+
+		@AliasFor(annotation = Procedure.class, attribute = "procedureName")
+		String explicitProcedureName() default "";
+
+		@AliasFor(annotation = Procedure.class, attribute = "name")
+		String emProcedureName() default "";
+
+		@AliasFor(annotation = Procedure.class, attribute = "outputParameterName")
+		String outParamName() default "";
+
 	}
 }

--- a/src/test/java/org/springframework/data/jpa/repository/support/DefaultJpaEntityMetadataUnitTest.java
+++ b/src/test/java/org/springframework/data/jpa/repository/support/DefaultJpaEntityMetadataUnitTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 the original author or authors.
+ * Copyright 2013-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,15 +18,20 @@ package org.springframework.data.jpa.repository.support;
 import static org.hamcrest.CoreMatchers.*;
 import static org.junit.Assert.*;
 
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
 import javax.persistence.Entity;
 
 import org.junit.Test;
+import org.springframework.core.annotation.AliasFor;
 import org.springframework.data.jpa.repository.query.DefaultJpaEntityMetadata;
 
 /**
  * Unit tests for {@link DefaultJpaEntityMetadata}.
  * 
  * @author Oliver Gierke
+ * @author Christoph Strobl
  */
 public class DefaultJpaEntityMetadataUnitTest {
 
@@ -57,8 +62,30 @@ public class DefaultJpaEntityMetadataUnitTest {
 		assertThat(metadata.getEntityName(), is("Entity"));
 	}
 
+	/**
+	 * @see DATAJPA-871
+	 */
+	@Test
+	public void returnsCustomizedEntityNameIfConfiguredViaComposedAnnotation() {
+
+		DefaultJpaEntityMetadata<BarWithComposedAnnotation> metadata = new DefaultJpaEntityMetadata<BarWithComposedAnnotation>(
+				BarWithComposedAnnotation.class);
+		assertThat(metadata.getEntityName(), is("Entity"));
+	}
+
 	static class Foo {}
 
 	@Entity(name = "Entity")
 	static class Bar {}
+
+	@CustomEntityAnnotationUsingAliasFor(entityName = "Entity")
+	static class BarWithComposedAnnotation {}
+
+	@Entity
+	@Retention(RetentionPolicy.RUNTIME)
+	static @interface CustomEntityAnnotationUsingAliasFor {
+
+		@AliasFor(annotation = Entity.class, attribute = "name")
+		String entityName();
+	}
 }


### PR DESCRIPTION
We allow and support composing annotations for:

- `@EntityGraph`
- `@Lock`
- `@Modifying`
- `@Query`
- `@QueryHints`
- `@Procedure`

----

Related issue: [DATACMNS-825](https://jira.spring.io/browse/DATACMNS-825)
Related Pull Request: spring-projects/spring-data-commons#156