### PR TITLE
DATAJPA-912 - Optimize paged query execution.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-jpa</artifactId>
-	<version>1.11.0.BUILD-SNAPSHOT</version>
+	<version>1.11.0.DATAJPA-912-SNAPSHOT</version>
 
 	<name>Spring Data JPA</name>
 	<description>Spring Data module for JPA repositories.</description>

--- a/src/test/java/org/springframework/data/jpa/repository/UserRepositoryTests.java
+++ b/src/test/java/org/springframework/data/jpa/repository/UserRepositoryTests.java
@@ -21,8 +21,8 @@ import static org.junit.Assert.*;
 import static org.springframework.data.domain.Example.*;
 import static org.springframework.data.domain.ExampleMatcher.*;
 import static org.springframework.data.domain.Sort.Direction.*;
-import static org.springframework.data.jpa.domain.Specifications.*;
 import static org.springframework.data.jpa.domain.Specifications.not;
+import static org.springframework.data.jpa.domain.Specifications.*;
 import static org.springframework.data.jpa.domain.sample.UserSpecifications.*;
 
 import java.util.ArrayList;
@@ -55,8 +55,7 @@ import org.springframework.dao.IncorrectResultSizeDataAccessException;
 import org.springframework.dao.InvalidDataAccessApiUsageException;
 import org.springframework.data.domain.Example;
 import org.springframework.data.domain.ExampleMatcher;
