### PR TITLE
DATAJPA-1041 - Append ad hoc EntityGraph subgraphs properly. 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-jpa</artifactId>
-	<version>1.11.0.BUILD-SNAPSHOT</version>
+	<version>1.11.0.DATAJPA-1041-SNAPSHOT</version>
 
 	<name>Spring Data JPA</name>
 	<description>Spring Data module for JPA repositories.</description>

--- a/src/test/java/org/springframework/data/jpa/domain/sample/User.java
+++ b/src/test/java/org/springframework/data/jpa/domain/sample/User.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2008-2015 the original author or authors.
+ * Copyright 2008-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,6 +37,7 @@ import javax.persistence.NamedEntityGraphs;
 import javax.persistence.NamedQuery;
 import javax.persistence.NamedStoredProcedureQueries;
 import javax.persistence.NamedStoredProcedureQuery;
+import javax.persistence.NamedSubgraph;
 import javax.persistence.ParameterMode;
 import javax.persistence.StoredProcedureParameter;
 import javax.persistence.Table;
@@ -49,6 +50,7 @@ import javax.persistence.TemporalType;
  * 
  * @author Oliver Gierke
  * @author Thomas Darimont
+ * @author Christoph Strobl
  */
 @Entity
 @NamedEntityGraphs({
@@ -56,7 +58,30 @@ import javax.persistence.TemporalType;
 		@NamedEntityGraph(name = "User.detail", attributeNodes = { @NamedAttributeNode("roles"),
 				@NamedAttributeNode("manager"), @NamedAttributeNode("colleagues") }),
 		@NamedEntityGraph(name = "User.getOneWithDefinedEntityGraphById", attributeNodes = { @NamedAttributeNode("roles"),
-				@NamedAttributeNode("manager"), @NamedAttributeNode("colleagues") }) })
+				@NamedAttributeNode("manager"), @NamedAttributeNode("colleagues") }),
+        @NamedEntityGraph(name = "User.withSubGraph",
+				attributeNodes = {
+        			@NamedAttributeNode("roles"),
+					@NamedAttributeNode(value="colleagues", subgraph = "User.colleagues")
+				},
+				subgraphs = {
+        			@NamedSubgraph(name = "User.colleagues", attributeNodes = {@NamedAttributeNode("colleagues"), @NamedAttributeNode("roles")})
+				}),
+		@NamedEntityGraph(name = "User.deepGraph",
+				attributeNodes = {
+					@NamedAttributeNode("roles"),
+					@NamedAttributeNode(value="colleagues", subgraph = "User.colleagues")
+				},
+				subgraphs = {
+					@NamedSubgraph(name = "User.colleagues", attributeNodes = {
+						@NamedAttributeNode("roles"),
+						@NamedAttributeNode(value = "colleagues", subgraph = "User.colleaguesOfColleagues")
+					}),
+					@NamedSubgraph(name="User.colleaguesOfColleagues", attributeNodes = {
+						@NamedAttributeNode("roles"),
+					})
+				})
+		})
 @NamedQuery(name = "User.findByEmailAddress", query = "SELECT u FROM User u WHERE u.emailAddress = ?1")
 @NamedStoredProcedureQueries({ //
 @NamedStoredProcedureQuery(name = "User.plus1", procedureName = "plus1inout", parameters = {

--- a/src/test/java/org/springframework/data/jpa/repository/query/EclipseLinkJpa21UtilsTests.java
+++ b/src/test/java/org/springframework/data/jpa/repository/query/EclipseLinkJpa21UtilsTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2017 the original author or authors.
+ * Copyright 2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,17 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.springframework.data.jpa.repository;
+package org.springframework.data.jpa.repository.query;
 
-import org.junit.Ignore;
 import org.springframework.test.context.ContextConfiguration;
 
 /**
- * @author Oliver Gierke
+ * @author Christoph Strobl
  */
 @ContextConfiguration("classpath:eclipselink.xml")
-@Ignore("EntityManager.clear() causes trouble applying fetch-/loadgraphs - see https://bugs.eclipse.org/bugs/show_bug.cgi?id=510627")
-public class EclipseLinkEntityGraphRepositoryMethodsIntegrationTests extends
-		EntityGraphRepositoryMethodsIntegrationTests {
+public class EclipseLinkJpa21UtilsTests extends Jpa21UtilsTests {
 
 }

--- a/src/test/java/org/springframework/data/jpa/repository/query/Jpa21UtilsTests.java
+++ b/src/test/java/org/springframework/data/jpa/repository/query/Jpa21UtilsTests.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.jpa.repository.query;
+
+import static org.junit.Assert.*;
+import static org.junit.Assume.*;
+import static org.springframework.data.jpa.support.EntityManagerTestUtils.*;
+import static org.springframework.data.jpa.util.IsAttributeNode.*;
+
+import javax.persistence.AttributeNode;
+import javax.persistence.EntityGraph;
+import javax.persistence.EntityManager;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.jpa.domain.sample.User;
+import org.springframework.data.jpa.repository.EntityGraph.EntityGraphType;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * @author Christoph Strobl
+ */
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration("classpath:application-context.xml")
+@Transactional
+public class Jpa21UtilsTests {
+
+	@Autowired EntityManager em;
+
+	@Test // DATAJPA-1041
+	public void shouldCreateGraphWithoutSubGraphCorrectly() {
+
+		assumeTrue(currentEntityManagerIsAJpa21EntityManager(em));
+
+		EntityGraph<User> graph = em.createEntityGraph(User.class);
+		Jpa21Utils.configureFetchGraphFrom(
+				new JpaEntityGraph("name", EntityGraphType.FETCH, new String[] { "roles", "colleagues" }), graph);
+
+		AttributeNode<?> roles = findNode("roles", graph);
+		assertThat(roles, terminatesGraph());
+
+		AttributeNode<?> colleagues = findNode("colleagues", graph);
+		assertThat(colleagues, terminatesGraph());
+	}
+
+	@Test // DATAJPA-1041
+	public void shouldCreateGraphWithMultipleSubGraphCorrectly() {
+
+		assumeTrue(currentEntityManagerIsAJpa21EntityManager(em));
+
+		EntityGraph<User> graph = em.createEntityGraph(User.class);
+		Jpa21Utils.configureFetchGraphFrom(new JpaEntityGraph("name", EntityGraphType.FETCH,
+				new String[] { "roles", "colleagues.roles", "colleagues.colleagues" }), graph);
+
+		AttributeNode<?> roles = findNode("roles", graph);
+		assertThat(roles, terminatesGraph());
+
+		AttributeNode<?> colleagues = findNode("colleagues", graph);
+		assertThat(colleagues, terminatesGraphWith("roles", "colleagues"));
+	}
+
+	@Test // DATAJPA-1041
+	public void shouldCreateGraphWithDeepSubGraphCorrectly() {
+
+		assumeTrue(currentEntityManagerIsAJpa21EntityManager(em));
+
+		EntityGraph<User> graph = em.createEntityGraph(User.class);
+		Jpa21Utils.configureFetchGraphFrom(new JpaEntityGraph("name", EntityGraphType.FETCH,
+				new String[] { "roles", "colleagues.roles", "colleagues.colleagues.roles" }), graph);
+
+		AttributeNode<?> roles = findNode("roles", graph);
+		assertThat(roles, terminatesGraph());
+
+		AttributeNode<?> colleagues = findNode("colleagues", graph);
+		assertThat(colleagues, terminatesGraphWith("roles"));
+		assertThat(colleagues, hasSubgraphs("colleagues"));
+
+		AttributeNode colleaguesOfColleagues = findNode("colleagues", colleagues);
+		assertThat(colleaguesOfColleagues, terminatesGraphWith("roles"));
+	}
+
+	@Test // DATAJPA-1041
+	public void shouldIgnoreIntermedeateSubGraphNodesThatAreNotNeeded() {
+
+		assumeTrue(currentEntityManagerIsAJpa21EntityManager(em));
+
+		EntityGraph<User> graph = em.createEntityGraph(User.class);
+		Jpa21Utils.configureFetchGraphFrom(new JpaEntityGraph("name", EntityGraphType.FETCH, new String[] { "roles",
+				"colleagues", "colleagues.roles", "colleagues.colleagues", "colleagues.colleagues.roles" }), graph);
+
+		AttributeNode<?> roles = findNode("roles", graph);
+		assertThat(roles, terminatesGraph());
+
+		AttributeNode<?> colleagues = findNode("colleagues", graph);
+		assertThat(colleagues, terminatesGraphWith("roles"));
+		assertThat(colleagues, hasSubgraphs("colleagues"));
+
+		AttributeNode colleaguesOfColleagues = findNode("colleagues", colleagues);
+		assertThat(colleaguesOfColleagues, terminatesGraphWith("roles"));
+	}
+
+	@Test // DATAJPA-1041
+	public void orderOfSubGraphsShouldNotMatter() {
+
+		assumeTrue(currentEntityManagerIsAJpa21EntityManager(em));
+
+		EntityGraph<User> graph = em.createEntityGraph(User.class);
+		Jpa21Utils.configureFetchGraphFrom(new JpaEntityGraph("name", EntityGraphType.FETCH, new String[] {
+				"colleagues.colleagues.roles", "roles", "colleagues.colleagues", "colleagues", "colleagues.roles" }), graph);
+
+		AttributeNode<?> roles = findNode("roles", graph);
+		assertThat(roles, terminatesGraph());
+
+		AttributeNode<?> colleagues = findNode("colleagues", graph);
+		assertThat(colleagues, terminatesGraphWith("roles"));
+		assertThat(colleagues, hasSubgraphs("colleagues"));
+
+		AttributeNode colleaguesOfColleagues = findNode("colleagues", colleagues);
+		assertThat(colleaguesOfColleagues, terminatesGraphWith("roles"));
+	}
+
+	@Test(expected = Exception.class) // DATAJPA-1041
+	public void errorsOnUnknownProperties() {
+
+		assumeTrue(currentEntityManagerIsAJpa21EntityManager(em));
+
+		Jpa21Utils.configureFetchGraphFrom(new JpaEntityGraph("name", EntityGraphType.FETCH, new String[] { "¯\\_(ツ)_/¯" }),
+				em.createEntityGraph(User.class));
+	}
+}

--- a/src/test/java/org/springframework/data/jpa/repository/query/OpenJpaJpa21UtilsTests.java
+++ b/src/test/java/org/springframework/data/jpa/repository/query/OpenJpaJpa21UtilsTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2017 the original author or authors.
+ * Copyright 2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,17 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.springframework.data.jpa.repository;
+package org.springframework.data.jpa.repository.query;
 
-import org.junit.Ignore;
 import org.springframework.test.context.ContextConfiguration;
 
 /**
- * @author Oliver Gierke
+ * @author Christoph Strobl
  */
-@ContextConfiguration("classpath:eclipselink.xml")
-@Ignore("EntityManager.clear() causes trouble applying fetch-/loadgraphs - see https://bugs.eclipse.org/bugs/show_bug.cgi?id=510627")
-public class EclipseLinkEntityGraphRepositoryMethodsIntegrationTests extends
-		EntityGraphRepositoryMethodsIntegrationTests {
+@ContextConfiguration("classpath:openjpa.xml")
+public class OpenJpaJpa21UtilsTests extends Jpa21UtilsTests {
 
 }

--- a/src/test/java/org/springframework/data/jpa/repository/sample/RepositoryMethodsWithEntityGraphConfigRepository.java
+++ b/src/test/java/org/springframework/data/jpa/repository/sample/RepositoryMethodsWithEntityGraphConfigRepository.java
@@ -33,6 +33,7 @@ import com.querydsl.core.types.Predicate;
  * 
  * @author Thomas Darimont
  * @author Jocelyn Ntakpe
+ * @author Christoph Strobl
  */
 public interface RepositoryMethodsWithEntityGraphConfigRepository
 		extends CrudRepository<User, Integer>, QueryDslPredicateExecutor<User> {
@@ -60,4 +61,17 @@ public interface RepositoryMethodsWithEntityGraphConfigRepository
 	// DATAJPA-790
 	@EntityGraph("User.detail")
 	Page<User> findAll(Predicate predicate, Pageable pageable);
+
+	// DATAJPA-1041
+	@EntityGraph(type = EntityGraphType.FETCH, value = "User.withSubGraph")
+	User findOneWithMultipleSubGraphsUsingNamedEntityGraphById(Integer id);
+
+	// DATAJPA-1041
+	@EntityGraph(attributePaths = { "colleagues", "colleagues.roles", "colleagues.colleagues" })
+	User findOneWithMultipleSubGraphsById(Integer id);
+
+	// DATAJPA-1041
+	@EntityGraph(attributePaths = { "colleagues", "colleagues.roles", "colleagues.colleagues.roles" })
+	User findOneWithDeepGraphById(Integer id);
+
 }

--- a/src/test/java/org/springframework/data/jpa/util/IsAttributeNode.java
+++ b/src/test/java/org/springframework/data/jpa/util/IsAttributeNode.java
@@ -1,0 +1,225 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.jpa.util;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import javax.persistence.AttributeNode;
+import javax.persistence.EntityGraph;
+import javax.persistence.Subgraph;
+
+import org.hamcrest.Description;
+import org.hamcrest.TypeSafeMatcher;
+import org.springframework.util.CollectionUtils;
+import org.springframework.util.ObjectUtils;
+
+/**
+ * @author Christoph Strobl
+ */
+public class IsAttributeNode<T> extends TypeSafeMatcher<AttributeNode<T>> {
+
+	private boolean terminatingNodeCheck = false;
+	private List<String> nodes;
+	private List<String> subgraphs;
+	private List<String> errors = new ArrayList<String>();
+
+	@Override
+	protected boolean matchesSafely(AttributeNode<T> item) {
+
+		if (item == null) {
+
+			errors.add("AttributeNode was null!");
+			return false;
+		}
+
+		if (terminatingNodeCheck) {
+
+			if (!CollectionUtils.isEmpty(item.getSubgraphs())) {
+
+				errors.add(String.format("'%s' was expected to be a terminating node but has subgraphs %s.",
+						item.getAttributeName(), extractExistingAttributeNames(item.getSubgraphs().values().iterator().next())));
+				return false;
+			}
+			return true;
+		}
+
+		if (CollectionUtils.isEmpty(item.getSubgraphs())) {
+			if (!CollectionUtils.isEmpty(nodes)) {
+				errors
+						.add(String.format("Leaf properties %s could not be found. The node does not have any subgraphs.", nodes));
+			}
+			if (!CollectionUtils.isEmpty(subgraphs)) {
+				errors.add(String.format("Subgraphs %s could not be found. The node does not have any subgraphs.", subgraphs));
+			}
+			return false;
+		}
+
+		Subgraph<?> graph = item.getSubgraphs().values().iterator().next();
+
+		if (!CollectionUtils.isEmpty(nodes)) {
+			for (String nodeName : nodes) {
+
+				AttributeNode<?> node = findNode(nodeName, graph.getAttributeNodes());
+				if (node == null) {
+
+					errors.add(String.format("AttributeNode '%s' could not be found in subgraph for '%s'. Know nodes are: %s.",
+							nodeName, item.getAttributeName(), extractExistingAttributeNames(graph)));
+					return false;
+				}
+
+				if (!CollectionUtils.isEmpty(node.getSubgraphs())) {
+
+					errors.add(String.format("AttributeNode %s of subgraph %s is not a leaf property but has % SubGraph(s).",
+							nodeName, item.getAttributeName(), node.getSubgraphs().size()));
+					return false;
+				}
+			}
+		}
+
+		if (!CollectionUtils.isEmpty(subgraphs)) {
+			for (String subgraphName : subgraphs) {
+
+				AttributeNode<?> node = findNode(subgraphName, graph.getAttributeNodes());
+				if (node == null) {
+
+					errors.add(String.format("Subgraph '%s' could not be found in SubGraph for '%s'. Know nodes are: %s.",
+							subgraphName, item.getAttributeName(), extractExistingAttributeNames(graph)));
+					return false;
+				}
+
+				if (CollectionUtils.isEmpty(node.getSubgraphs())) {
+					errors.add(String.format("'%s' of SubGraph '%s' is not a SubGraph.", subgraphName, item.getAttributeName()));
+					return false;
+				}
+			}
+		}
+		return true;
+	}
+
+	@Override
+	public void describeTo(Description description) {
+
+		for (String error : errors) {
+			description.appendText(error);
+		}
+	}
+
+	/**
+	 * Lookup the {@link AttributeNode} with given {@literal nodeName} in the root of the given {@literal graph}.
+	 *
+	 * @param nodeName
+	 * @param graph
+	 * @return
+	 */
+	public static AttributeNode<?> findNode(String nodeName, EntityGraph<?> graph) {
+
+		if (graph == null) {
+			return null;
+		}
+
+		return findNode(nodeName, graph.getAttributeNodes());
+	}
+
+	/**
+	 * Lookup the {@link AttributeNode} with given {@literal nodeName} in the {@link List} of given {@literal nodes}.
+	 *
+	 * @param nodeName
+	 * @param nodes
+	 * @return
+	 */
+	public static AttributeNode<?> findNode(String nodeName, List<AttributeNode<?>> nodes) {
+
+		if (CollectionUtils.isEmpty(nodes)) {
+			return null;
+		}
+
+		for (AttributeNode<?> node : nodes) {
+			if (ObjectUtils.nullSafeEquals(node.getAttributeName(), nodeName)) {
+				return node;
+			}
+		}
+
+		return null;
+	}
+
+	/**
+	 * Lookup the {@link AttributeNode} with given {@literal nodeName} in the first {@link Subgraph} of the given
+	 * {@literal node}.
+	 *
+	 * @param attributeName
+	 * @param node
+	 * @return
+	 */
+	public static AttributeNode<?> findNode(String attributeName, AttributeNode<?> node) {
+
+		if (CollectionUtils.isEmpty(node.getSubgraphs())) {
+			return null;
+		}
+
+		Subgraph<?> subgraph = node.getSubgraphs().values().iterator().next();
+		return findNode(attributeName, subgraph.getAttributeNodes());
+	}
+
+	private List<String> extractExistingAttributeNames(Subgraph<?> graph) {
+
+		List<String> result = new ArrayList<String>(graph.getAttributeNodes().size());
+		for (AttributeNode<?> node : graph.getAttributeNodes()) {
+			result.add(node.getAttributeName());
+		}
+		return result;
+	}
+
+	/**
+	 * Asserts that the fetch graph terminates with {@link AttributeNode}s having the given {@literal nodeNames}.
+	 *
+	 * @param nodeNames
+	 * @return
+	 */
+	public static IsAttributeNode terminatesGraphWith(String... nodeNames) {
+
+		IsAttributeNode matcher = new IsAttributeNode();
+		matcher.nodes = Arrays.asList(nodeNames);
+		return matcher;
+	}
+
+	/**
+	 * Asserts that the fetch graph continues with {@link AttributeNode}s having {@link AttributeNode#getSubgraphs()} with
+	 * given {@literal subgraphNames}.
+	 *
+	 * @return
+	 */
+	public static IsAttributeNode hasSubgraphs(String... subgraphNames) {
+
+		IsAttributeNode matcher = new IsAttributeNode();
+		matcher.subgraphs = Arrays.asList(subgraphNames);
+		return matcher;
+	}
+
+	/**
+	 * Asserts that the fetch graph terminates with the given {@link AttributeNode} by checking
+	 * {@link AttributeNode#getSubgraphs()} is empty.
+	 *
+	 * @return
+	 */
+	public static IsAttributeNode terminatesGraph() {
+
+		IsAttributeNode matcher = new IsAttributeNode();
+		matcher.terminatingNodeCheck = true;
+		return matcher;
+	}
+}


### PR DESCRIPTION
We now make sure to append instead of recreate `SubGraphs` correctly when `AttributeNodes` already exist for a given property or dot path. This change fixes errors when creating ad hoc fetch graphs like below where multiple properties are loaded via a `SubGraph` on the same type.

```java
@EntityGraph(attributePaths = { "colleagues.roles", "colleagues.colleagues" })
```

Additionally we fixed issues with the creation of "deep" ad hoc fetch graphs via `@EntityGraph` so that

```java
@EntityGraph(attributePaths = { "roles", "colleagues.roles", "colleagues.colleagues.roles" })
```

can be used as a short form of

```java
@NamedEntityGraph(name = "User.deepGraph",
        attributeNodes = {
                @NamedAttributeNode("roles"),
                @NamedAttributeNode(value="colleagues", subgraph = "User.colleagues")
        },
        subgraphs = {
                @NamedSubgraph(name = "User.colleagues", attributeNodes = {
                        @NamedAttributeNode("roles"),
                        @NamedAttributeNode(value = "colleagues", subgraph = "User.colleaguesOfColleagues")
                }),
                @NamedSubgraph(name="User.colleaguesOfColleagues", attributeNodes = {
                        @NamedAttributeNode("roles"),
                })

        })
})
```

However we had to disable EclipseLink tests for this one since there seems to be a glitch when calling `EntityManager.clear()` prior to applying the _fetch-/loadgraph_ causing the properties not to be in the correct load state. Omitting `EntityManager.clear()` is not an option since the load state is always `LOADED` even when leaving out query hints.

---

Supersedes: #186