### PR TITLE
Fix docs on creation of EntityManagerFactory

### DIFF
--- a/src/main/asciidoc/jpa.adoc
+++ b/src/main/asciidoc/jpa.adoc
@@ -65,7 +65,7 @@ class ApplicationConfig {
   }
 
   @Bean
-  public EntityManagerFactory entityManagerFactory() {
+  public LocalContainerEntityManagerFactoryBean entityManagerFactory() {
 
     HibernateJpaVendorAdapter vendorAdapter = new HibernateJpaVendorAdapter();
     vendorAdapter.setGenerateDdl(true);
@@ -74,9 +74,7 @@ class ApplicationConfig {
     factory.setJpaVendorAdapter(vendorAdapter);
     factory.setPackagesToScan("com.acme.domain");
     factory.setDataSource(dataSource());
-    factory.afterPropertiesSet();
-
-    return factory.getObject();
+    return factory;
   }
 
   @Bean
@@ -89,6 +87,7 @@ class ApplicationConfig {
 }
 ----
 ====
+NB: It's important to create `LocalContainerEntityManagerFactoryBean` and not `EntityManagerFactory` directly since the former also participates in exception translation mechanisms besides simply creating `EntityManagerFactory`.
 
 The just shown configuration class sets up an embedded HSQL database using the `EmbeddedDatabaseBuilder` API of spring-jdbc. We then set up a `EntityManagerFactory` and use Hibernate as sample persistence provider. The last infrastructure component declared here is the `JpaTransactionManager`. We finally activate Spring Data JPA repositories using the `@EnableJpaRepositories` annotation which essentially carries the same attributes as the XML namespace does. If no base package is configured it will use the one the configuration class resides in.
 


### PR DESCRIPTION
(the PR is trivial so I didn't read the agreement, hope that it's fine)

Previously EntityManagerFactory was created manually which resulted in
`LocalContainerEntityManagerFactoryBean` not being exposed to
ApplicationContext. The latter is an important bean since it enables
exception translation.

The fact that factory bean implements additional mechanisms is probably
a mistake in the design. But I guess we have to live with this now.