-import org.springframework.data.domain.ExampleMatcher.GenericPropertyMatcher;
-import org.springframework.data.domain.ExampleMatcher.StringMatcher;
+import org.springframework.data.domain.ExampleMatcher.*;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
@@ -1651,6 +1650,40 @@ public class UserRepositoryTests {
 
 		Slice<User> secondPage = repository.findTop2UsersBy(new PageRequest(1, 3, ASC, "age"));
 		assertThat(secondPage.getContent(), hasItems(youngest3));
+	}
+
+	/**
+	 * @see DATAJPA-912
+	 */
+	@Test
+	public void pageableQueryReportsTotalFromResult() {
+
+		flushTestUsers();
+
+		Page<User> firstPage = repository.findAll(new PageRequest(0, 10));
+		assertThat(firstPage.getContent(), hasSize(4));
+		assertThat(firstPage.getTotalElements(), is(4L));
+
+		Page<User> secondPage = repository.findAll(new PageRequest(1, 3));
+		assertThat(secondPage.getContent(), hasSize(1));
+		assertThat(secondPage.getTotalElements(), is(4L));
+	}
+
+	/**
+	 * @see DATAJPA-912
+	 */
+	@Test
+	public void pageableQueryReportsTotalFromCount() {
+
+		flushTestUsers();
+
+		Page<User> firstPage = repository.findAll(new PageRequest(0, 4));
+		assertThat(firstPage.getContent(), hasSize(4));
+		assertThat(firstPage.getTotalElements(), is(4L));
+
+		Page<User> secondPage = repository.findAll(new PageRequest(10, 10));
+		assertThat(secondPage.getContent(), hasSize(0));
+		assertThat(secondPage.getTotalElements(), is(4L));
 	}
 
 	/**

--- a/src/test/java/org/springframework/data/jpa/repository/query/JpaQueryExecutionUnitTests.java
+++ b/src/test/java/org/springframework/data/jpa/repository/query/JpaQueryExecutionUnitTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2008-2014 the original author or authors.
+ * Copyright 2008-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,6 +21,7 @@ import static org.mockito.Matchers.*;
 import static org.mockito.Mockito.*;
 
 import java.util.Arrays;
+import java.util.Collections;
 
 import javax.persistence.EntityManager;
 import javax.persistence.Query;
@@ -43,6 +44,7 @@ import org.springframework.data.repository.query.Parameters;
  * 
  * @author Oliver Gierke
  * @author Thomas Darimont
+ * @author Mark Paluch
  */
 @RunWith(MockitoJUnitRunner.class)
 public class JpaQueryExecutionUnitTests {
@@ -115,9 +117,10 @@ public class JpaQueryExecutionUnitTests {
 
 	/**
 	 * @see DATAJPA-124
+	 * @see DATAJPA-912
 	 */
 	@Test
-	public void pagedExecutionDoesNotRetrieveObjectsForPageableOutOfRange() throws Exception {
+	public void pagedExecutionRetrievesObjectsForPageableOutOfRange() throws Exception {
 
 		Parameters<?, ?> parameters = new DefaultParameters(getClass().getMethod("sampleMethod", Pageable.class));
 		when(jpaQuery.createCountQuery(Mockito.any(Object[].class))).thenReturn(countQuery);
@@ -127,24 +130,94 @@ public class JpaQueryExecutionUnitTests {
 		PagedExecution execution = new PagedExecution(parameters);
 		execution.doExecute(jpaQuery, new Object[] { new PageRequest(2, 10) });
 
-		verify(query, times(0)).getResultList();
+		verify(query).getResultList();
+		verify(countQuery).getResultList();
 	}
 
 	/**
 	 * @see DATAJPA-477
+	 * @see DATAJPA-912
 	 */
 	@Test
-	public void pagedExecutionShouldNotGenerateUnecessaryQueryIfCountReportedNoResults() throws Exception {
+	public void pagedExecutionShouldNotGenerateCountQueryIfQueryReportedNoResults() throws Exception {
 
 		Parameters<?, ?> parameters = new DefaultParameters(getClass().getMethod("sampleMethod", Pageable.class));
-		when(jpaQuery.createCountQuery(Mockito.any(Object[].class))).thenReturn(countQuery);
-		when(countQuery.getResultList()).thenReturn(Arrays.asList(0L));
+		when(jpaQuery.createQuery(Mockito.any(Object[].class))).thenReturn(query);
+		when(query.getResultList()).thenReturn(Arrays.asList(0L));
 
 		PagedExecution execution = new PagedExecution(parameters);
 		execution.doExecute(jpaQuery, new Object[] { new PageRequest(0, 10) });
 
-		verify(query, times(0)).getResultList();
-		verify(jpaQuery, times(0)).createQuery((Object[]) any());
+		verify(countQuery, times(0)).getResultList();
+		verify(jpaQuery, times(0)).createCountQuery((Object[]) any());
+	}
+
+	/**
+	 * @see DATAJPA-912
+	 */
+	@Test
+	public void pagedExecutionShouldUseCountFromResultIfOffsetIsZeroAndResultsWithinPageSize() throws Exception {
+
+		Parameters<?, ?> parameters = new DefaultParameters(getClass().getMethod("sampleMethod", Pageable.class));
+		when(jpaQuery.createQuery(Mockito.any(Object[].class))).thenReturn(query);
+		when(query.getResultList()).thenReturn(Arrays.asList(new Object(), new Object(), new Object(), new Object()));
+
+		PagedExecution execution = new PagedExecution(parameters);
+		execution.doExecute(jpaQuery, new Object[] { new PageRequest(0, 10) });
+
+		verify(jpaQuery, times(0)).createCountQuery((Object[]) any());
+	}
+
+	/**
+	 * @see DATAJPA-912
+	 */
+	@Test
+	public void pagedExecutionShouldUseCountFromResultWithOffsetAndResultsWithinPageSize() throws Exception {
+
+		Parameters<?, ?> parameters = new DefaultParameters(getClass().getMethod("sampleMethod", Pageable.class));
+		when(jpaQuery.createQuery(Mockito.any(Object[].class))).thenReturn(query);
+		when(query.getResultList()).thenReturn(Arrays.asList(new Object(), new Object(), new Object(), new Object()));
+
+		PagedExecution execution = new PagedExecution(parameters);
+		execution.doExecute(jpaQuery, new Object[] { new PageRequest(5, 10) });
+
+		verify(jpaQuery, times(0)).createCountQuery((Object[]) any());
+	}
+
+	/**
+	 * @see DATAJPA-912
+	 */
+	@Test
+	public void pagedExecutionShouldUseRequestCountFromResultWithOffsetAndResultsHitLowerPageSizeBounds() throws Exception {
+
+		Parameters<?, ?> parameters = new DefaultParameters(getClass().getMethod("sampleMethod", Pageable.class));
+		when(jpaQuery.createQuery(Mockito.any(Object[].class))).thenReturn(query);
+		when(query.getResultList()).thenReturn(Collections.emptyList());
+		when(jpaQuery.createCountQuery(Mockito.any(Object[].class))).thenReturn(query);
+		when(countQuery.getResultList()).thenReturn(Arrays.asList(20L));
+
+		PagedExecution execution = new PagedExecution(parameters);
+		execution.doExecute(jpaQuery, new Object[] { new PageRequest(4, 4) });
+
+		verify(jpaQuery).createCountQuery((Object[]) any());
+	}
+
+	/**
+	 * @see DATAJPA-912
+	 */
+	@Test
+	public void pagedExecutionShouldUseRequestCountFromResultWithOffsetAndResultsHitUpperPageSizeBounds() throws Exception {
+
+		Parameters<?, ?> parameters = new DefaultParameters(getClass().getMethod("sampleMethod", Pageable.class));
+		when(jpaQuery.createQuery(Mockito.any(Object[].class))).thenReturn(query);
+		when(query.getResultList()).thenReturn(Arrays.asList(new Object(), new Object(), new Object(), new Object()));
+		when(jpaQuery.createCountQuery(Mockito.any(Object[].class))).thenReturn(query);
+		when(countQuery.getResultList()).thenReturn(Arrays.asList(20L));
+
+		PagedExecution execution = new PagedExecution(parameters);
+		execution.doExecute(jpaQuery, new Object[] { new PageRequest(4, 4) });
+
+		verify(jpaQuery).createCountQuery((Object[]) any());
 	}
 
 	public static void sampleMethod(Pageable pageable) {

--- a/src/test/java/org/springframework/data/jpa/repository/support/QueryDslJpaRepositoryTests.java
+++ b/src/test/java/org/springframework/data/jpa/repository/support/QueryDslJpaRepositoryTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2008-2015 the original author or authors.
+ * Copyright 2008-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -53,6 +53,7 @@ import com.querydsl.core.types.dsl.PathBuilderFactory;
  * 
  * @author Oliver Gierke
  * @author Thomas Darimont
+ * @author Mark Paluch
  */
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration({ "classpath:infrastructure.xml" })
@@ -358,5 +359,35 @@ public class QueryDslJpaRepositoryTests {
 	@Test
 	public void worksWithNullPageable() {
 		assertThat(repository.findAll(user.dateOfBirth.isNull(), (Pageable) null).getContent(), hasSize(3));
+	}
+
+	/**
+	 * @see DATAJPA-912
+	 */
+	@Test
+	public void pageableQueryReportsTotalFromResult() {
+
+		Page<User> firstPage = repository.findAll(user.dateOfBirth.isNull(), new PageRequest(0, 10));
+		assertThat(firstPage.getContent(), hasSize(3));
+		assertThat(firstPage.getTotalElements(), is(3L));
+
+		Page<User> secondPage = repository.findAll(user.dateOfBirth.isNull(), new PageRequest(1, 2));
+		assertThat(secondPage.getContent(), hasSize(1));
+		assertThat(secondPage.getTotalElements(), is(3L));
+	}
+
+	/**
+	 * @see DATAJPA-912
+	 */
+	@Test
+	public void pageableQueryReportsTotalFromCount() {
+
+		Page<User> firstPage = repository.findAll(user.dateOfBirth.isNull(), new PageRequest(0, 3));
+		assertThat(firstPage.getContent(), hasSize(3));
+		assertThat(firstPage.getTotalElements(), is(3L));
+
+		Page<User> secondPage = repository.findAll(user.dateOfBirth.isNull(), new PageRequest(10, 10));
+		assertThat(secondPage.getContent(), hasSize(0));
+		assertThat(secondPage.getTotalElements(), is(3L));
 	}
 }


### PR DESCRIPTION
We execute paged queries now in an optimized way. The data is obtained for each paged execution but the count query is deferred. We determine the total from the pageable and the results in which we don't hit the page size bounds.Such cases are if results are less than a full page without offset or results are greater `0` and less than a full page with offset. 

In all other cases we issue an additional count query.

----

Ticket: [DATAJPA-912](https://jira.spring.io/browse/DATAJPA-912)
Related tickets: [DATAJPA-124](https://jira.spring.io/browse/DATAJPA-124), [DATAJPA-477](https://jira.spring.io/browse/DATAJPA-477), [DATACMNS-884](https://jira.spring.io/browse/DATACMNS-884)
Requires: https://github.com/spring-projects/spring-data-commons/pull/169