### PR TITLE
DATAJPA-970 - Remove explicit group name from alias detection pattern.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-jpa</artifactId>
-	<version>1.11.0.BUILD-SNAPSHOT</version>
+	<version>1.11.0.DATAJPA-970-SNAPSHOT</version>
 
 	<name>Spring Data JPA</name>
 	<description>Spring Data module for JPA repositories.</description>

--- a/src/main/java/org/springframework/data/jpa/repository/query/QueryUtils.java
+++ b/src/main/java/org/springframework/data/jpa/repository/query/QueryUtils.java
@@ -105,7 +105,6 @@ public abstract class QueryUtils {
 	private static final int VARIABLE_NAME_GROUP_INDEX = 4;
 
 	private static final Pattern PUNCTATION_PATTERN = Pattern.compile(".*((?![\\._])[\\p{Punct}|\\s])");
-	private static final String FUNCTION_ALIAS_GROUP_NAME = "alias";
 	private static final Pattern FUNCTION_PATTERN;
 
 	private static final String UNSAFE_PROPERTY_REFERENCE = "Sort expression '%s' must only contain property references or "
@@ -159,7 +158,7 @@ public abstract class QueryUtils {
 		builder = new StringBuilder();
 		builder.append("\\s+"); // at least one space
 		builder.append("\\w+\\([0-9a-zA-z\\._,\\s']+\\)"); // any function call including parameters within the brackets
-		builder.append("\\s+[as|AS]+\\s+(?<" + FUNCTION_ALIAS_GROUP_NAME + ">[\\w\\.]+)"); // the potential alias
+		builder.append("\\s+[as|AS]+\\s+(([\\w\\.]+))"); // the potential alias
 
 		FUNCTION_PATTERN = compile(builder.toString());
 	}
@@ -325,7 +324,7 @@ public abstract class QueryUtils {
 
 		while (matcher.find()) {
 
-			String alias = matcher.group(FUNCTION_ALIAS_GROUP_NAME);
+			String alias = matcher.group(1);
 
 			if (StringUtils.hasText(alias)) {
 				result.add(alias);

--- a/src/test/java/org/springframework/data/jpa/repository/query/QueryUtilsUnitTests.java
+++ b/src/test/java/org/springframework/data/jpa/repository/query/QueryUtilsUnitTests.java
@@ -363,7 +363,8 @@ public class QueryUtilsUnitTests {
 	}
 
 	/**
-	 * @see DATAJPA-???
+	 * @see DATAJPA-965
+	 * @see DATAJPA-970
 	 */
 	@Test(expected = InvalidDataAccessApiUsageException.class)
 	public void doesNotAllowWhitespaceInSort() {
@@ -373,7 +374,8 @@ public class QueryUtilsUnitTests {
 	}
 
 	/**
-	 * @see DATAJPA-???
+	 * @see DATAJPA-965
+	 * @see DATAJPA-970
 	 */
 	@Test
 	public void doesNotPrefixUnsageJpaSortFunctionCalls() {
@@ -383,7 +385,8 @@ public class QueryUtilsUnitTests {
 	}
 
 	/**
-	 * @see DATAJPA-???
+	 * @see DATAJPA-965
+	 * @see DATAJPA-970
 	 */
 	@Test
 	public void doesNotPrefixMultipleAliasedFunctionCalls() {
@@ -395,7 +398,8 @@ public class QueryUtilsUnitTests {
 	}
 
 	/**
-	 * @see DATAJPA-???
+	 * @see DATAJPA-965
+	 * @see DATAJPA-970
 	 */
 	@Test
 	public void doesNotPrefixSingleAliasedFunctionCalls() {
@@ -407,7 +411,8 @@ public class QueryUtilsUnitTests {
 	}
 
 	/**
-	 * @see DATAJPA-???
+	 * @see DATAJPA-965
+	 * @see DATAJPA-970
 	 */
 	@Test
 	public void prefixesSingleNonAliasedFunctionCallRelatedSortProperty() {
@@ -419,7 +424,8 @@ public class QueryUtilsUnitTests {
 	}
 
 	/**
-	 * @see DATAJPA-???
+	 * @see DATAJPA-965
+	 * @see DATAJPA-970
 	 */
 	@Test
 	public void prefixesNonAliasedFunctionCallRelatedSortPropertyWhenSelectClauseContainesAliasedFunctionForDifferentProperty() {
@@ -431,7 +437,8 @@ public class QueryUtilsUnitTests {
 	}
 
 	/**
-	 * @see DATAJPA-???
+	 * @see DATAJPA-965
+	 * @see DATAJPA-970
 	 */
 	@Test
 	public void doesNotPrefixAliasedFunctionCallNameWithMultipleNumericParameters() {
@@ -443,7 +450,8 @@ public class QueryUtilsUnitTests {
 	}
 
 	/**
-	 * @see DATAJPA-???
+	 * @see DATAJPA-965
+	 * @see DATAJPA-970
 	 */
 	@Test
 	public void doesNotPrefixAliasedFunctionCallNameWithMultipleStringParameters() {
@@ -455,7 +463,8 @@ public class QueryUtilsUnitTests {
 	}
 
 	/**
-	 * @see DATAJPA-???
+	 * @see DATAJPA-965
+	 * @see DATAJPA-970
 	 */
 	@Test
 	public void doesNotPrefixAliasedFunctionCallNameWithUnderscores() {
@@ -467,7 +476,8 @@ public class QueryUtilsUnitTests {
 	}
 
 	/**
-	 * @see DATAJPA-???
+	 * @see DATAJPA-965
+	 * @see DATAJPA-970
 	 */
 	@Test
 	public void doesNotPrefixAliasedFunctionCallNameWithDots() {
@@ -479,7 +489,8 @@ public class QueryUtilsUnitTests {
 	}
 
 	/**
-	 * @see DATAJPA-???
+	 * @see DATAJPA-965
+	 * @see DATAJPA-970
 	 */
 	@Test
 	public void doesNotPrefixAliasedFunctionCallNameWhenQueryStringContainsMultipleWhiteSpaces() {


### PR DESCRIPTION
We now use the group index instead of an explicit name to retrieve the potential function alias.
This fixes a `PatternSyntaxException` when running on Java 6.
