### PR TITLE
DATAJPA-433 - added workaround to allow parameterized IN with eclipselink

### DIFF
--- a/src/main/java/org/springframework/data/jpa/repository/query/JpaQueryCreator.java
+++ b/src/main/java/org/springframework/data/jpa/repository/query/JpaQueryCreator.java
@@ -241,9 +241,9 @@ public class JpaQueryCreator extends AbstractQueryCreator<CriteriaQuery<? extend
 				case IS_NOT_NULL:
 					return getTypedPath(root, part).isNotNull();
 				case NOT_IN:
-					return getTypedPath(root, part).in(provider.next(part, Collection.class).getExpression()).not();
+					return getTypedPath(root, part).in((Expression<Collection<?>>) provider.next(part, Collection.class).getExpression()).not();
 				case IN:
-					return getTypedPath(root, part).in(provider.next(part, Collection.class).getExpression());
+					return getTypedPath(root, part).in((Expression<Collection<?>>) provider.next(part, Collection.class).getExpression());
 				case STARTING_WITH:
 				case ENDING_WITH:
 				case CONTAINING:

--- a/src/main/java/org/springframework/data/jpa/repository/query/JpaQueryCreator.java
+++ b/src/main/java/org/springframework/data/jpa/repository/query/JpaQueryCreator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2008-2015 the original author or authors.
+ * Copyright 2008-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -45,6 +45,7 @@ import org.springframework.util.Assert;
  * Query creator to create a {@link CriteriaQuery} from a {@link PartTree}.
  * 
  * @author Oliver Gierke
+ * @author Moritz Becker
  */
 public class JpaQueryCreator extends AbstractQueryCreator<CriteriaQuery<? extends Object>, Predicate> {
 
@@ -241,8 +242,10 @@ public class JpaQueryCreator extends AbstractQueryCreator<CriteriaQuery<? extend
 				case IS_NOT_NULL:
 					return getTypedPath(root, part).isNotNull();
 				case NOT_IN:
+					// cast required for eclipselink workaround, see DATAJPA-433
 					return getTypedPath(root, part).in((Expression<Collection<?>>) provider.next(part, Collection.class).getExpression()).not();
 				case IN:
+					// cast required for eclipselink workaround, see DATAJPA-433
 					return getTypedPath(root, part).in((Expression<Collection<?>>) provider.next(part, Collection.class).getExpression());
 				case STARTING_WITH:
 				case ENDING_WITH:

--- a/src/main/java/org/springframework/data/jpa/repository/support/SimpleJpaRepository.java
+++ b/src/main/java/org/springframework/data/jpa/repository/support/SimpleJpaRepository.java
@@ -19,6 +19,7 @@ import static org.springframework.data.jpa.repository.query.QueryUtils.*;
 
 import java.io.Serializable;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -350,10 +351,16 @@ public class SimpleJpaRepository<T, ID extends Serializable>
 			return results;
 		}
 
+		// required for eclipselink workaround
+		List<ID> idCollection = new ArrayList<ID>();
+		for (ID id : ids) {
+			idCollection.add(id);
+		}
+
 		ByIdsSpecification<T> specification = new ByIdsSpecification<T>(entityInformation);
 		TypedQuery<T> query = getQuery(specification, (Sort) null);
 
-		return query.setParameter(specification.parameter, ids).getResultList();
+		return query.setParameter(specification.parameter, idCollection).getResultList();
 	}
 
 	/*
@@ -777,7 +784,7 @@ public class SimpleJpaRepository<T, ID extends Serializable>
 
 		private final JpaEntityInformation<T, ?> entityInformation;
 
-		ParameterExpression<Iterable> parameter;
+		ParameterExpression<Collection<?>> parameter;
 
 		public ByIdsSpecification(JpaEntityInformation<T, ?> entityInformation) {
 			this.entityInformation = entityInformation;
@@ -790,7 +797,7 @@ public class SimpleJpaRepository<T, ID extends Serializable>
 		public Predicate toPredicate(Root<T> root, CriteriaQuery<?> query, CriteriaBuilder cb) {
 
 			Path<?> path = root.get(entityInformation.getIdAttribute());
-			parameter = cb.parameter(Iterable.class);
+			parameter = (ParameterExpression<Collection<?>>) (ParameterExpression) cb.parameter(Collection.class);
 			return path.in(parameter);
 		}
 	}

--- a/src/main/java/org/springframework/data/jpa/repository/support/SimpleJpaRepository.java
+++ b/src/main/java/org/springframework/data/jpa/repository/support/SimpleJpaRepository.java
@@ -69,6 +69,7 @@ import org.springframework.util.Assert;
  * @author Eberhard Wolff
  * @author Thomas Darimont
  * @author Mark Paluch
+ * @author Moritz Becker
  * @param <T> the type of the entity to handle
  * @param <ID> the type of the entity's identifier
  */
@@ -351,7 +352,7 @@ public class SimpleJpaRepository<T, ID extends Serializable>
 			return results;
 		}
 
