### PR TITLE
DATAJPA-806 - Added flushAutomatically attribute to @Modifying annotation.

### DIFF
--- a/src/main/java/org/springframework/data/jpa/repository/Modifying.java
+++ b/src/main/java/org/springframework/data/jpa/repository/Modifying.java
@@ -26,11 +26,19 @@ import java.lang.annotation.Target;
  * 
  * @author Oliver Gierke
  * @author Christoph Strobl
+ * @author Nicolas Cirigliano
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ ElementType.METHOD, ElementType.ANNOTATION_TYPE })
 @Documented
 public @interface Modifying {
+
+	/**
+	 * Defines whether we should flush the underlying persistence context before executing the modifying query.
+	 * 
+	 * @return
+	 */
+	boolean flushAutomatically() default false;
 
 	/**
 	 * Defines whether we should clear the underlying persistence context after executing the modifying query.

--- a/src/main/java/org/springframework/data/jpa/repository/query/AbstractJpaQuery.java
+++ b/src/main/java/org/springframework/data/jpa/repository/query/AbstractJpaQuery.java
@@ -50,6 +50,7 @@ import org.springframework.util.Assert;
  * @author Thomas Darimont
  * @author Mark Paluch
  * @author Christoph Strobl
+ * @author Nicolas Cirigliano
  */
 public abstract class AbstractJpaQuery implements RepositoryQuery {
 
@@ -135,7 +136,7 @@ public abstract class AbstractJpaQuery implements RepositoryQuery {
 		} else if (method.isPageQuery()) {
 			return new PagedExecution(method.getParameters());
 		} else if (method.isModifyingQuery()) {
-			return method.getClearAutomatically() ? new ModifyingExecution(method, em) : new ModifyingExecution(method, null);
+			return new ModifyingExecution(method, em);
 		} else {
 			return new SingleEntityExecution();
 		}

--- a/src/main/java/org/springframework/data/jpa/repository/query/JpaQueryMethod.java
+++ b/src/main/java/org/springframework/data/jpa/repository/query/JpaQueryMethod.java
@@ -49,6 +49,7 @@ import org.springframework.util.StringUtils;
  * @author Oliver Gierke
  * @author Thomas Darimont
  * @author Christoph Strobl
+ * @author Nicolas Cirigliano
  */
 public class JpaQueryMethod extends QueryMethod {
 
@@ -281,6 +282,15 @@ public class JpaQueryMethod extends QueryMethod {
 
 		String annotatedName = getAnnotationValue("countName", String.class);
 		return StringUtils.hasText(annotatedName) ? annotatedName : getNamedQueryName() + ".count";
+	}
+
+	/**
+	 * Returns whether we should flush automatically for modifying queries.
+	 * 
+	 * @return
+	 */
+	boolean getFlushAutomatically() {
+		return getMergedOrDefaultAnnotationValue("flushAutomatically", Modifying.class, Boolean.class);
 	}
 
 	/**

--- a/src/test/java/org/springframework/data/jpa/repository/query/JpaQueryExecutionUnitTests.java
+++ b/src/test/java/org/springframework/data/jpa/repository/query/JpaQueryExecutionUnitTests.java
@@ -46,6 +46,7 @@ import org.springframework.data.repository.query.Parameters;
  * @author Oliver Gierke
  * @author Thomas Darimont
  * @author Mark Paluch
+ * @author Nicolas Cirigliano
  */
 @RunWith(MockitoJUnitRunner.Silent.class)
 public class JpaQueryExecutionUnitTests {
@@ -84,16 +85,35 @@ public class JpaQueryExecutionUnitTests {
 
 	@Test
 	@SuppressWarnings({ "unchecked", "rawtypes" })
-	public void modifyingExecutionClearsEntityManagerIfSet() {
+	public void modifyingExecutionFlushesEntityManagerIfSet() {
 
 		when(query.executeUpdate()).thenReturn(0);
 		when(method.getReturnType()).thenReturn((Class) void.class);
+		when(method.getFlushAutomatically()).thenReturn(true);
 		when(jpaQuery.createQuery(Mockito.any(Object[].class))).thenReturn(query);
 		when(jpaQuery.getQueryMethod()).thenReturn(method);
 
 		ModifyingExecution execution = new ModifyingExecution(method, em);
 		execution.execute(jpaQuery, new Object[] {});
 
+		verify(em, times(1)).flush();
+		verify(em, times(0)).clear();
+	}
+
+	@Test
+	@SuppressWarnings({ "unchecked", "rawtypes" })
+	public void modifyingExecutionClearsEntityManagerIfSet() {
+
+		when(query.executeUpdate()).thenReturn(0);
+		when(method.getReturnType()).thenReturn((Class) void.class);
+		when(method.getClearAutomatically()).thenReturn(true);
+		when(jpaQuery.createQuery(Mockito.any(Object[].class))).thenReturn(query);
+		when(jpaQuery.getQueryMethod()).thenReturn(method);
+
+		ModifyingExecution execution = new ModifyingExecution(method, em);
+		execution.execute(jpaQuery, new Object[] {});
+
+		verify(em, times(0)).flush();
 		verify(em, times(1)).clear();
 	}
 


### PR DESCRIPTION
Added _flushAutomatically_ attribute to @Modifying annotation not to loose not persisted changes in _EntityManager_ when _clearAutomatically_ is activated.

For further explanations refer to comment: https://jira.spring.io/browse/DATAJPA-806?focusedCommentId=129320&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-129320