-		// required for eclipselink workaround
+		// required for eclipselink workaround, see DATAJPA-433
 		List<ID> idCollection = new ArrayList<ID>();
 		for (ID id : ids) {
 			idCollection.add(id);

--- a/src/main/resources/changelog.txt
+++ b/src/main/resources/changelog.txt
@@ -1,6 +1,12 @@
 Spring Data JPA Changelog
 =========================
 
+Changes in version 2.0.0.M1 (2016-11-23)
+----------------------------------------
+* DATAJPA-998 - Set up 2.0 development.
+* DATAJPA-997 - Release 2.0 M1 (Kay).
+
+
 Changes in version 1.10.5.RELEASE (2016-11-03)
 ----------------------------------------------
 * DATAJPA-993 - Improve infrastructure setup example in reference documentation.

--- a/src/test/java/org/springframework/data/jpa/repository/EclipseLinkNamespaceUserRepositoryTests.java
+++ b/src/test/java/org/springframework/data/jpa/repository/EclipseLinkNamespaceUserRepositoryTests.java
@@ -28,40 +28,39 @@ import org.springframework.test.context.ContextConfiguration;
 public class EclipseLinkNamespaceUserRepositoryTests extends NamespaceUserRepositoryTests {
 
 	/**
-	 * Ignored until https://bugs.eclipse.org/bugs/show_bug.cgi?id=349477 is resolved.
-	 */
-	@Override
-	public void findsAllByGivenIds() {
-
-	}
-
-	/**
-	 * Ignored until https://bugs.eclipse.org/bugs/show_bug.cgi?id=349477 is resolved.
-	 */
-	@Override
-	public void handlesIterableOfIdsCorrectly() {
-
-	}
-
-	/**
-	 * Ignored until https://bugs.eclipse.org/bugs/show_bug.cgi?id=349477 is resolved.
-	 */
-	@Override
-	public void allowsExecutingPageableMethodWithNullPageable() {
-
-	}
-
-	/**
-	 * Ignored until https://bugs.eclipse.org/bugs/show_bug.cgi?id=349477 is resolved.
-	 */
-	@Override
-	public void invokesQueryWithVarargsParametersCorrectly() {}
-
-	/**
 	 * Ignored until https://bugs.eclipse.org/bugs/show_bug.cgi?id=422450 is resolved.
 	 */
 	@Override
 	public void sortByAssociationPropertyShouldUseLeftOuterJoin() {}
+
+
+	/**
+	 * Ignored until https://bugs.eclipse.org/bugs/show_bug.cgi?id=349477 is resolved.
+	 */
+	@Override
+	public void findByEmptyArrayOfIntegers() throws Exception {
+	}
+
+	/**
+	 * Ignored until https://bugs.eclipse.org/bugs/show_bug.cgi?id=349477 is resolved.
+	 */
+	@Override
+	public void findByAgeWithEmptyArrayOfIntegersOrFirstName() {
+	}
+
+	/**
+	 * Ignored until https://bugs.eclipse.org/bugs/show_bug.cgi?id=349477 is resolved.
+	 */
+	@Override
+	public void findByEmptyCollectionOfIntegers() throws Exception {
+	}
+
+	/**
+	 * Ignored until https://bugs.eclipse.org/bugs/show_bug.cgi?id=349477 is resolved.
+	 */
+	@Override
+	public void findByEmptyCollectionOfStrings() throws Exception {
+	}
 
 	/**
 	 * Ignored until https://bugs.eclipse.org/bugs/show_bug.cgi?id=422450 is resolved.
@@ -69,9 +68,4 @@ public class EclipseLinkNamespaceUserRepositoryTests extends NamespaceUserReposi
 	@Override
 	public void sortByAssociationPropertyInPageableShouldUseLeftOuterJoin() {}
 
-	/**
-	 * Ignored until https://bugs.eclipse.org/bugs/show_bug.cgi?id=349477 is resolved.
-	 */
-	@Override
-	public void findByElementCollectionAttribute() {}
 }

--- a/src/test/java/org/springframework/data/jpa/repository/EclipseLinkNamespaceUserRepositoryTests.java
+++ b/src/test/java/org/springframework/data/jpa/repository/EclipseLinkNamespaceUserRepositoryTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2008-2014 the original author or authors.
+ * Copyright 2008-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,6 +23,7 @@ import org.springframework.test.context.ContextConfiguration;
  * 
  * @author Oliver Gierke
  * @author Thomas Darimont
+ * @author Moritz Becker
  */
 @ContextConfiguration(value = "classpath:eclipselink.xml")
 public class EclipseLinkNamespaceUserRepositoryTests extends NamespaceUserRepositoryTests {
@@ -31,7 +32,8 @@ public class EclipseLinkNamespaceUserRepositoryTests extends NamespaceUserReposi
 	 * Ignored until https://bugs.eclipse.org/bugs/show_bug.cgi?id=422450 is resolved.
 	 */
 	@Override
-	public void sortByAssociationPropertyShouldUseLeftOuterJoin() {}
+	public void sortByAssociationPropertyShouldUseLeftOuterJoin() {
+	}
 
 
 	/**
@@ -66,6 +68,7 @@ public class EclipseLinkNamespaceUserRepositoryTests extends NamespaceUserReposi
 	 * Ignored until https://bugs.eclipse.org/bugs/show_bug.cgi?id=422450 is resolved.
 	 */
 	@Override
-	public void sortByAssociationPropertyInPageableShouldUseLeftOuterJoin() {}
+	public void sortByAssociationPropertyInPageableShouldUseLeftOuterJoin() {
+	}
 
 }


### PR DESCRIPTION
This workaround changes calls to 
```
javax.persistence.criteria.Expression#in(javax.persistence.criteria.Expression<?>...)
```
to calls to
```
javax.persistence.criteria.Expression#in(javax.persistence.criteria.Expression<java.util.Collection<?>>)
```
by adding the required casts.

Eclipselink is missing some logic in `javax.persistence.criteria.Expression#in(javax.persistence.criteria.Expression<?>...)` to handle single collection valued parameters.

Note: This pull request breaks IN with empty collection parameter values for eclipselink which seems to have been working accidentally before. While eclipselink users have not been able to use parameterized IN at all before this fix, they can now use parameterized IN at least with non-empty collection parameter values.

To make parameterized IN work with empty collections, a fix in eclipselink's sql generation is required. See https://bugs.eclipse.org/bugs/show_bug.cgi?id=349477.