### PR TITLE
DATAJPA-1067 - Fixed typo in reference documentation

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,9 +1,13 @@
+<!--
+
 Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
 Make sure that:
+
+-->
 
 - [ ] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
 - [ ] There is a ticket in the bug tracker for the project in our [JIRA](https://jira.spring.io/browse/DATAJPA).
 - [ ] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
 - [ ] You submit test cases (unit or integration tests) that back your changes.
 - [ ] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
-- [ ] You provide your full name and an email address registered with your GitHub account. If you’re a first-time submitter, make sure you have completed the [Contributor’s License Agreement form](https://support.springsource.com/spring_committer_signup).
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,11 @@ env:
     - PROFILE=eclipselink-27-next
     - PROFILE=querydsl-next
 
+addons:
+  apt:
+    packages:
+    - oracle-java8-installer
+
 sudo: false
 
 cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ cache:
 
 install: true
 
-script: "mvn clean dependency:list test -P${PROFILE} -Dsort -Dbundlor.enabled=false"
+script: "mvn clean dependency:list test -P${PROFILE} -Dsort -Dbundlor.enabled=false -B"
 notifications:
   slack:
     secure: VYoJ2D6BM3etTNHJArJ47rVvj49PRZ+eIg12itOzlQSCnsPPob9X2OJVZ8Umatfx6TyP+rOrJAz+pqA1geumEzx+dIWTtBf6og703XKS9feLpM7sa1DupdstlGu506Wwevmb7nUq/Ct0ziCZykD3Cqu9tOhnai5wWlULBYDQ4WE=

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ jdk:
 env:
   matrix:
     - PROFILE=ci
-    - PROFILE=spring43
     - PROFILE=spring43-next
     - PROFILE=spring5,hibernate-43
     - PROFILE=spring5-next,hibernate-43

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,8 @@ env:
     - PROFILE=ci
     - PROFILE=spring43
     - PROFILE=spring43-next
-    - PROFILE=spring5
-    - PROFILE=spring5-next
+    - PROFILE=spring5,hibernate-43
+    - PROFILE=spring5-next,hibernate-43
     - PROFILE=hibernate-41
     - PROFILE=hibernate-42
     - PROFILE=hibernate-42-next

--- a/pom.xml
+++ b/pom.xml
@@ -97,13 +97,13 @@
 		<profile>
 			<id>hibernate-51</id>
 			<properties>
-				<hibernate>5.1.0.Final</hibernate>
+				<hibernate>5.1.1.Final</hibernate>
 			</properties>
 		</profile>
 		<profile>
 			<id>hibernate-51-next</id>
 			<properties>
-				<hibernate>5.1.1-SNAPSHOT</hibernate>
+				<hibernate>5.1.2-SNAPSHOT</hibernate>
 			</properties>
 			<repositories>
 				<repository>

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.springframework.data.build</groupId>
 		<artifactId>spring-data-parent</artifactId>
-		<version>1.9.0.BUILD-SNAPSHOT</version>
+		<version>1.9.0.RELEASE</version>
 	</parent>
 
 	<properties>
@@ -27,7 +27,7 @@
 		<hsqldb1>1.8.0.10</hsqldb1>
 		<jpa>2.0.0</jpa>
 		<openjpa>2.4.1</openjpa>
-		<springdata.commons>1.13.0.BUILD-SNAPSHOT</springdata.commons>
+		<springdata.commons>1.13.0.RELEASE</springdata.commons>
 
 		<sonar.dynamicAnalysis>reuseReports</sonar.dynamicAnalysis>
 		<skip-openjpa>false</skip-openjpa>
@@ -604,8 +604,8 @@
 
 	<repositories>
 		<repository>
-			<id>spring-libs-snapshot</id>
-			<url>https://repo.spring.io/libs-snapshot</url>
+			<id>spring-libs-release</id>
+			<url>https://repo.spring.io/libs-release</url>
 		</repository>
 	</repositories>
 

--- a/pom.xml
+++ b/pom.xml
@@ -79,13 +79,13 @@
 		<profile>
 			<id>hibernate-5</id>
 			<properties>
-				<hibernate>5.0.9.Final</hibernate>
+				<hibernate>5.0.10.Final</hibernate>
 			</properties>
 		</profile>
 		<profile>
 			<id>hibernate-5-next</id>
 			<properties>
-				<hibernate>5.0.10-SNAPSHOTS</hibernate>
+				<hibernate>5.0.11-SNAPSHOTS</hibernate>
 			</properties>
 			<repositories>
 				<repository>

--- a/pom.xml
+++ b/pom.xml
@@ -128,14 +128,14 @@
 		<profile>
 			<id>hibernate-52</id>
 			<properties>
-				<hibernate>5.2.4.Final</hibernate>
+				<hibernate>5.2.6.Final</hibernate>
 				<hibernate.artifact>hibernate-core</hibernate.artifact>
 			</properties>
 		</profile>
 		<profile>
 			<id>hibernate-52-next</id>
 			<properties>
-				<hibernate>5.2.5-SNAPSHOT</hibernate>
+				<hibernate>5.2.7-SNAPSHOT</hibernate>
 				<hibernate.artifact>hibernate-core</hibernate.artifact>
 			</properties>
 			<repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.springframework.data.build</groupId>
 		<artifactId>spring-data-parent</artifactId>
-		<version>1.9.0.BUILD-SNAPSHOT</version>
+		<version>1.9.0.RC1</version>
 	</parent>
 
 	<properties>
@@ -27,7 +27,7 @@
 		<hsqldb1>1.8.0.10</hsqldb1>
 		<jpa>2.0.0</jpa>
 		<openjpa>2.4.1</openjpa>
-		<springdata.commons>1.13.0.BUILD-SNAPSHOT</springdata.commons>
+		<springdata.commons>1.13.0.RC1</springdata.commons>
 
 		<sonar.dynamicAnalysis>reuseReports</sonar.dynamicAnalysis>
 		<skip-openjpa>false</skip-openjpa>
@@ -604,8 +604,8 @@
 
 	<repositories>
 		<repository>
-			<id>spring-libs-snapshot</id>
-			<url>https://repo.spring.io/libs-snapshot</url>
+			<id>spring-libs-milestone</id>
+			<url>https://repo.spring.io/libs-milestone</url>
 		</repository>
 	</repositories>
 

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.springframework.data.build</groupId>
 		<artifactId>spring-data-parent</artifactId>
-		<version>1.9.0.RC1</version>
+		<version>1.9.0.BUILD-SNAPSHOT</version>
 	</parent>
 
 	<properties>
@@ -27,7 +27,7 @@
 		<hsqldb1>1.8.0.10</hsqldb1>
 		<jpa>2.0.0</jpa>
 		<openjpa>2.4.1</openjpa>
-		<springdata.commons>1.13.0.RC1</springdata.commons>
+		<springdata.commons>1.13.0.BUILD-SNAPSHOT</springdata.commons>
 
 		<sonar.dynamicAnalysis>reuseReports</sonar.dynamicAnalysis>
 		<skip-openjpa>false</skip-openjpa>
@@ -604,8 +604,8 @@
 
 	<repositories>
 		<repository>
-			<id>spring-libs-milestone</id>
-			<url>https://repo.spring.io/libs-milestone</url>
+			<id>spring-libs-snapshot</id>
+			<url>https://repo.spring.io/libs-snapshot</url>
 		</repository>
 	</repositories>
 

--- a/pom.xml
+++ b/pom.xml
@@ -30,10 +30,23 @@
 		<springdata.commons>1.13.0.BUILD-SNAPSHOT</springdata.commons>
 
 		<sonar.dynamicAnalysis>reuseReports</sonar.dynamicAnalysis>
+		<skip-openjpa>false</skip-openjpa>
 
 	</properties>
 
 	<profiles>
+		<profile>
+			<id>spring5</id>
+			<properties>
+				<skip-openjpa>true</skip-openjpa>
+			</properties>
+		</profile>
+		<profile>
+			<id>spring5-next</id>
+			<properties>
+				<skip-openjpa>true</skip-openjpa>
+			</properties>
+		</profile>
 		<profile>
 			<id>hibernate-41</id>
 			<properties>
@@ -457,6 +470,7 @@
 						</goals>
 						<phase>test</phase>
 						<configuration>
+							<skip>${skip-openjpa}</skip>
 							<includes>
 								<include>**/OpenJpa*Tests.java</include>
 							</includes>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-jpa</artifactId>
-	<version>1.11.0.RELEASE</version>
+	<version>1.12.0.BUILD-SNAPSHOT</version>
 
 	<name>Spring Data JPA</name>
 	<description>Spring Data module for JPA repositories.</description>

--- a/pom.xml
+++ b/pom.xml
@@ -555,7 +555,7 @@
 							<goal>process</goal>
 						</goals>
 						<configuration>
-							<outputDirectory>target/generated-sources/annotations</outputDirectory>
+							<outputDirectory>target/generated-sources/querydsl</outputDirectory>
 						</configuration>
 					</execution>
 					<execution>
@@ -565,7 +565,7 @@
 							<goal>test-process</goal>
 						</goals>
 						<configuration>
-							<testOutputDirectory>target/generated-test-sources/test-annotations</testOutputDirectory>
+							<testOutputDirectory>target/generated-test-sources/test-querydsl</testOutputDirectory>
 							<options>
 								<querydsl.excludedClasses>
 									org.springframework.data.jpa.repository.util.JpaClassUtilsUnitTests.NamedUser,org.springframework.data.jpa.repository.query.ParameterBinderUnitTests.SampleEmbeddable

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-jpa</artifactId>
-	<version>1.11.0.BUILD-SNAPSHOT</version>
+	<version>1.11.0.RC1</version>
 
 	<name>Spring Data JPA</name>
 	<description>Spring Data module for JPA repositories.</description>

--- a/pom.xml
+++ b/pom.xml
@@ -597,8 +597,8 @@
 
 	<pluginRepositories>
 		<pluginRepository>
-			<id>spring-plugins-release</id>
-			<url>https://repo.spring.io/plugins-release</url>
+			<id>spring-plugins-snapshot</id>
+			<url>https://repo.spring.io/plugins-snapshot</url>
 		</pluginRepository>
 	</pluginRepositories>
 

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.springframework.data.build</groupId>
 		<artifactId>spring-data-parent</artifactId>
-		<version>1.9.0.RELEASE</version>
+		<version>1.10.0.BUILD-SNAPSHOT</version>
 	</parent>
 
 	<properties>
@@ -27,7 +27,7 @@
 		<hsqldb1>1.8.0.10</hsqldb1>
 		<jpa>2.0.0</jpa>
 		<openjpa>2.4.1</openjpa>
-		<springdata.commons>1.13.0.RELEASE</springdata.commons>
+		<springdata.commons>1.14.0.BUILD-SNAPSHOT</springdata.commons>
 
 		<sonar.dynamicAnalysis>reuseReports</sonar.dynamicAnalysis>
 		<skip-openjpa>false</skip-openjpa>
@@ -604,8 +604,8 @@
 
 	<repositories>
 		<repository>
-			<id>spring-libs-release</id>
-			<url>https://repo.spring.io/libs-release</url>
+			<id>spring-libs-snapshot</id>
+			<url>https://repo.spring.io/libs-snapshot</url>
 		</repository>
 	</repositories>
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-jpa</artifactId>
-	<version>1.11.0.BUILD-SNAPSHOT</version>
+	<version>1.11.0.RELEASE</version>
 
 	<name>Spring Data JPA</name>
 	<description>Spring Data module for JPA repositories.</description>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-jpa</artifactId>
-	<version>1.11.0.RC1</version>
+	<version>1.11.0.BUILD-SNAPSHOT</version>
 
 	<name>Spring Data JPA</name>
 	<description>Spring Data module for JPA repositories.</description>

--- a/pom.xml
+++ b/pom.xml
@@ -128,14 +128,14 @@
 		<profile>
 			<id>hibernate-52</id>
 			<properties>
-				<hibernate>5.2.6.Final</hibernate>
+				<hibernate>5.2.7.Final</hibernate>
 				<hibernate.artifact>hibernate-core</hibernate.artifact>
 			</properties>
 		</profile>
 		<profile>
 			<id>hibernate-52-next</id>
 			<properties>
-				<hibernate>5.2.7-SNAPSHOT</hibernate>
+				<hibernate>5.2.8-SNAPSHOT</hibernate>
 				<hibernate.artifact>hibernate-core</hibernate.artifact>
 			</properties>
 			<repositories>

--- a/readme.md
+++ b/readme.md
@@ -129,8 +129,8 @@ public class UserRepositoryIntegrationTest {
 Here are some ways for you to get involved in the community:
 
 * Get involved with the Spring community by helping out on [stackoverflow](http://stackoverflow.com/questions/tagged/spring-data-jpa) by responding to questions and joining the debate.
-* Create [JIRA](https://jira.springsource.org/browse/DATAJPA) tickets for bugs and new features and comment and vote on the ones that you are interested in.  
+* Create [JIRA](https://jira.spring.io/browse/DATAJPA) tickets for bugs and new features and comment and vote on the ones that you are interested in.  
 * Github is for social coding: if you want to write code, we encourage contributions through pull requests from [forks of this repository](http://help.github.com/forking/). If you want to contribute code this way, please reference a JIRA ticket as well covering the specific issue you are addressing.
 * Watch for upcoming articles on Spring by [subscribing](http://spring.io/blog) to spring.io.
 
-Before we accept a non-trivial patch or pull request we will need you to sign the [contributor's agreement](https://support.springsource.com/spring_committer_signup).  Signing the contributor's agreement does not grant anyone commit rights to the main repository, but it does mean that we can accept your contributions, and you will get an author credit if we do.  Active contributors might be asked to join the core team, and given the ability to merge pull requests.
+Before we accept a non-trivial patch or pull request we will need you to [sign the Contributor License Agreement](https://cla.pivotal.io/sign/spring). Signing the contributor’s agreement does not grant anyone commit rights to the main repository, but it does mean that we can accept your contributions, and you will get an author credit if we do. If you forget to do so, you'll be reminded when you submit a pull request. Active contributors might be asked to join the core team, and given the ability to merge pull requests.

--- a/src/main/asciidoc/jpa.adoc
+++ b/src/main/asciidoc/jpa.adoc
@@ -161,7 +161,7 @@ We will create a query using the JPA criteria API from this but essentially this
 |`OrderBy`|`findByAgeOrderByLastnameDesc`|`… where x.age = ?1 order by x.lastname desc`
 |`Not`|`findByLastnameNot`|`… where x.lastname <> ?1`
 |`In`|`findByAgeIn(Collection<Age> ages)`|`… where x.age in ?1`
-|`NotIn`|`findByAgeNotIn(Collection<Age> age)`|`… where x.age not in ?1`
+|`NotIn`|`findByAgeNotIn(Collection<Age> ages)`|`… where x.age not in ?1`
 |`True`|`findByActiveTrue()`|`… where x.active = true`
 |`False`|`findByActiveFalse()`|`… where x.active = false`
 |`IgnoreCase`|`findByFirstnameIgnoreCase`|`… where UPPER(x.firstame) = UPPER(?1)`

--- a/src/main/asciidoc/new-features.adoc
+++ b/src/main/asciidoc/new-features.adoc
@@ -1,6 +1,13 @@
 [[new-features]]
 = New & Noteworthy
 
+[[new-features.1-11-0]]
+== What's new in Spring Data JPA 1.11
+* Improved compatibility with Hibernate 5.2.
+* Support any-match mode for <<query-by-example>>.
+* Paged query execution optimizations.
+* Support for `exists` projection in repository query derivation.
+
 [[new-features.1-10-0]]
 == What's new in Spring Data JPA 1.10
 

--- a/src/main/java/org/springframework/data/jpa/convert/threetenbp/ThreeTenBackPortJpaConverters.java
+++ b/src/main/java/org/springframework/data/jpa/convert/threetenbp/ThreeTenBackPortJpaConverters.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 the original author or authors.
+ * Copyright 2015-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -44,7 +44,7 @@ import org.threeten.bp.ZoneId;
  * package to be scanned on e.g. the {@link LocalContainerEntityManagerFactoryBean}.
  * 
  * @author Oliver Gierke
- * @see http://www.threeten.org/threetenbp
+ * @see <a href="http://www.threeten.org/threetenbp">http://www.threeten.org/threetenbp</a>
  * @since 1.8
  */
 public class ThreeTenBackPortJpaConverters {

--- a/src/main/java/org/springframework/data/jpa/domain/AbstractPersistable.java
+++ b/src/main/java/org/springframework/data/jpa/domain/AbstractPersistable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2008-2015 the original author or authors.
+ * Copyright 2008-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -60,10 +60,9 @@ public abstract class AbstractPersistable<PK extends Serializable> implements Pe
 	/**
 	 * Must be {@link Transient} in order to ensure that no JPA provider complains because of a missing setter.
 	 * 
-	 * @see DATAJPA-622
 	 * @see org.springframework.data.domain.Persistable#isNew()
 	 */
-	@Transient
+	@Transient // DATAJPA-622
 	public boolean isNew() {
 		return null == getId();
 	}

--- a/src/main/java/org/springframework/data/jpa/provider/HibernateUtils.java
+++ b/src/main/java/org/springframework/data/jpa/provider/HibernateUtils.java
@@ -63,7 +63,7 @@ public abstract class HibernateUtils {
 			queryInterface = ClassUtils.forName("org.hibernate.query.Query", classLoader);
 		} catch (Exception o_O) {}
 
-		HIBERNATE_QUERY_INTERFACE = queryInterface;
+		HIBERNATE_QUERY_INTERFACE = queryInterface == null ? type : queryInterface;
 		QUERY_STRING_METHOD = HIBERNATE_QUERY_INTERFACE == null ? null
 				: ReflectionUtils.findMethod(HIBERNATE_QUERY_INTERFACE, "getQueryString");
 	}
@@ -76,8 +76,13 @@ public abstract class HibernateUtils {
 	 */
 	public static String getHibernateQuery(Object query) {
 
-		if (HIBERNATE_QUERY_INTERFACE != null && HIBERNATE_QUERY_INTERFACE.isInstance(query)) {
+		if (HIBERNATE_QUERY_INTERFACE != null && QUERY_STRING_METHOD != null
+				&& HIBERNATE_QUERY_INTERFACE.isInstance(query)) {
 			return String.class.cast(ReflectionUtils.invokeMethod(QUERY_STRING_METHOD, query));
+		}
+
+		if (HIBERNATE_QUERY_INTERFACE != null && !HIBERNATE_QUERY_INTERFACE.isInstance(query)) {
+			query = ((javax.persistence.Query) query).unwrap(HIBERNATE_QUERY_INTERFACE);
 		}
 
 		return ((Query) ReflectionUtils.invokeMethod(GET_HIBERNATE_QUERY, query)).getQueryString();

--- a/src/main/java/org/springframework/data/jpa/provider/PersistenceProvider.java
+++ b/src/main/java/org/springframework/data/jpa/provider/PersistenceProvider.java
@@ -54,7 +54,7 @@ import org.springframework.util.ReflectionUtils;
  * @author Oliver Gierke
  * @author Thomas Darimont
  */
-public enum PersistenceProvider implements QueryExtractor,ProxyIdAccessor {
+public enum PersistenceProvider implements QueryExtractor, ProxyIdAccessor {
 
 	/**
 	 * Hibernate persistence provider.
@@ -65,8 +65,9 @@ public enum PersistenceProvider implements QueryExtractor,ProxyIdAccessor {
 	 * @see DATAJPA-444
 	 */
 	HIBERNATE(//
-			Arrays.asList(HIBERNATE43_ENTITY_MANAGER_INTERFACE, HIBERNATE_ENTITY_MANAGER_INTERFACE), //
-			Arrays.asList(HIBERNATE43_JPA_METAMODEL_TYPE, HIBERNATE_JPA_METAMODEL_TYPE)) {
+			Arrays.asList(HIBERNATE52_ENTITY_MANAGER_INTERFACE, HIBERNATE43_ENTITY_MANAGER_INTERFACE,
+					HIBERNATE_ENTITY_MANAGER_INTERFACE), //
+			Arrays.asList(HIBERNATE52_JPA_METAMODEL_TYPE, HIBERNATE43_JPA_METAMODEL_TYPE, HIBERNATE_JPA_METAMODEL_TYPE)) {
 
 		public String extractQueryString(Query query) {
 			return HibernateUtils.getHibernateQuery(query);
@@ -124,8 +125,7 @@ public enum PersistenceProvider implements QueryExtractor,ProxyIdAccessor {
 	/**
 	 * EclipseLink persistence provider.
 	 */
-	ECLIPSELINK(Collections.singleton(ECLIPSELINK_ENTITY_MANAGER_INTERFACE),
-			Collections.singleton(ECLIPSELINK_JPA_METAMODEL_TYPE)) {
+	ECLIPSELINK(Collections.singleton(ECLIPSELINK_ENTITY_MANAGER_INTERFACE), Collections.singleton(ECLIPSELINK_JPA_METAMODEL_TYPE)) {
 
 		public String extractQueryString(Query query) {
 			return ((JpaQuery<?>) query).getDatabaseQuery().getJPQLString();
@@ -263,9 +263,11 @@ public enum PersistenceProvider implements QueryExtractor,ProxyIdAccessor {
 		String ECLIPSELINK_ENTITY_MANAGER_INTERFACE = "org.eclipse.persistence.jpa.JpaEntityManager";
 		String HIBERNATE_ENTITY_MANAGER_INTERFACE = "org.hibernate.ejb.HibernateEntityManager";
 		String HIBERNATE43_ENTITY_MANAGER_INTERFACE = "org.hibernate.jpa.HibernateEntityManager";
+		String HIBERNATE52_ENTITY_MANAGER_INTERFACE = "org.hibernate.Session";
 
 		String HIBERNATE_JPA_METAMODEL_TYPE = "org.hibernate.ejb.metamodel.MetamodelImpl";
 		String HIBERNATE43_JPA_METAMODEL_TYPE = "org.hibernate.jpa.internal.metamodel.MetamodelImpl";
+		String HIBERNATE52_JPA_METAMODEL_TYPE = "org.hibernate.metamodel.internal.MetamodelImpl";
 		String ECLIPSELINK_JPA_METAMODEL_TYPE = "org.eclipse.persistence.internal.jpa.metamodel.MetamodelImpl";
 		String OPENJPA_JPA_METAMODEL_TYPE = "org.apache.openjpa.persistence.meta.MetamodelImpl";
 	}

--- a/src/main/java/org/springframework/data/jpa/provider/PersistenceProvider.java
+++ b/src/main/java/org/springframework/data/jpa/provider/PersistenceProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2008-2016 the original author or authors.
+ * Copyright 2008-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -62,7 +62,7 @@ public enum PersistenceProvider implements QueryExtractor, ProxyIdAccessor {
 	 * Since Hibernate 4.3 the location of the HibernateEntityManager moved to the org.hibernate.jpa package. In order to
 	 * support both locations we interpret both classnames as a Hibernate {@code PersistenceProvider}.
 	 * 
-	 * @see DATAJPA-444
+	 * @see <a href="https://jira.spring.io/browse/DATAJPA-444">DATAJPA-444</a>
 	 */
 	HIBERNATE(//
 			Arrays.asList(HIBERNATE52_ENTITY_MANAGER_INTERFACE, HIBERNATE43_ENTITY_MANAGER_INTERFACE,
@@ -77,8 +77,8 @@ public enum PersistenceProvider implements QueryExtractor, ProxyIdAccessor {
 		 * Return custom placeholder ({@code *}) as Hibernate does create invalid queries for count queries for objects with
 		 * compound keys.
 		 * 
-		 * @see HHH-4044
-		 * @see HHH-3096
+		 * @see <a href="https://hibernate.atlassian.net/browse/HHH-4044">HHH-4044</a>
+		 * @see <a href="https://hibernate.atlassian.net/browse/HHH-3096">HHH-3096</a>
 		 */
 		@Override
 		public String getCountQueryPlaceholder() {
@@ -383,7 +383,7 @@ public enum PersistenceProvider implements QueryExtractor, ProxyIdAccessor {
 	 * Potentially converts an empty collection to the appropriate representation of this {@link PersistenceProvider},
 	 * since some JPA providers cannot correctly handle empty collections.
 	 * 
-	 * @see DATAJPA-606
+	 * @see <a href="https://jira.spring.io/browse/DATAJPA-606">DATAJPA-606</a>
 	 * @param collection
 	 * @return
 	 */

--- a/src/main/java/org/springframework/data/jpa/repository/EntityGraph.java
+++ b/src/main/java/org/springframework/data/jpa/repository/EntityGraph.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2016 the original author or authors.
+ * Copyright 2014-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,14 +27,11 @@ import org.springframework.data.jpa.repository.query.JpaQueryMethod;
 
 /**
  * Annotation to configure the JPA 2.1 {@link javax.persistence.EntityGraph}s that should be used on repository methods.
+ * Since 1.9 we support the definition of dynamic {@link EntityGraph}s by allowing to customize the fetch-graph via via
+ * {@link #attributePaths()} ad-hoc fetch-graph configuration.
  * 
- * Since 1.9 we support the definition of dynamic {@link EntityGraph}s by allowing to customize the fetch-graph via 
- * via {@link #attributePaths()} ad-hoc fetch-graph configuration.
- * @author Christoph Strobl
- * 
- * If {@link #attributePaths()} are specified then we ignore the entity-graph name {@link #value()}
- * and treat this {@link EntityGraph} as dynamic.
- * 
+ * @author Christoph Strobl If {@link #attributePaths()} are specified then we ignore the entity-graph name
+ *         {@link #value()} and treat this {@link EntityGraph} as dynamic.
  * @author Thomas Darimont
  * @since 1.6
  */
@@ -44,24 +41,23 @@ import org.springframework.data.jpa.repository.query.JpaQueryMethod;
 public @interface EntityGraph {
 
 	/**
-	 * The name of the EntityGraph to use.
-	 * If empty we fall-back to {@link JpaQueryMethod#getNamedQueryName()} as the value.
+	 * The name of the EntityGraph to use. If empty we fall-back to {@link JpaQueryMethod#getNamedQueryName()} as the
+	 * value.
 	 * 
 	 * @return
 	 */
 	String value() default "";
 
 	/**
-	 * The {@link Type} of the EntityGraph to use, defaults to {@link Type#FETCH}.
+	 * The {@link EntityGraphType} of the EntityGraph to use, defaults to {@link EntityGraphType#FETCH}.
 	 * 
 	 * @return
 	 */
 	EntityGraphType type() default EntityGraphType.FETCH;
-	
+
 	/**
-	 * The paths of attributes of this {@link EntityGraph} to use, empty by default.
-	 * 
-	 * You can refer to direct properties of the entity or nested properties via a {@code property.nestedProperty}. 
+	 * The paths of attributes of this {@link EntityGraph} to use, empty by default. You can refer to direct properties of
+	 * the entity or nested properties via a {@code property.nestedProperty}.
 	 * 
 	 * @return
 	 * @since 1.9
@@ -81,7 +77,8 @@ public @interface EntityGraph {
 		 * by attribute nodes of the entity graph are treated as FetchType.EAGER and attributes that are not specified are
 		 * treated according to their specified or default FetchType.
 		 * 
-		 * @see JPA 2.1 Specification: 3.7.4.2 Load Graph Semantics
+		 * @see <a href="http://download.oracle.com/otn-pub/jcp/persistence-2_1-fr-eval-spec/JavaPersistence.pdf">JPA 2.1
+		 *      Specification: 3.7.4.2 Load Graph Semantics</a>
 		 */
 		LOAD("javax.persistence.loadgraph"),
 
@@ -90,7 +87,8 @@ public @interface EntityGraph {
 		 * by attribute nodes of the entity graph are treated as FetchType.EAGER and attributes that are not specified are
 		 * treated as FetchType.LAZY
 		 * 
-		 * @see JPA 2.1 Specification: 3.7.4.1 Fetch Graph Semantics
+		 * @see <a href="http://download.oracle.com/otn-pub/jcp/persistence-2_1-fr-eval-spec/JavaPersistence.pdf">JPA 2.1
+		 *      Specification: 3.7.4.1 Fetch Graph Semantics</a>
 		 */
 		FETCH("javax.persistence.fetchgraph");
 

--- a/src/main/java/org/springframework/data/jpa/repository/cdi/JpaRepositoryBean.java
+++ b/src/main/java/org/springframework/data/jpa/repository/cdi/JpaRepositoryBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011 the original author or authors.
+ * Copyright 2011-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -54,7 +54,7 @@ class JpaRepositoryBean<T> extends CdiRepositoryBean<T> {
 
 		super(qualifiers, repositoryType, beanManager, detector);
 
-		Assert.notNull(entityManagerBean);
+		Assert.notNull(entityManagerBean, "EntityManager bean must not be null!");
 		this.entityManagerBean = entityManagerBean;
 	}
 

--- a/src/main/java/org/springframework/data/jpa/repository/config/AuditingBeanDefinitionParser.java
+++ b/src/main/java/org/springframework/data/jpa/repository/config/AuditingBeanDefinitionParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2008-2013 the original author or authors.
+ * Copyright 2008-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -80,7 +80,7 @@ public class AuditingBeanDefinitionParser implements BeanDefinitionParser {
 	/**
 	 * Copied code of SpringConfiguredBeanDefinitionParser until this class gets public.
 	 * 
-	 * @see http://jira.springframework.org/browse/SPR-7340
+	 * @see <a href="http://jira.springframework.org/browse/SPR-7340">SPR-7340</a>
 	 * @author Juergen Hoeller
 	 */
 	private static class SpringConfiguredBeanDefinitionParser implements BeanDefinitionParser {

--- a/src/main/java/org/springframework/data/jpa/repository/query/AbstractJpaQuery.java
+++ b/src/main/java/org/springframework/data/jpa/repository/query/AbstractJpaQuery.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2008-2016 the original author or authors.
+ * Copyright 2008-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -48,6 +48,7 @@ import org.springframework.util.Assert;
  * 
  * @author Oliver Gierke
  * @author Thomas Darimont
+ * @author Mark Paluch
  */
 public abstract class AbstractJpaQuery implements RepositoryQuery {
 
@@ -59,13 +60,12 @@ public abstract class AbstractJpaQuery implements RepositoryQuery {
 	 * Creates a new {@link AbstractJpaQuery} from the given {@link JpaQueryMethod}.
 	 * 
 	 * @param method
-	 * @param resultFactory
 	 * @param em
 	 */
 	public AbstractJpaQuery(JpaQueryMethod method, EntityManager em) {
 
-		Assert.notNull(method);
-		Assert.notNull(em);
+		Assert.notNull(method, "JpaQueryMethod must not be null!");
+		Assert.notNull(em, "EntityManager must not be null!");
 
 		this.method = method;
 		this.em = em;

--- a/src/main/java/org/springframework/data/jpa/repository/query/AbstractJpaQuery.java
+++ b/src/main/java/org/springframework/data/jpa/repository/query/AbstractJpaQuery.java
@@ -269,7 +269,7 @@ public abstract class AbstractJpaQuery implements RepositoryQuery {
 
 				Object value = tuple.get(elements.get(0));
 
-				if (type.isInstance(value)) {
+				if (type.isInstance(value) || value == null) {
 					return value;
 				}
 			}

--- a/src/main/java/org/springframework/data/jpa/repository/query/CriteriaQueryParameterBinder.java
+++ b/src/main/java/org/springframework/data/jpa/repository/query/CriteriaQueryParameterBinder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2013 the original author or authors.
+ * Copyright 2011-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,6 +32,7 @@ import org.springframework.util.Assert;
  * 
  * @author Oliver Gierke
  * @author Thomas Darimont
+ * @author Mark Paluch
  */
 class CriteriaQueryParameterBinder extends ParameterBinder {
 
@@ -41,14 +42,15 @@ class CriteriaQueryParameterBinder extends ParameterBinder {
 	 * Creates a new {@link CriteriaQueryParameterBinder} for the given {@link Parameters}, values and some
 	 * {@link javax.persistence.criteria.ParameterExpression}.
 	 * 
-	 * @param parameters
-	 * @param values
-	 * @param expressions
+	 * @param parameters must not be {@literal null}.
+	 * @param values must not be {@literal null}.
+	 * @param expressions must not be {@literal null}.
 	 */
 	CriteriaQueryParameterBinder(JpaParameters parameters, Object[] values, Iterable<ParameterMetadata<?>> expressions) {
 
 		super(parameters, values);
-		Assert.notNull(expressions);
+
+		Assert.notNull(expressions, "Iterable of ParameterMetadata must not be null!");
 		this.expressions = expressions.iterator();
 	}
 

--- a/src/main/java/org/springframework/data/jpa/repository/query/Jpa21Utils.java
+++ b/src/main/java/org/springframework/data/jpa/repository/query/Jpa21Utils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2015 the original author or authors.
+ * Copyright 2014-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -85,7 +85,8 @@ public class Jpa21Utils {
 	/**
 	 * Adds a JPA 2.1 fetch-graph or load-graph hint to the given {@link Query} if running under JPA 2.1.
 	 * 
-	 * @see JPA 2.1 Specfication 3.7.4 - Use of Entity Graphs in find and query operations P.117
+	 * @see <a href="download.oracle.com/otn-pub/jcp/persistence-2_1-fr-eval-spec/JavaPersistence.pdf">JPA 2.1
+	 *      Specfication 3.7.4 - Use of Entity Graphs in find and query operations P.117</a>
 	 * @param em must not be {@literal null}.
 	 * @param jpaEntityGraph must not be {@literal null}.
 	 * @param entityType must not be {@literal null}.

--- a/src/main/java/org/springframework/data/jpa/repository/query/Jpa21Utils.java
+++ b/src/main/java/org/springframework/data/jpa/repository/query/Jpa21Utils.java
@@ -157,9 +157,10 @@ public class Jpa21Utils {
 			// Fast path - just single attribute
 			if (!path.contains(".")) {
 
-				if(findAttributeNode(path, entityGraph) == null) {
+				if (findAttributeNode(path, entityGraph) == null) {
 					entityGraph.addAttributeNodes(path);
 				}
+
 				continue;
 			}
 
@@ -175,26 +176,50 @@ public class Jpa21Utils {
 		}
 	}
 
-	private static Subgraph<?> findOrCreateSubgraph(String attributeNode, EntityGraph<?> entityGraph) {
+	/**
+	 * Returns the {@link Subgraph} with the given name fro the given {@link EntityGraph} or creates a new one if none
+	 * already available.
+	 * 
+	 * @param name
+	 * @param entityGraph
+	 * @return
+	 */
+	private static Subgraph<?> findOrCreateSubgraph(String name, EntityGraph<?> entityGraph) {
 
-		Subgraph<?> subgraph = findSubgraph(attributeNode, entityGraph);
-		return subgraph != null ? subgraph : entityGraph.addSubgraph(attributeNode);
+		Subgraph<?> subgraph = findSubgraph(name, entityGraph);
+
+		return subgraph != null ? subgraph : entityGraph.addSubgraph(name);
 	}
 
-	private static Subgraph<?> findSubgraph(String attributeNode, EntityGraph<?> entityGraph) {
+	/**
+	 * Returns the {@link Subgraph} with the given name from the given {@link EntityGraph}.
+	 * 
+	 * @param name
+	 * @param entityGraph
+	 * @return
+	 */
+	private static Subgraph<?> findSubgraph(String name, EntityGraph<?> entityGraph) {
 
-		AttributeNode<?> node = findAttributeNode(attributeNode, entityGraph);
-		if(node != null && !ObjectUtils.isEmpty(node.getSubgraphs())) {
+		AttributeNode<?> node = findAttributeNode(name, entityGraph);
+
+		if (node != null && !ObjectUtils.isEmpty(node.getSubgraphs())) {
 			return node.getSubgraphs().values().iterator().next();
 		}
 
 		return null;
 	}
 
-	private static AttributeNode<?> findAttributeNode(String attributeNode, EntityGraph<?> entityGraph) {
+	/**
+	 * Returns the {@link AttributeNode} with the given name if present in the given {@link EntityGraph}.
+	 * 
+	 * @param name
+	 * @param entityGraph must not be {@literal null}.
+	 * @return
+	 */
+	private static AttributeNode<?> findAttributeNode(String name, EntityGraph<?> entityGraph) {
 
-		for(AttributeNode<?> node : entityGraph.getAttributeNodes()) {
-			if(ObjectUtils.nullSafeEquals(node.getAttributeName(), attributeNode)) {
+		for (AttributeNode<?> node : entityGraph.getAttributeNodes()) {
+			if (ObjectUtils.nullSafeEquals(node.getAttributeName(), name)) {
 				return node;
 			}
 		}

--- a/src/main/java/org/springframework/data/jpa/repository/query/Jpa21Utils.java
+++ b/src/main/java/org/springframework/data/jpa/repository/query/Jpa21Utils.java
@@ -21,6 +21,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
+import javax.persistence.AttributeNode;
 import javax.persistence.EntityGraph;
 import javax.persistence.EntityManager;
 import javax.persistence.Query;
@@ -28,6 +29,7 @@ import javax.persistence.Subgraph;
 
 import org.springframework.util.Assert;
 import org.springframework.util.ClassUtils;
+import org.springframework.util.ObjectUtils;
 import org.springframework.util.ReflectionUtils;
 import org.springframework.util.StringUtils;
 
@@ -36,6 +38,7 @@ import org.springframework.util.StringUtils;
  * 
  * @author Thomas Darimont
  * @author Oliver Gierke
+ * @author Christoph Strobl
  * @since 1.6
  */
 public class Jpa21Utils {
@@ -153,7 +156,10 @@ public class Jpa21Utils {
 
 			// Fast path - just single attribute
 			if (!path.contains(".")) {
-				entityGraph.addAttributeNodes(path);
+
+				if(findAttributeNode(path, entityGraph) == null) {
+					entityGraph.addAttributeNodes(path);
+				}
 				continue;
 			}
 
@@ -162,10 +168,37 @@ public class Jpa21Utils {
 			Subgraph<?> parent = null;
 
 			for (int c = 0; c < pathComponents.length - 1; c++) {
-				parent = c == 0 ? entityGraph.addSubgraph(pathComponents[c]) : parent.addSubgraph(pathComponents[c]);
+				parent = c == 0 ? findOrCreateSubgraph(pathComponents[c], entityGraph) : parent.addSubgraph(pathComponents[c]);
 			}
 
 			parent.addAttributeNodes(pathComponents[pathComponents.length - 1]);
 		}
+	}
+
+	private static Subgraph<?> findOrCreateSubgraph(String attributeNode, EntityGraph<?> entityGraph) {
+
+		Subgraph<?> subgraph = findSubgraph(attributeNode, entityGraph);
+		return subgraph != null ? subgraph : entityGraph.addSubgraph(attributeNode);
+	}
+
+	private static Subgraph<?> findSubgraph(String attributeNode, EntityGraph<?> entityGraph) {
+
+		AttributeNode<?> node = findAttributeNode(attributeNode, entityGraph);
+		if(node != null && !ObjectUtils.isEmpty(node.getSubgraphs())) {
+			return node.getSubgraphs().values().iterator().next();
+		}
+
+		return null;
+	}
+
+	private static AttributeNode<?> findAttributeNode(String attributeNode, EntityGraph<?> entityGraph) {
+
+		for(AttributeNode<?> node : entityGraph.getAttributeNodes()) {
+			if(ObjectUtils.nullSafeEquals(node.getAttributeName(), attributeNode)) {
+				return node;
+			}
+		}
+
+		return null;
 	}
 }

--- a/src/main/java/org/springframework/data/jpa/repository/query/JpaCountQueryCreator.java
+++ b/src/main/java/org/springframework/data/jpa/repository/query/JpaCountQueryCreator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2008-2013 the original author or authors.
+ * Copyright 2008-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,6 +29,7 @@ import org.springframework.data.repository.query.parser.PartTree;
  * Special {@link JpaQueryCreator} that creates a count projecting query.
  * 
  * @author Oliver Gierke
+ * @author Marc Lefrançois
  */
 public class JpaCountQueryCreator extends JpaQueryCreator {
 
@@ -59,11 +60,16 @@ public class JpaCountQueryCreator extends JpaQueryCreator {
 	 * @see org.springframework.data.jpa.repository.query.JpaQueryCreator#complete(javax.persistence.criteria.Predicate, org.springframework.data.domain.Sort, javax.persistence.criteria.CriteriaQuery, javax.persistence.criteria.CriteriaBuilder, javax.persistence.criteria.Root)
 	 */
 	@Override
-	@SuppressWarnings({ "unchecked", "rawtypes" })
+	@SuppressWarnings("unchecked")
 	protected CriteriaQuery<? extends Object> complete(Predicate predicate, Sort sort,
 			CriteriaQuery<? extends Object> query, CriteriaBuilder builder, Root<?> root) {
 
-		CriteriaQuery<? extends Object> select = query.select((Expression) builder.count(root));
+		CriteriaQuery<? extends Object> select = query.select(getCountQuery(query, builder, root));
 		return predicate == null ? select : select.where(predicate);
+	}
+
+	@SuppressWarnings("rawtypes")
+	private static Expression getCountQuery(CriteriaQuery<?> query, CriteriaBuilder builder, Root<?> root) {
+		return query.isDistinct() ? builder.countDistinct(root) : builder.count(root);
 	}
 }

--- a/src/main/java/org/springframework/data/jpa/repository/query/JpaQueryCreator.java
+++ b/src/main/java/org/springframework/data/jpa/repository/query/JpaQueryCreator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2008-2016 the original author or authors.
+ * Copyright 2008-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -228,8 +228,8 @@ public class JpaQueryCreator extends AbstractQueryCreator<CriteriaQuery<? extend
 		 */
 		public PredicateBuilder(Part part, Root<?> root) {
 
-			Assert.notNull(part);
-			Assert.notNull(root);
+			Assert.notNull(part, "Part must not be null!");
+			Assert.notNull(root, "Root must not be null!");
 			this.part = part;
 			this.root = root;
 		}

--- a/src/main/java/org/springframework/data/jpa/repository/query/JpaQueryCreator.java
+++ b/src/main/java/org/springframework/data/jpa/repository/query/JpaQueryCreator.java
@@ -23,7 +23,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
-import java.util.Set;
 
 import javax.persistence.criteria.CriteriaBuilder;
 import javax.persistence.criteria.CriteriaQuery;
@@ -62,10 +61,10 @@ public class JpaQueryCreator extends AbstractQueryCreator<CriteriaQuery<? extend
 	/**
 	 * Create a new {@link JpaQueryCreator}.
 	 * 
-	 * @param tree
-	 * @param domainClass
-	 * @param accessor
-	 * @param em
+	 * @param tree must not be {@literal null}.
+	 * @param type must not be {@literal null}.
+	 * @param builder must not be {@literal null}.
+	 * @param provider must not be {@literal null}.
 	 */
 	public JpaQueryCreator(PartTree tree, ReturnedType type, CriteriaBuilder builder,
 			ParameterMetadataProvider provider) {
@@ -93,7 +92,8 @@ public class JpaQueryCreator extends AbstractQueryCreator<CriteriaQuery<? extend
 
 		Class<?> typeToRead = type.getTypeToRead();
 
-		return (typeToRead == null || tree.isExistsProjection()) ? builder.createTupleQuery() : builder.createQuery(typeToRead);
+		return typeToRead == null || tree.isExistsProjection() ? builder.createTupleQuery()
+				: builder.createQuery(typeToRead);
 	}
 
 	/**
@@ -168,24 +168,26 @@ public class JpaQueryCreator extends AbstractQueryCreator<CriteriaQuery<? extend
 			}
 
 			query = query.multiselect(selections);
+
 		} else if (tree.isExistsProjection()) {
 
 			if (root.getModel().hasSingleIdAttribute()) {
 
 				SingularAttribute<?, ?> id = root.getModel().getId(root.getModel().getIdType().getJavaType());
 				query = query.multiselect(root.get((SingularAttribute) id).alias(id.getName()));
+
 			} else {
 
 				List<Selection<?>> selections = new ArrayList<Selection<?>>();
 
-				Set<SingularAttribute<?, ?>> idClassAttributes = (Set<SingularAttribute<?, ?>>) root.getModel().getIdClassAttributes();
-
-				for (SingularAttribute<?, ?> attribute : idClassAttributes) {
+				for (SingularAttribute<?, ?> attribute : root.getModel().getIdClassAttributes()) {
 					selections.add(root.get((SingularAttribute) attribute).alias(attribute.getName()));
 				}
+
 				selections.add(root.get((SingularAttribute) id).alias(id.getName()));
 				query = query.multiselect(selections);
 			}
+
 		} else {
 			query = query.select((Root) root);
 		}

--- a/src/main/java/org/springframework/data/jpa/repository/query/JpaQueryCreator.java
+++ b/src/main/java/org/springframework/data/jpa/repository/query/JpaQueryCreator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2008-2015 the original author or authors.
+ * Copyright 2008-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,6 +15,7 @@
  */
 package org.springframework.data.jpa.repository.query;
 
+import static org.springframework.data.jpa.domain.AbstractPersistable_.*;
 import static org.springframework.data.jpa.repository.query.QueryUtils.*;
 import static org.springframework.data.repository.query.parser.Part.Type.*;
 
@@ -22,6 +23,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Set;
 
 import javax.persistence.criteria.CriteriaBuilder;
 import javax.persistence.criteria.CriteriaQuery;
@@ -30,6 +32,7 @@ import javax.persistence.criteria.Path;
 import javax.persistence.criteria.Predicate;
 import javax.persistence.criteria.Root;
 import javax.persistence.criteria.Selection;
+import javax.persistence.metamodel.SingularAttribute;
 
 import org.springframework.data.domain.Sort;
 import org.springframework.data.jpa.repository.query.ParameterMetadataProvider.ParameterMetadata;
@@ -45,6 +48,7 @@ import org.springframework.util.Assert;
  * Query creator to create a {@link CriteriaQuery} from a {@link PartTree}.
  * 
  * @author Oliver Gierke
+ * @author Mark Paluch
  */
 public class JpaQueryCreator extends AbstractQueryCreator<CriteriaQuery<? extends Object>, Predicate> {
 
@@ -53,6 +57,7 @@ public class JpaQueryCreator extends AbstractQueryCreator<CriteriaQuery<? extend
 	private final CriteriaQuery<? extends Object> query;
 	private final ParameterMetadataProvider provider;
 	private final ReturnedType returnedType;
+	private final PartTree tree;
 
 	/**
 	 * Create a new {@link JpaQueryCreator}.
@@ -66,6 +71,7 @@ public class JpaQueryCreator extends AbstractQueryCreator<CriteriaQuery<? extend
 			ParameterMetadataProvider provider) {
 
 		super(tree);
+		this.tree = tree;
 
 		CriteriaQuery<? extends Object> criteriaQuery = createCriteriaQuery(builder, type);
 
@@ -87,7 +93,7 @@ public class JpaQueryCreator extends AbstractQueryCreator<CriteriaQuery<? extend
 
 		Class<?> typeToRead = type.getTypeToRead();
 
-		return typeToRead == null ? builder.createTupleQuery() : builder.createQuery(typeToRead);
+		return (typeToRead == null || tree.isExistsProjection()) ? builder.createTupleQuery() : builder.createQuery(typeToRead);
 	}
 
 	/**
@@ -162,6 +168,24 @@ public class JpaQueryCreator extends AbstractQueryCreator<CriteriaQuery<? extend
 			}
 
 			query = query.multiselect(selections);
+		} else if (tree.isExistsProjection()) {
+
+			if (root.getModel().hasSingleIdAttribute()) {
+
+				SingularAttribute<?, ?> id = root.getModel().getId(root.getModel().getIdType().getJavaType());
+				query = query.multiselect(root.get((SingularAttribute) id).alias(id.getName()));
+			} else {
+
+				List<Selection<?>> selections = new ArrayList<Selection<?>>();
+
+				Set<SingularAttribute<?, ?>> idClassAttributes = (Set<SingularAttribute<?, ?>>) root.getModel().getIdClassAttributes();
+
+				for (SingularAttribute<?, ?> attribute : idClassAttributes) {
+					selections.add(root.get((SingularAttribute) attribute).alias(attribute.getName()));
+				}
+				selections.add(root.get((SingularAttribute) id).alias(id.getName()));
+				query = query.multiselect(selections);
+			}
 		} else {
 			query = query.select((Root) root);
 		}
@@ -172,7 +196,7 @@ public class JpaQueryCreator extends AbstractQueryCreator<CriteriaQuery<? extend
 
 	/**
 	 * Creates a {@link Predicate} from the given {@link Part}.
-	 * 
+	 *
 	 * @param part
 	 * @param root
 	 * @param iterator

--- a/src/main/java/org/springframework/data/jpa/repository/query/JpaQueryExecution.java
+++ b/src/main/java/org/springframework/data/jpa/repository/query/JpaQueryExecution.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2008-2016 the original author or authors.
+ * Copyright 2008-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -71,13 +71,13 @@ public abstract class JpaQueryExecution {
 	 * Executes the given {@link AbstractStringBasedJpaQuery} with the given {@link ParameterBinder}.
 	 * 
 	 * @param query must not be {@literal null}.
-	 * @param binder must not be {@literal null}.
+	 * @param values must not be {@literal null}.
 	 * @return
 	 */
 	public Object execute(AbstractJpaQuery query, Object[] values) {
 
-		Assert.notNull(query);
-		Assert.notNull(values);
+		Assert.notNull(query, "AbstractJpaQuery must not be null!");
+		Assert.notNull(values, "Values must not be null!");
 
 		Object result;
 

--- a/src/main/java/org/springframework/data/jpa/repository/query/JpaQueryExecution.java
+++ b/src/main/java/org/springframework/data/jpa/repository/query/JpaQueryExecution.java
@@ -277,6 +277,20 @@ public abstract class JpaQueryExecution {
 	}
 
 	/**
+	 * {@link Execution} performing an exists check on the query.
+	 *
+	 * @author Mark Paluch
+	 * @since 1.11
+	 */
+	static class ExistsExecution extends JpaQueryExecution {
+
+		@Override
+		protected Object doExecute(AbstractJpaQuery query, Object[] values) {
+			return !query.createQuery(values).getResultList().isEmpty();
+		}
+	}
+
+	/**
 	 * {@link Execution} executing a stored procedure.
 	 * 
 	 * @author Thomas Darimont

--- a/src/main/java/org/springframework/data/jpa/repository/query/JpaQueryMethod.java
+++ b/src/main/java/org/springframework/data/jpa/repository/query/JpaQueryMethod.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2008-2016 the original author or authors.
+ * Copyright 2008-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -52,7 +52,11 @@ import org.springframework.util.StringUtils;
  */
 public class JpaQueryMethod extends QueryMethod {
 
-	// @see JPA 2.0 Specification 2.2 Persistent Fields and Properties Page 23 - Top paragraph.
+	/**
+	 * @see <a href=
+	 *      "http://download.oracle.com/otn-pub/jcp/persistence-2.0-fr-eval-oth-JSpec/persistence-2_0-final-spec.pdf">JPA
+	 *      2.0 Specification 2.2 Persistent Fields and Properties Page 23 - Top paragraph.</a>
+	 */
 	private static final Set<Class<?>> NATIVE_ARRAY_TYPES;
 	private static final StoredProcedureAttributeSource storedProcedureAttributeSource = StoredProcedureAttributeSource.INSTANCE;
 

--- a/src/main/java/org/springframework/data/jpa/repository/query/NamedQuery.java
+++ b/src/main/java/org/springframework/data/jpa/repository/query/NamedQuery.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2008-2014 the original author or authors.
+ * Copyright 2008-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,6 +21,7 @@ import javax.persistence.TypedQuery;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
 import org.springframework.data.jpa.provider.QueryExtractor;
 import org.springframework.data.repository.query.Parameters;
 import org.springframework.data.repository.query.QueryCreationException;
@@ -90,8 +91,8 @@ final class NamedQuery extends AbstractJpaQuery {
 	private static boolean hasNamedQuery(EntityManager em, String queryName) {
 
 		/*
-		 * @see DATAJPA-617
-		 * we have to use a dedicated em for the lookups to avoid a potential rollback of the running tx.
+		 * See DATAJPA-617, we have to use a dedicated em for the lookups to avoid a
+		 * potential rollback of the running tx.
 		 */
 		EntityManager lookupEm = em.getEntityManagerFactory().createEntityManager();
 

--- a/src/main/java/org/springframework/data/jpa/repository/query/ParameterBinder.java
+++ b/src/main/java/org/springframework/data/jpa/repository/query/ParameterBinder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2008-2014 the original author or authors.
+ * Copyright 2008-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,6 +33,7 @@ import org.springframework.util.Assert;
  * 
  * @author Oliver Gierke
  * @author Thomas Darimont
+ * @author Mark Paluch
  */
 public class ParameterBinder {
 
@@ -48,8 +49,8 @@ public class ParameterBinder {
 	 */
 	public ParameterBinder(JpaParameters parameters, Object[] values) {
 
-		Assert.notNull(parameters);
-		Assert.notNull(values);
+		Assert.notNull(parameters, "JpaParameters must not be null!");
+		Assert.notNull(values, "Values must not be null!");
 
 		Assert.isTrue(parameters.getNumberOfParameters() == values.length, "Invalid number of parameters given!");
 

--- a/src/main/java/org/springframework/data/jpa/repository/query/ParameterMetadataProvider.java
+++ b/src/main/java/org/springframework/data/jpa/repository/query/ParameterMetadataProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2016 the original author or authors.
+ * Copyright 2011-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -41,6 +41,7 @@ import org.springframework.util.ObjectUtils;
  * 
  * @author Oliver Gierke
  * @author Thomas Darimont
+ * @author Mark Paluch
  */
 class ParameterMetadataProvider {
 
@@ -144,12 +145,12 @@ class ParameterMetadataProvider {
 	 * @param <T>
 	 * @param part must not be {@literal null}.
 	 * @param type must not be {@literal null}.
-	 * @param name
+	 * @param parameter
 	 * @return
 	 */
 	private <T> ParameterMetadata<T> next(Part part, Class<T> type, Parameter parameter) {
 
-		Assert.notNull(type);
+		Assert.notNull(type, "Type must not be null!");
 
 		/*
 		 * We treat Expression types as Object vales since the real value to be bound as a parameter is determined at query time.
@@ -221,7 +222,7 @@ class ParameterMetadataProvider {
 		 */
 		public Object prepare(Object value) {
 
-			Assert.notNull(value);
+			Assert.notNull(value, "Value must not be null!");
 
 			Class<? extends T> expressionType = expression.getJavaType();
 

--- a/src/main/java/org/springframework/data/jpa/repository/query/PartTreeJpaQuery.java
+++ b/src/main/java/org/springframework/data/jpa/repository/query/PartTreeJpaQuery.java
@@ -26,6 +26,7 @@ import javax.persistence.criteria.CriteriaQuery;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.jpa.provider.PersistenceProvider;
 import org.springframework.data.jpa.repository.query.JpaQueryExecution.DeleteExecution;
+import org.springframework.data.jpa.repository.query.JpaQueryExecution.ExistsExecution;
 import org.springframework.data.jpa.repository.query.ParameterMetadataProvider.ParameterMetadata;
 import org.springframework.data.repository.query.ParametersParameterAccessor;
 import org.springframework.data.repository.query.ResultProcessor;
@@ -94,7 +95,14 @@ public class PartTreeJpaQuery extends AbstractJpaQuery {
 	 */
 	@Override
 	protected JpaQueryExecution getExecution() {
-		return this.tree.isDelete() ? new DeleteExecution(em) : super.getExecution();
+
+		if(this.tree.isDelete()) {
+			return new DeleteExecution(em);
+		} else if(this.tree.isExistsProjection()) {
+			return new ExistsExecution();
+		}
+
+		return super.getExecution();
 	}
 
 	/**
@@ -166,6 +174,10 @@ public class PartTreeJpaQuery extends AbstractJpaQuery {
 				}
 
 				query.setMaxResults(tree.getMaxResults());
+			}
+
+			if(tree.isExistsProjection()) {
+				query.setMaxResults(1);
 			}
 
 			return query;

--- a/src/main/java/org/springframework/data/jpa/repository/query/PartTreeJpaQuery.java
+++ b/src/main/java/org/springframework/data/jpa/repository/query/PartTreeJpaQuery.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2008-2016 the original author or authors.
+ * Copyright 2008-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -184,11 +184,10 @@ public class PartTreeJpaQuery extends AbstractJpaQuery {
 		}
 
 		/**
-		 * Checks whether we are working with a cached {@link CriteriaQuery} and snychronizes the creation of a
+		 * Checks whether we are working with a cached {@link CriteriaQuery} and synchronizes the creation of a
 		 * {@link TypedQuery} instance from it. This is due to non-thread-safety in the {@link CriteriaQuery} implementation
-		 * of some persistence providers (i.e. Hibernate in this case).
+		 * of some persistence providers (i.e. Hibernate in this case), see DATAJPA-396.
 		 * 
-		 * @see DATAJPA-396
 		 * @param criteriaQuery must not be {@literal null}.
 		 * @return
 		 */

--- a/src/main/java/org/springframework/data/jpa/repository/query/QueryUtils.java
+++ b/src/main/java/org/springframework/data/jpa/repository/query/QueryUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2008-2016 the original author or authors.
+ * Copyright 2008-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -69,6 +69,7 @@ import org.springframework.util.StringUtils;
  * @author Thomas Darimont
  * @author Komi Innocent
  * @author Christoph Strobl
+ * @author Mark Paluch
  */
 public abstract class QueryUtils {
 
@@ -221,14 +222,14 @@ public abstract class QueryUtils {
 	/**
 	 * Adds {@literal order by} clause to the JPQL query.
 	 * 
-	 * @param query
+	 * @param query must not be {@literal null} or empty.
 	 * @param sort
 	 * @param alias
 	 * @return
 	 */
 	public static String applySorting(String query, Sort sort, String alias) {
 
-		Assert.hasText(query);
+		Assert.hasText(query, "Query must not be null or empty!");
 
 		if (null == sort || !sort.iterator().hasNext()) {
 			return query;
@@ -356,16 +357,16 @@ public abstract class QueryUtils {
 	 * entities to the query.
 	 * 
 	 * @param <T>
-	 * @param queryString
-	 * @param entities
-	 * @param entityManager
+	 * @param queryString must not be {@literal null}.
+	 * @param entities must not be {@literal null}.
+	 * @param entityManager must not be {@literal null}.
 	 * @return
 	 */
 	public static <T> Query applyAndBind(String queryString, Iterable<T> entities, EntityManager entityManager) {
 
-		Assert.notNull(queryString);
-		Assert.notNull(entities);
-		Assert.notNull(entityManager);
+		Assert.notNull(queryString, "Querystring must not be null!");
+		Assert.notNull(entities, "Iterable of entities must not be null!");
+		Assert.notNull(entityManager, "EntityManager must not be null!");
 
 		Iterator<T> iterator = entities.iterator();
 
@@ -489,8 +490,8 @@ public abstract class QueryUtils {
 			return orders;
 		}
 
-		Assert.notNull(root);
-		Assert.notNull(cb);
+		Assert.notNull(root, "Root must not be null!");
+		Assert.notNull(cb, "CriteriaBuilder must not be null!");
 
 		for (org.springframework.data.domain.Sort.Order order : sort) {
 			orders.add(toJpaOrder(order, root, cb));

--- a/src/main/java/org/springframework/data/jpa/repository/query/StringQuery.java
+++ b/src/main/java/org/springframework/data/jpa/repository/query/StringQuery.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2016 the original author or authors.
+ * Copyright 2013-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,6 +37,7 @@ import org.springframework.util.StringUtils;
  * @author Oliver Gierke
  * @author Thomas Darimont
  * @author Oliver Wehrens
+ * @author Mark Paluch
  */
 class StringQuery {
 
@@ -729,7 +730,7 @@ class StringQuery {
 		 */
 		private static Type getLikeTypeFrom(String expression) {
 
-			Assert.hasText(expression);
+			Assert.hasText(expression, "Expression must not be null or empty!");
 
 			if (expression.matches("%.*%")) {
 				return Type.CONTAINING;

--- a/src/main/java/org/springframework/data/jpa/repository/query/StringQueryParameterBinder.java
+++ b/src/main/java/org/springframework/data/jpa/repository/query/StringQueryParameterBinder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2014 the original author or authors.
+ * Copyright 2013-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -84,7 +84,7 @@ public class StringQueryParameterBinder extends ParameterBinder {
 
 			// We should actually reject parameters unavailable, but as EclipseLink doesn't implement ….getParameter(int) for
 			// native queries correctly we need to fall back to an indexed parameter
-			// @see https://bugs.eclipse.org/bugs/show_bug.cgi?id=427892
+			// see https://bugs.eclipse.org/bugs/show_bug.cgi?id=427892
 
 			return new ParameterBinding(position);
 		}

--- a/src/main/java/org/springframework/data/jpa/repository/support/JpaEntityInformationSupport.java
+++ b/src/main/java/org/springframework/data/jpa/repository/support/JpaEntityInformationSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011 the original author or authors.
+ * Copyright 2011-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,6 +30,7 @@ import org.springframework.util.Assert;
  * Base class for {@link JpaEntityInformation} implementations to share common method implementations.
  * 
  * @author Oliver Gierke
+ * @author Mark Paluch
  */
 public abstract class JpaEntityInformationSupport<T, ID extends Serializable> extends AbstractEntityInformation<T, ID>
 		implements JpaEntityInformation<T, ID> {
@@ -56,8 +57,8 @@ public abstract class JpaEntityInformationSupport<T, ID extends Serializable> ex
 	@SuppressWarnings({ "rawtypes", "unchecked" })
 	public static <T> JpaEntityInformation<T, ?> getEntityInformation(Class<T> domainClass, EntityManager em) {
 
-		Assert.notNull(domainClass);
-		Assert.notNull(em);
+		Assert.notNull(domainClass, "Domain class must not be null!");
+		Assert.notNull(em, "EntityManager must not be null!");
 
 		Metamodel metamodel = em.getMetamodel();
 

--- a/src/main/java/org/springframework/data/jpa/repository/support/JpaMetamodelEntityInformation.java
+++ b/src/main/java/org/springframework/data/jpa/repository/support/JpaMetamodelEntityInformation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2016 the original author or authors.
+ * Copyright 2011-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -64,7 +64,7 @@ public class JpaMetamodelEntityInformation<T, ID extends Serializable> extends J
 
 		super(domainClass);
 
-		Assert.notNull(metamodel);
+		Assert.notNull(metamodel, "Metamodel must not be null!");
 		this.metamodel = metamodel;
 
 		ManagedType<T> type = metamodel.managedType(domainClass);
@@ -210,7 +210,9 @@ public class JpaMetamodelEntityInformation<T, ID extends Serializable> extends J
 	 * @see org.springframework.data.jpa.repository.support.JpaEntityInformation#getCompositeIdAttributeValue(java.io.Serializable, java.lang.String)
 	 */
 	public Object getCompositeIdAttributeValue(Serializable id, String idAttribute) {
-		Assert.isTrue(hasCompositeId());
+		
+		Assert.isTrue(hasCompositeId(), "Model must have a composite Id!");
+		
 		return new DirectFieldAccessFallbackBeanWrapper(id).getPropertyValue(idAttribute);
 	}
 

--- a/src/main/java/org/springframework/data/jpa/repository/support/JpaRepositoryFactory.java
+++ b/src/main/java/org/springframework/data/jpa/repository/support/JpaRepositoryFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2008-2015 the original author or authors.
+ * Copyright 2008-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -38,6 +38,7 @@ import org.springframework.util.Assert;
  * JPA specific generic repository factory.
  * 
  * @author Oliver Gierke
+ * @author Mark Paluch
  */
 public class JpaRepositoryFactory extends RepositoryFactorySupport {
 
@@ -52,7 +53,7 @@ public class JpaRepositoryFactory extends RepositoryFactorySupport {
 	 */
 	public JpaRepositoryFactory(EntityManager entityManager) {
 
-		Assert.notNull(entityManager);
+		Assert.notNull(entityManager, "EntityManager must not be null!");
 
 		this.entityManager = entityManager;
 		this.extractor = PersistenceProvider.fromEntityManager(entityManager);

--- a/src/main/java/org/springframework/data/jpa/repository/support/JpaRepositoryFactoryBean.java
+++ b/src/main/java/org/springframework/data/jpa/repository/support/JpaRepositoryFactoryBean.java
@@ -34,10 +34,19 @@ import org.springframework.util.Assert;
  * @author Eberhard Wolff
  * @param <T> the type of the repository
  */
-public class JpaRepositoryFactoryBean<T extends Repository<S, ID>, S, ID extends Serializable> extends
-		TransactionalRepositoryFactoryBeanSupport<T, S, ID> {
+public class JpaRepositoryFactoryBean<T extends Repository<S, ID>, S, ID extends Serializable>
+		extends TransactionalRepositoryFactoryBeanSupport<T, S, ID> {
 
 	private EntityManager entityManager;
+
+	/**
+	 * Creates a new {@link JpaRepositoryFactoryBean} for the given repository interface.
+	 * 
+	 * @param repositoryInterface must not be {@literal null}.
+	 */
+	public JpaRepositoryFactoryBean(Class<? extends T> repositoryInterface) {
+		super(repositoryInterface);
+	}
 
 	/**
 	 * The {@link EntityManager} to be used.

--- a/src/main/java/org/springframework/data/jpa/repository/support/QueryDslRepositorySupport.java
+++ b/src/main/java/org/springframework/data/jpa/repository/support/QueryDslRepositorySupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011 the original author or authors.
+ * Copyright 2011-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,6 +35,7 @@ import com.querydsl.jpa.impl.JPAUpdateClause;
  * Base class for implementing repositories using QueryDsl library.
  * 
  * @author Oliver Gierke
+ * @author Mark Paluch
  */
 @Repository
 public abstract class QueryDslRepositorySupport {
@@ -50,7 +51,8 @@ public abstract class QueryDslRepositorySupport {
 	 * @param domainClass must not be {@literal null}.
 	 */
 	public QueryDslRepositorySupport(Class<?> domainClass) {
-		Assert.notNull(domainClass);
+
+		Assert.notNull(domainClass, "Domain class must not be null!");
 		this.builder = new PathBuilderFactory().create(domainClass);
 	}
 
@@ -62,7 +64,7 @@ public abstract class QueryDslRepositorySupport {
 	@PersistenceContext
 	public void setEntityManager(EntityManager entityManager) {
 
-		Assert.notNull(entityManager);
+		Assert.notNull(entityManager, "EntityManager must not be null!");
 		this.querydsl = new Querydsl(entityManager, builder);
 		this.entityManager = entityManager;
 	}
@@ -88,7 +90,7 @@ public abstract class QueryDslRepositorySupport {
 	/**
 	 * Returns a fresh {@link JPQLQuery}.
 	 * 
-	 * @param path must not be {@literal null}.
+	 * @param paths must not be {@literal null}.
 	 * @return the Querydsl {@link JPQLQuery}.
 	 */
 	protected JPQLQuery<Object> from(EntityPath<?>... paths) {

--- a/src/main/java/org/springframework/data/jpa/repository/support/Querydsl.java
+++ b/src/main/java/org/springframework/data/jpa/repository/support/Querydsl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2014 the original author or authors.
+ * Copyright 2012-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -46,6 +46,7 @@ import com.querydsl.jpa.impl.JPAQuery;
  * 
  * @author Oliver Gierke
  * @author Thomas Darimont
+ * @author Mark Paluch
  */
 public class Querydsl {
 
@@ -61,8 +62,8 @@ public class Querydsl {
 	 */
 	public Querydsl(EntityManager em, PathBuilder<?> builder) {
 
-		Assert.notNull(em);
-		Assert.notNull(builder);
+		Assert.notNull(em, "EntityManager must not be null!");
+		Assert.notNull(builder, "PathBuilder must not be null!");
 
 		this.em = em;
 		this.provider = PersistenceProvider.fromEntityManager(em);

--- a/src/main/java/org/springframework/data/jpa/repository/support/SimpleJpaRepository.java
+++ b/src/main/java/org/springframework/data/jpa/repository/support/SimpleJpaRepository.java
@@ -92,8 +92,8 @@ public class SimpleJpaRepository<T, ID extends Serializable>
 	 */
 	public SimpleJpaRepository(JpaEntityInformation<T, ?> entityInformation, EntityManager entityManager) {
 
-		Assert.notNull(entityInformation);
-		Assert.notNull(entityManager);
+		Assert.notNull(entityInformation, "JpaEntityInformation must not be null!");
+		Assert.notNull(entityManager, "EntityManager must not be null!");
 
 		this.entityInformation = entityInformation;
 		this.em = entityManager;
@@ -705,8 +705,9 @@ public class SimpleJpaRepository<T, ID extends Serializable>
 	private <S, U extends T> Root<U> applySpecificationToCriteria(Specification<U> spec, Class<U> domainClass,
 			CriteriaQuery<S> query) {
 
-		Assert.notNull(query);
-		Assert.notNull(domainClass);
+		Assert.notNull(domainClass, "Domain class must not be null!");
+		Assert.notNull(query, "CriteriaQuery must not be null!");
+
 		Root<U> root = query.from(domainClass);
 
 		if (spec == null) {
@@ -752,7 +753,7 @@ public class SimpleJpaRepository<T, ID extends Serializable>
 	 */
 	private static Long executeCountQuery(TypedQuery<Long> query) {
 
-		Assert.notNull(query);
+		Assert.notNull(query, "TypedQuery must not be null!");
 
 		List<Long> totals = query.getResultList();
 		Long total = 0L;

--- a/src/main/java/org/springframework/data/jpa/repository/support/SimpleJpaRepository.java
+++ b/src/main/java/org/springframework/data/jpa/repository/support/SimpleJpaRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2008-2016 the original author or authors.
+ * Copyright 2008-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -769,7 +769,7 @@ public class SimpleJpaRepository<T, ID extends Serializable>
 	 * {@link SimpleJpaRepository#findAll(Iterable)}. Workaround for OpenJPA not binding collections to in-clauses
 	 * correctly when using by-name binding.
 	 * 
-	 * @see https://issues.apache.org/jira/browse/OPENJPA-2018?focusedCommentId=13924055
+	 * @see <a href="https://issues.apache.org/jira/browse/OPENJPA-2018?focusedCommentId=13924055">OPENJPA-2018</a>
 	 * @author Oliver Gierke
 	 */
 	@SuppressWarnings("rawtypes")

--- a/src/main/java/org/springframework/data/jpa/support/ClasspathScanningPersistenceUnitPostProcessor.java
+++ b/src/main/java/org/springframework/data/jpa/support/ClasspathScanningPersistenceUnitPostProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2015 the original author or authors.
+ * Copyright 2011-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -152,7 +152,7 @@ public class ClasspathScanningPersistenceUnitPostProcessor
 		 * Note that we cannot use File.pathSeparator here since resourcePath uses a forward slash path ('/') separator 
 		 * being an URI, while basePackagePathComponent has system dependent separator (on windows it's the backslash separator). 
 		 * 
-		 * @see DATAJPA-407  
+		 * See DATAJPA-407.
 		 */
 		char slash = '/';
 		String basePackagePathComponent = basePackage.replace('.', slash);
@@ -182,11 +182,10 @@ public class ClasspathScanningPersistenceUnitPostProcessor
 
 	/**
 	 * Returns the path from the given {@link URI}. In case the given {@link URI} is opaque, e.g. beginning with jar:file,
-	 * the path is extracted from URI by leaving out the protocol prefix.
+	 * the path is extracted from URI by leaving out the protocol prefix, see DATAJPA-519.
 	 * 
 	 * @param uri
 	 * @return
-	 * @see DATAJPA-519
 	 */
 	private static String getResourcePath(URI uri) throws IOException {
 

--- a/src/main/java/org/springframework/data/jpa/util/BeanDefinitionUtils.java
+++ b/src/main/java/org/springframework/data/jpa/util/BeanDefinitionUtils.java
@@ -127,7 +127,8 @@ public class BeanDefinitionUtils {
 			if (!EntityManagerFactory.class.getName().equals(definition.getPropertyValues().get("expectedType"))) {
 				return;
 			}
-		} else if (!EntityManagerFactory.class.equals(beanFactory.getType(name))) {
+		} else if (beanFactory.getType(name) == null
+				|| !EntityManagerFactory.class.isAssignableFrom(beanFactory.getType(name))) {
 			return;
 		}
 

--- a/src/main/java/org/springframework/data/jpa/util/JpaMetamodel.java
+++ b/src/main/java/org/springframework/data/jpa/util/JpaMetamodel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 the original author or authors.
+ * Copyright 2016-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -66,7 +66,7 @@ public class JpaMetamodel {
 	 * {@literal null} for calls to {@link ManagedType#getJavaType()}.
 	 * 
 	 * @return all managed types.
-	 * @see https://hibernate.atlassian.net/browse/HHH-10968
+	 * @see <a href="https://hibernate.atlassian.net/browse/HHH-10968">HHH-10968</a>
 	 */
 	private Collection<Class<?>> getManagedTypes() {
 

--- a/src/main/resources/META-INF/spring.factories
+++ b/src/main/resources/META-INF/spring.factories
@@ -1,0 +1,1 @@
+org.springframework.data.repository.core.support.RepositoryFactorySupport=org.springframework.data.jpa.repository.support.JpaRepositoryFactory

--- a/src/main/resources/changelog.txt
+++ b/src/main/resources/changelog.txt
@@ -1,6 +1,18 @@
 Spring Data JPA Changelog
 =========================
 
+Changes in version 1.11.0.RELEASE (2017-01-26)
+----------------------------------------------
+* DATAJPA-1049 - Update "what’s new" section in reference documentation.
+* DATAJPA-1048 - Upgrade Hibernate 5.2 build profile to 5.2.7.
+* DATAJPA-1044 - Bug in JpaCountQueryCreator when doing Paged execution of a Query that uses the Distinct Keyword.
+* DATAJPA-1043 - Update project documentation with the CLA tool integration.
+* DATAJPA-1042 - Migrate ticket references in test code to Spring Framework style.
+* DATAJPA-1041 - Dynamic entity graphs may omit subgraphs.
+* DATAJPA-1031 - Release 1.11 GA (Ingalls).
+* DATAJPA-1005 - Error bootstrapping Spring Data JPA with EntityManagerFactory already semi-initialized.
+
+
 Changes in version 1.10.6.RELEASE (2016-12-21)
 ----------------------------------------------
 * DATAJPA-1029 - JpaQueryCreator should deduplicate multi-select selections.

--- a/src/main/resources/changelog.txt
+++ b/src/main/resources/changelog.txt
@@ -1,6 +1,40 @@
 Spring Data JPA Changelog
 =========================
 
+Changes in version 1.11.0.RC1 (2016-12-21)
+------------------------------------------
+* DATAJPA-1029 - JpaQueryCreator should deduplicate multi-select selections.
+* DATAJPA-1027 - Upgrade to a newer JDK version on TravisCI.
+* DATAJPA-1026 - Adapt API in RepositoryFactoryBeanSupport implementation.
+* DATAJPA-1023 - Reject stream executions if not executed within transaction.
+* DATAJPA-1021 - Make sure builds against Spring 5 skip tests for OpenJPA.
+* DATAJPA-1019 - Make sure build runs on Hibernate 5.
+* DATAJPA-1018 - Upgrade Hibernate build profile to latest releases.
+* DATAJPA-1017 - Make sure tests work on Spring 5.
+* DATAJPA-1014 - Register repository factory in spring.factories for multi-store support.
+* DATAJPA-1000 - Pageable With Fetch not returning the right alias Name.
+* DATAJPA-993 - Improve infrastructure setup example in reference documentation.
+* DATAJPA-992 - Fix package name in JavaDoc of AuditingEntityListener.
+* DATAJPA-984 - JPA projection query returning single non-standard JPA type results in "No aliases found in result tuple" error.
+* DATAJPA-978 - Upgrade Hibernate 5.2 build profile to 5.2.4.
+* DATAJPA-974 - Projections referring to collection attributes don't create a proper selection (missing joins).
+* DATAJPA-970 - Ensure JDK 6 compatibility of regular expression used in QueryUtils.
+* DATAJPA-965 - Mapping Sort instances to ORDER BY expressions should be restricted to fields for manually defined queries.
+* DATAJPA-962 - Update Travis configuration with build profiles for Spring 5.
+* DATAJPA-960 - Order by clause not created correctly if a manually defined query is not using an alias.
+* DATAJPA-956 - Error creating DefaultJpaContext bean with a non-EntityManagerFactory JndiObjectFactoryBean defined via JavaConfig.
+* DATAJPA-953 - Fix typo in reference documentation.
+* DATAJPA-951 - Projections not handled correctly when Optional is used as wrapping return type.
+* DATAJPA-950 - Upgrade Hibernate 5 build profile to 5.2.2.
+* DATAJPA-941 - JpaClassUtils.isOfType performance improvement.
+* DATAJPA-939 - Release 1.11 RC1 (Ingalls).
+* DATAJPA-938 - Complex select clauses in manually declared query using constructor expressions fail.
+* DATAJPA-920 - Add support for exists projection in repository query derivation.
+* DATAJPA-914 - findAll with Iterable parameter gives JpaSystemException when using Hibernate 5.2.
+* DATAJPA-911 - Assert compatibility with Hibernate 5.2.
+* DATAJPA-790 - org.hibernate.QueryException when applying @EntityGraph on (Querydsl) findAll(Predicate, Pageable) method.
+
+
 Changes in version 2.0.0.M1 (2016-11-23)
 ----------------------------------------
 * DATAJPA-998 - Set up 2.0 development.

--- a/src/main/resources/changelog.txt
+++ b/src/main/resources/changelog.txt
@@ -1,6 +1,12 @@
 Spring Data JPA Changelog
 =========================
 
+Changes in version 2.0.0.M1 (2016-11-23)
+----------------------------------------
+* DATAJPA-998 - Set up 2.0 development.
+* DATAJPA-997 - Release 2.0 M1 (Kay).
+
+
 Changes in version 1.10.5.RELEASE (2016-11-03)
 ----------------------------------------------
 * DATAJPA-993 - Improve infrastructure setup example in reference documentation.

--- a/src/main/resources/changelog.txt
+++ b/src/main/resources/changelog.txt
@@ -1,6 +1,21 @@
 Spring Data JPA Changelog
 =========================
 
+Changes in version 1.10.6.RELEASE (2016-12-21)
+----------------------------------------------
+* DATAJPA-1029 - JpaQueryCreator should deduplicate multi-select selections.
+* DATAJPA-1024 - Querrying empty table for non-standard JPA type results in IllegalStateExcepion with the message "No aliases found in result tuple".
+* DATAJPA-1022 - Drop Travis CI build profile for Spring 5 for Hopper.
+* DATAJPA-1021 - Make sure builds against Spring 5 skip tests for OpenJPA.
+* DATAJPA-1020 - Tweak Travis build against Hibernate 5.2 to run on Spring 4.3.
+* DATAJPA-1019 - Make sure build runs on Hibernate 5.
+* DATAJPA-1018 - Upgrade Hibernate build profile to latest releases.
+* DATAJPA-1000 - Pageable With Fetch not returning the right alias Name.
+* DATAJPA-994 - Release 1.10.6 (Hopper SR6).
+* DATAJPA-914 - findAll with Iterable parameter gives JpaSystemException when using Hibernate 5.2.
+* DATAJPA-911 - Assert compatibility with Hibernate 5.2.
+
+
 Changes in version 1.11.0.RC1 (2016-12-21)
 ------------------------------------------
 * DATAJPA-1029 - JpaQueryCreator should deduplicate multi-select selections.

--- a/src/main/resources/notice.txt
+++ b/src/main/resources/notice.txt
@@ -1,4 +1,4 @@
-Spring Data JPA 1.11 M1
+Spring Data JPA 1.11 RC1
 Copyright (c) [2011-2015] Pivotal Software, Inc.
 
 This product is licensed to you under the Apache License, Version 2.0 (the "License").

--- a/src/main/resources/notice.txt
+++ b/src/main/resources/notice.txt
@@ -1,4 +1,4 @@
-Spring Data JPA 1.11 RC1
+Spring Data JPA 1.11 GA
 Copyright (c) [2011-2015] Pivotal Software, Inc.
 
 This product is licensed to you under the Apache License, Version 2.0 (the "License").

--- a/src/test/java/org/springframework/data/jpa/convert/QueryByExamplePredicateBuilderUnitTests.java
+++ b/src/test/java/org/springframework/data/jpa/convert/QueryByExamplePredicateBuilderUnitTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 the original author or authors.
+ * Copyright 2016-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -116,42 +116,27 @@ public class QueryByExamplePredicateBuilderUnitTests {
 		doReturn(orPredicate).when(cb).or(Matchers.<Predicate>anyVararg());
 	}
 
-	/**
-	 * @see DATAJPA-218
-	 */
-	@Test(expected = IllegalArgumentException.class)
+	@Test(expected = IllegalArgumentException.class) // DATAJPA-218
 	public void getPredicateShouldThrowExceptionOnNullRoot() {
 		QueryByExamplePredicateBuilder.getPredicate(null, cb, of(new Person()));
 	}
 
-	/**
-	 * @see DATAJPA-218
-	 */
-	@Test(expected = IllegalArgumentException.class)
+	@Test(expected = IllegalArgumentException.class) // DATAJPA-218
 	public void getPredicateShouldThrowExceptionOnNullCriteriaBuilder() {
 		QueryByExamplePredicateBuilder.getPredicate(root, null, of(new Person()));
 	}
 
-	/**
-	 * @see DATAJPA-218
-	 */
-	@Test(expected = IllegalArgumentException.class)
+	@Test(expected = IllegalArgumentException.class) // DATAJPA-218
 	public void getPredicateShouldThrowExceptionOnNullExample() {
 		QueryByExamplePredicateBuilder.getPredicate(root, null, null);
 	}
 
-	/**
-	 * @see DATAJPA-218
-	 */
-	@Test
+	@Test // DATAJPA-218
 	public void emptyCriteriaListShouldResultTruePredicate() {
 		assertThat(QueryByExamplePredicateBuilder.getPredicate(root, cb, of(new Person())), equalTo(truePredicate));
 	}
 
-	/**
-	 * @see DATAJPA-218
-	 */
-	@Test
+	@Test // DATAJPA-218
 	public void singleElementCriteriaShouldJustReturnIt() {
 
 		Person p = new Person();
@@ -161,10 +146,7 @@ public class QueryByExamplePredicateBuilderUnitTests {
 		verify(cb, times(1)).equal(any(Expression.class), eq("foo"));
 	}
 
-	/**
-	 * @see DATAJPA-937
-	 */
-	@Test
+	@Test // DATAJPA-937
 	public void unresolvableNestedAssociatedPathShouldFail() {
 
 		Person p = new Person();
@@ -178,10 +160,7 @@ public class QueryByExamplePredicateBuilderUnitTests {
 		QueryByExamplePredicateBuilder.getPredicate(root, cb, of(p));
 	}
 
-	/**
-	 * @see DATAJPA-218
-	 */
-	@Test
+	@Test // DATAJPA-218
 	public void multiPredicateCriteriaShouldReturnCombinedOnes() {
 
 		Person p = new Person();
@@ -194,10 +173,7 @@ public class QueryByExamplePredicateBuilderUnitTests {
 		verify(cb, times(1)).equal(any(Expression.class), eq(2L));
 	}
 
-	/**
-	 * @see DATAJPA-879
-	 */
-	@Test
+	@Test // DATAJPA-879
 	public void orConcatenatesPredicatesIfMatcherSpecifies() {
 
 		Person person = new Person();

--- a/src/test/java/org/springframework/data/jpa/convert/threeten/Jsr310JpaConvertersIntegrationTests.java
+++ b/src/test/java/org/springframework/data/jpa/convert/threeten/Jsr310JpaConvertersIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2015 the original author or authors.
+ * Copyright 2014-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -55,10 +55,7 @@ public class Jsr310JpaConvertersIntegrationTests extends AbstractAttributeConver
 
 	@PersistenceContext EntityManager em;
 
-	/**
-	 * @see DATAJPA-650
-	 */
-	@Test
+	@Test // DATAJPA-650
 	public void usesJsr310JpaConverters() {
 
 		assumeTrue(currentEntityManagerIsAJpa21EntityManager(em));

--- a/src/test/java/org/springframework/data/jpa/convert/threetenbp/ThreeTenBackPortJpaConvertersIntegrationTests.java
+++ b/src/test/java/org/springframework/data/jpa/convert/threetenbp/ThreeTenBackPortJpaConvertersIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 the original author or authors.
+ * Copyright 2015-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -55,10 +55,7 @@ public class ThreeTenBackPortJpaConvertersIntegrationTests extends AbstractAttri
 
 	@PersistenceContext EntityManager em;
 
-	/**
-	 * @see DATAJPA-650
-	 */
-	@Test
+	@Test // DATAJPA-650
 	public void usesThreeTenBackPortJpaConverters() {
 
 		assumeTrue(currentEntityManagerIsAJpa21EntityManager(em));

--- a/src/test/java/org/springframework/data/jpa/domain/JpaSortTests.java
+++ b/src/test/java/org/springframework/data/jpa/domain/JpaSortTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2016 the original author or authors.
+ * Copyright 2013-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -45,7 +45,6 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
  * but only after they've been enhanced by the persistence provider. This requires an {@link EntityManagerFactory} to be
  * bootstrapped.
  * 
- * @see DATAJPA-12
  * @author Thomas Darimont
  * @author Oliver Gierke
  * @author Christoph Strobl
@@ -60,126 +59,108 @@ public class JpaSortTests {
 	private static final PluralAttribute<?, ?, ?> NULL_PLURAL_ATTRIBUTE = null;
 	private static final PluralAttribute<?, ?, ?>[] EMPTY_PLURAL_ATTRIBUTES = new PluralAttribute<?, ?, ?>[0];
 
-	@Test(expected = IllegalArgumentException.class)
+	@Test(expected = IllegalArgumentException.class) // DATAJPA-12
 	public void rejectsNullAttribute() {
 		new JpaSort(NULL_ATTRIBUTE);
 	}
 
-	@Test(expected = IllegalArgumentException.class)
+	@Test(expected = IllegalArgumentException.class) // DATAJPA-12
 	public void rejectsEmptyAttributes() {
 		new JpaSort(EMPTY_ATTRIBUTES);
 	}
 
-	@Test(expected = IllegalArgumentException.class)
+	@Test(expected = IllegalArgumentException.class) // DATAJPA-12
 	public void rejectsNullPluralAttribute() {
 		new JpaSort(NULL_PLURAL_ATTRIBUTE);
 	}
 
-	@Test(expected = IllegalArgumentException.class)
+	@Test(expected = IllegalArgumentException.class) // DATAJPA-12
 	public void rejectsEmptyPluralAttributes() {
 		new JpaSort(EMPTY_PLURAL_ATTRIBUTES);
 	}
 
-	@Test
+	@Test // DATAJPA-12
 	public void sortBySinglePropertyWithDefaultSortDirection() {
 		assertThat(new JpaSort(path(User_.firstname)), hasItems(new Sort.Order("firstname")));
 	}
 
-	@Test
+	@Test // DATAJPA-12
 	public void sortByMultiplePropertiesWithDefaultSortDirection() {
 		assertThat(new JpaSort(User_.firstname, User_.lastname), hasItems(new Order("firstname"), new Order("lastname")));
 	}
 
-	@Test
+	@Test // DATAJPA-12
 	public void sortByMultiplePropertiesWithDescSortDirection() {
 
 		assertThat(new JpaSort(DESC, User_.firstname, User_.lastname),
 				hasItems(new Order(DESC, "firstname"), new Order(Direction.DESC, "lastname")));
 	}
 
-	@Test
+	@Test // DATAJPA-12
 	public void combiningSortByMultipleProperties() {
 
 		assertThat(new JpaSort(User_.firstname).and(new JpaSort(User_.lastname)),
 				hasItems(new Order("firstname"), new Order("lastname")));
 	}
 
-	@Test
+	@Test // DATAJPA-12
 	public void combiningSortByMultiplePropertiesWithDifferentSort() {
 
 		assertThat(new JpaSort(User_.firstname).and(new JpaSort(DESC, User_.lastname)),
 				hasItems(new Order("firstname"), new Order(DESC, "lastname")));
 	}
 
-	@Test
+	@Test // DATAJPA-12
 	public void combiningSortByNestedEmbeddedProperty() {
 		assertThat(new JpaSort(path(User_.address).dot(Address_.streetName)), hasItems(new Order("address.streetName")));
 	}
 
-	@Test
+	@Test // DATAJPA-12
 	public void buildJpaSortFromJpaMetaModelSingleAttribute() {
 
 		assertThat(new JpaSort(ASC, path(User_.firstname)), //
 				hasItems(new Order("firstname")));
 	}
 
-	@Test
+	@Test // DATAJPA-12
 	public void buildJpaSortFromJpaMetaModelNestedAttribute() {
 
 		assertThat(new JpaSort(ASC, path(MailMessage_.mailSender).dot(MailSender_.name)), //
 				hasItems(new Order("mailSender.name")));
 	}
 
-	/**
-	 * @see DATAJPA-702
-	 */
-	@Test
+	@Test // DATAJPA-702
 	public void combiningSortByMultiplePropertiesWithDifferentSortUsingSimpleAnd() {
 
 		assertThat(new JpaSort(User_.firstname).and(DESC, User_.lastname),
 				contains(new Order("firstname"), new Order(DESC, "lastname")));
 	}
 
-	/**
-	 * @see DATAJPA-702
-	 */
-	@Test
+	@Test // DATAJPA-702
 	public void combiningSortByMultiplePathsWithDifferentSortUsingSimpleAnd() {
 
 		assertThat(new JpaSort(User_.firstname).and(DESC, path(MailMessage_.mailSender).dot(MailSender_.name)),
 				contains(new Order("firstname"), new Order(DESC, "mailSender.name")));
 	}
 
-	/**
-	 * @see DATAJPA-702
-	 */
-	@Test(expected = IllegalArgumentException.class)
+	@Test(expected = IllegalArgumentException.class) // DATAJPA-702
 	public void rejectsNullAttributesForCombiningCriterias() {
 		new JpaSort(User_.firstname).and(DESC, (Attribute<?, ?>[]) null);
 	}
 
-	/**
-	 * @see DATAJPA-702
-	 */
-	@Test(expected = IllegalArgumentException.class)
+	@Test(expected = IllegalArgumentException.class) // DATAJPA-702
 	public void rejectsNullPathsForCombiningCriterias() {
 		new JpaSort(User_.firstname).and(DESC, (Path<?, ?>[]) null);
 	}
 
-	/**
-	 * @see DATAJPA-702
-	 */
-	@Test
+	@Test // DATAJPA-702
 	public void buildsUpPathForPluralAttributesCorrectly() {
 
 		assertThat(new JpaSort(path(User_.colleagues).dot(User_.roles).dot(Role_.name)), //
 				hasItem(new Order(ASC, "colleagues.roles.name")));
 	}
 
-	/**
-	 * @see DATAJPA-???
-	 */
-	@Test
+	@Test // DATAJPA-965
 	public void createsUnsafeSortCorrectly() {
 
 		JpaSort sort = JpaSort.unsafe(DESC, "foo.bar");
@@ -188,10 +169,7 @@ public class JpaSortTests {
 		assertThat(sort.getOrderFor("foo.bar"), is(instanceOf(JpaOrder.class)));
 	}
 
-	/**
-	 * @see DATAJPA-???
-	 */
-	@Test
+	@Test // DATAJPA-965
 	public void createsUnsafeSortWithMultiplePropertiesCorrectly() {
 
 		JpaSort sort = JpaSort.unsafe(DESC, "foo.bar", "spring.data");
@@ -201,10 +179,7 @@ public class JpaSortTests {
 		assertThat(sort.getOrderFor("spring.data"), is(instanceOf(JpaOrder.class)));
 	}
 
-	/**
-	 * @see DATAJPA-???
-	 */
-	@Test
+	@Test // DATAJPA-965
 	public void combinesSafeAndUnsafeSortCorrectly() {
 
 		JpaSort sort = new JpaSort(path(User_.colleagues).dot(User_.roles).dot(Role_.name)).andUnsafe(DESC, "foo.bar");
@@ -214,10 +189,7 @@ public class JpaSortTests {
 		assertThat(sort.getOrderFor("foo.bar"), is(instanceOf(JpaOrder.class)));
 	}
 
-	/**
-	 * @see DATAJPA-???
-	 */
-	@Test
+	@Test // DATAJPA-965
 	public void combinesUnsafeAndSafeSortCorrectly() {
 
 		Sort sort = JpaSort.unsafe(DESC, "foo.bar").and(ASC, path(User_.colleagues).dot(User_.roles).dot(Role_.name));

--- a/src/test/java/org/springframework/data/jpa/domain/SpecificationsUnitTests.java
+++ b/src/test/java/org/springframework/data/jpa/domain/SpecificationsUnitTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2014 the original author or authors.
+ * Copyright 2013-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -57,10 +57,7 @@ public class SpecificationsUnitTests {
 		when(mockSpec.toPredicate(root, query, builder)).thenReturn(predicate);
 	}
 
-	/**
-	 * @see DATAJPA-300
-	 */
-	@Test
+	@Test // DATAJPA-300
 	public void createsSpecificationsFromNull() {
 
 		Specifications<Object> specification = where(null);
@@ -68,10 +65,7 @@ public class SpecificationsUnitTests {
 		assertThat(specification.toPredicate(root, query, builder), is(nullValue()));
 	}
 
-	/**
-	 * @see DATAJPA-300
-	 */
-	@Test
+	@Test // DATAJPA-300
 	public void negatesNullSpecToNull() {
 
 		Specifications<Object> specification = not((Specification<Object>) null);
@@ -80,10 +74,7 @@ public class SpecificationsUnitTests {
 		assertThat(specification.toPredicate(root, query, builder), is(nullValue()));
 	}
 
-	/**
-	 * @see DATAJPA-300
-	 */
-	@Test
+	@Test // DATAJPA-300
 	public void andConcatenatesSpecToNullSpec() {
 
 		Specifications<Object> specification = where(null);
@@ -93,10 +84,7 @@ public class SpecificationsUnitTests {
 		assertThat(specification.toPredicate(root, query, builder), is(predicate));
 	}
 
-	/**
-	 * @see DATAJPA-300
-	 */
-	@Test
+	@Test // DATAJPA-300
 	public void andConcatenatesNullSpecToSpec() {
 
 		Specifications<Object> specification = where(mockSpec);
@@ -106,10 +94,7 @@ public class SpecificationsUnitTests {
 		assertThat(specification.toPredicate(root, query, builder), is(predicate));
 	}
 
-	/**
-	 * @see DATAJPA-300
-	 */
-	@Test
+	@Test // DATAJPA-300
 	public void orConcatenatesSpecToNullSpec() {
 
 		Specifications<Object> specification = where(null);
@@ -119,10 +104,7 @@ public class SpecificationsUnitTests {
 		assertThat(specification.toPredicate(root, query, builder), is(predicate));
 	}
 
-	/**
-	 * @see DATAJPA-300
-	 */
-	@Test
+	@Test // DATAJPA-300
 	public void orConcatenatesNullSpecToSpec() {
 
 		Specifications<Object> specification = where(mockSpec);
@@ -132,10 +114,7 @@ public class SpecificationsUnitTests {
 		assertThat(specification.toPredicate(root, query, builder), is(predicate));
 	}
 
-	/**
-	 * @see DATAJPA-523
-	 */
-	@Test
+	@Test // DATAJPA-523
 	public void specificationsShouldBeSerializable() {
 
 		Specifications<Object> specification = where(mockSpec);
@@ -149,10 +128,7 @@ public class SpecificationsUnitTests {
 		assertThat(transferedSpecification, is(notNullValue()));
 	}
 
-	/**
-	 * @see DATAJPA-523
-	 */
-	@Test
+	@Test // DATAJPA-523
 	public void complexSpecificationsShouldBeSerializable() {
 
 		Specifications<Object> specification = where(mockSpec);

--- a/src/test/java/org/springframework/data/jpa/domain/sample/AuditorAwareStub.java
+++ b/src/test/java/org/springframework/data/jpa/domain/sample/AuditorAwareStub.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2008-2011 the original author or authors.
+ * Copyright 2008-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,6 +23,7 @@ import org.springframework.util.Assert;
  * Stub implementation for {@link AuditorAware}. Returns {@literal null} for the current auditor.
  * 
  * @author Oliver Gierke
+ * @author Mark Paluch
  */
 public class AuditorAwareStub implements AuditorAware<AuditableUser> {
 
@@ -32,7 +33,7 @@ public class AuditorAwareStub implements AuditorAware<AuditableUser> {
 
 	public AuditorAwareStub(AuditableUserRepository repository) {
 
-		Assert.notNull(repository);
+		Assert.notNull(repository, "AuditableUserRepository must not be null!");
 		this.repository = repository;
 	}
 

--- a/src/test/java/org/springframework/data/jpa/domain/sample/CustomAbstractPersistable.java
+++ b/src/test/java/org/springframework/data/jpa/domain/sample/CustomAbstractPersistable.java
@@ -15,15 +15,9 @@
  */
 package org.springframework.data.jpa.domain.sample;
 
-import java.util.UUID;
-
-import javax.persistence.Column;
 import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.Id;
 import javax.persistence.Table;
 
-import org.hibernate.annotations.GenericGenerator;
 import org.springframework.data.jpa.domain.AbstractPersistable;
 
 /**
@@ -31,16 +25,7 @@ import org.springframework.data.jpa.domain.AbstractPersistable;
  */
 @Entity
 @Table(name = "customAbstractPersistable")
-public class CustomAbstractPersistable extends AbstractPersistable<UUID> {
+public class CustomAbstractPersistable extends AbstractPersistable<Long> {
 
 	private static final long serialVersionUID = 1L;
-
-	@Id
-	@Override
-	@GeneratedValue(generator = "uuid2")
-	@GenericGenerator(name = "uuid2", strategy = "uuid2")
-	@Column(name = "task_id", columnDefinition = "BINARY(16)")
-	public UUID getId() {
-		return super.getId();
-	}
 }

--- a/src/test/java/org/springframework/data/jpa/domain/sample/EmbeddedIdExampleEmployee.java
+++ b/src/test/java/org/springframework/data/jpa/domain/sample/EmbeddedIdExampleEmployee.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2104 the original author or authors.
+ * Copyright 2013-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,6 +23,7 @@ import javax.persistence.MapsId;
 
 /**
  * @author Thomas Darimont
+ * @author Mark Paluch
  */
 @Entity
 public class EmbeddedIdExampleEmployee {
@@ -32,6 +33,8 @@ public class EmbeddedIdExampleEmployee {
 	@MapsId("departmentId")//
 	@ManyToOne(cascade = CascadeType.ALL)//
 	EmbeddedIdExampleDepartment department;
+
+	String name;
 
 	public EmbeddedIdExampleEmployeePK getEmployeePk() {
 		return employeePk;
@@ -47,5 +50,13 @@ public class EmbeddedIdExampleEmployee {
 
 	public void setDepartment(EmbeddedIdExampleDepartment department) {
 		this.department = department;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
 	}
 }

--- a/src/test/java/org/springframework/data/jpa/domain/sample/IdClassExampleDepartment.java
+++ b/src/test/java/org/springframework/data/jpa/domain/sample/IdClassExampleDepartment.java
@@ -18,6 +18,9 @@ package org.springframework.data.jpa.domain.sample;
 import javax.persistence.Entity;
 import javax.persistence.Id;
 
+/**
+ * @author Thomas Darimont
+ */
 @Entity
 public class IdClassExampleDepartment {
 

--- a/src/test/java/org/springframework/data/jpa/domain/sample/IdClassExampleEmployee.java
+++ b/src/test/java/org/springframework/data/jpa/domain/sample/IdClassExampleEmployee.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 the original author or authors.
+ * Copyright 2013-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,12 +20,18 @@ import javax.persistence.Id;
 import javax.persistence.IdClass;
 import javax.persistence.ManyToOne;
 
+/**
+ * @author Thomas Darimont
+ * @author Mark Paluch
+ */
 @IdClass(IdClassExampleEmployeePK.class)
 @Entity
 public class IdClassExampleEmployee {
 
 	@Id long empId;
 	@Id @ManyToOne IdClassExampleDepartment department;
+
+	String name;
 
 	public long getEmpId() {
 		return empId;
@@ -41,5 +47,13 @@ public class IdClassExampleEmployee {
 
 	public void setDepartment(IdClassExampleDepartment department) {
 		this.department = department;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
 	}
 }

--- a/src/test/java/org/springframework/data/jpa/domain/sample/Item.java
+++ b/src/test/java/org/springframework/data/jpa/domain/sample/Item.java
@@ -23,10 +23,9 @@ import javax.persistence.JoinColumn;
 import javax.persistence.Table;
 
 /**
- * Related to DATAJPA-413.
- *
  * @author Mark Paluch
- * @see Final JPA 2.1 Specification 2.4.1.3 Derived Identities Example 2
+ * @see <a href="download.oracle.com/otn-pub/jcp/persistence-2_1-fr-eval-spec/JavaPersistence.pdf">Final JPA 2.1
+ *      Specification 2.4.1.3 Derived Identities Example 2</a>
  */
 @Entity
 @Table

--- a/src/test/java/org/springframework/data/jpa/domain/sample/Item.java
+++ b/src/test/java/org/springframework/data/jpa/domain/sample/Item.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 the original author or authors.
+ * Copyright 2016-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,8 +23,9 @@ import javax.persistence.JoinColumn;
 import javax.persistence.Table;
 
 /**
+ * Related to DATAJPA-413.
+ *
  * @author Mark Paluch
- * @see DATAJPA-413
  * @see Final JPA 2.1 Specification 2.4.1.3 Derived Identities Example 2
  */
 @Entity

--- a/src/test/java/org/springframework/data/jpa/domain/sample/ItemId.java
+++ b/src/test/java/org/springframework/data/jpa/domain/sample/ItemId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 the original author or authors.
+ * Copyright 2016-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,8 +18,9 @@ package org.springframework.data.jpa.domain.sample;
 import java.io.Serializable;
 
 /**
+ * Related to DATAJPA-413.
+ *
  * @author Mark Paluch
- * @see DATAJPA-413
  * @see Final JPA 2.1 Specification 2.4.1.3 Derived Identities Example 2
  */
 public class ItemId implements Serializable {

--- a/src/test/java/org/springframework/data/jpa/domain/sample/ItemId.java
+++ b/src/test/java/org/springframework/data/jpa/domain/sample/ItemId.java
@@ -18,10 +18,9 @@ package org.springframework.data.jpa.domain.sample;
 import java.io.Serializable;
 
 /**
- * Related to DATAJPA-413.
- *
  * @author Mark Paluch
- * @see Final JPA 2.1 Specification 2.4.1.3 Derived Identities Example 2
+ * @see <a href="download.oracle.com/otn-pub/jcp/persistence-2_1-fr-eval-spec/JavaPersistence.pdf">Final JPA 2.1
+ *      Specification 2.4.1.3 Derived Identities Example 2</a>
  */
 public class ItemId implements Serializable {
 

--- a/src/test/java/org/springframework/data/jpa/domain/sample/ItemSite.java
+++ b/src/test/java/org/springframework/data/jpa/domain/sample/ItemSite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 the original author or authors.
+ * Copyright 2016-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,8 +22,9 @@ import javax.persistence.ManyToOne;
 import javax.persistence.Table;
 
 /**
+ * Related to DATAJPA-413.
+ *
  * @author Mark Paluch
- * @see DATAJPA-413
  * @see Final JPA 2.1 Specification 2.4.1.3 Derived Identities Example 2
  */
 @Entity

--- a/src/test/java/org/springframework/data/jpa/domain/sample/ItemSite.java
+++ b/src/test/java/org/springframework/data/jpa/domain/sample/ItemSite.java
@@ -22,10 +22,9 @@ import javax.persistence.ManyToOne;
 import javax.persistence.Table;
 
 /**
- * Related to DATAJPA-413.
- *
  * @author Mark Paluch
- * @see Final JPA 2.1 Specification 2.4.1.3 Derived Identities Example 2
+ * @see <a href="download.oracle.com/otn-pub/jcp/persistence-2_1-fr-eval-spec/JavaPersistence.pdf">Final JPA 2.1
+ *      Specification 2.4.1.3 Derived Identities Example 2</a>
  */
 @Entity
 @Table

--- a/src/test/java/org/springframework/data/jpa/domain/sample/ItemSiteId.java
+++ b/src/test/java/org/springframework/data/jpa/domain/sample/ItemSiteId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 the original author or authors.
+ * Copyright 2016-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,8 +18,9 @@ package org.springframework.data.jpa.domain.sample;
 import java.io.Serializable;
 
 /**
+ * Related to DATAJPA-413.
+ *
  * @author Mark Paluch
- * @see DATAJPA-413
  * @see Final JPA 2.1 Specification 2.4.1.3 Derived Identities Example 2
  */
 public class ItemSiteId implements Serializable {

--- a/src/test/java/org/springframework/data/jpa/domain/sample/ItemSiteId.java
+++ b/src/test/java/org/springframework/data/jpa/domain/sample/ItemSiteId.java
@@ -18,10 +18,9 @@ package org.springframework.data.jpa.domain.sample;
 import java.io.Serializable;
 
 /**
- * Related to DATAJPA-413.
- *
  * @author Mark Paluch
- * @see Final JPA 2.1 Specification 2.4.1.3 Derived Identities Example 2
+ * @see <a href="download.oracle.com/otn-pub/jcp/persistence-2_1-fr-eval-spec/JavaPersistence.pdf">Final JPA 2.1
+ *      Specification 2.4.1.3 Derived Identities Example 2</a>
  */
 public class ItemSiteId implements Serializable {
 

--- a/src/test/java/org/springframework/data/jpa/domain/sample/SampleEntityPK.java
+++ b/src/test/java/org/springframework/data/jpa/domain/sample/SampleEntityPK.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2008-2011 the original author or authors.
+ * Copyright 2008-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -40,8 +40,8 @@ public class SampleEntityPK implements Serializable {
 
 	public SampleEntityPK(String first, String second) {
 
-		Assert.notNull(first);
-		Assert.notNull(second);
+		Assert.notNull(first, "First must not be null!");
+		Assert.notNull(second, "Second must not be null!");
 		this.first = first;
 		this.second = second;
 	}

--- a/src/test/java/org/springframework/data/jpa/domain/sample/Site.java
+++ b/src/test/java/org/springframework/data/jpa/domain/sample/Site.java
@@ -21,10 +21,9 @@ import javax.persistence.Id;
 import javax.persistence.Table;
 
 /**
- * Related to DATAJPA-413.
- *
  * @author Mark Paluch
- * @see Final JPA 2.1 Specification 2.4.1.3 Derived Identities Example 2
+ * @see <a href="download.oracle.com/otn-pub/jcp/persistence-2_1-fr-eval-spec/JavaPersistence.pdf">Final JPA 2.1
+ *      Specification 2.4.1.3 Derived Identities Example 2</a>
  */
 @Entity
 @Table

--- a/src/test/java/org/springframework/data/jpa/domain/sample/Site.java
+++ b/src/test/java/org/springframework/data/jpa/domain/sample/Site.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 the original author or authors.
+ * Copyright 2016-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,8 +21,9 @@ import javax.persistence.Id;
 import javax.persistence.Table;
 
 /**
+ * Related to DATAJPA-413.
+ *
  * @author Mark Paluch
- * @see DATAJPA-413
  * @see Final JPA 2.1 Specification 2.4.1.3 Derived Identities Example 2
  */
 @Entity

--- a/src/test/java/org/springframework/data/jpa/domain/sample/User.java
+++ b/src/test/java/org/springframework/data/jpa/domain/sample/User.java
@@ -53,30 +53,27 @@ import javax.persistence.TemporalType;
  * @author Christoph Strobl
  */
 @Entity
-@NamedEntityGraphs({
-		@NamedEntityGraph(name = "User.overview", attributeNodes = { @NamedAttributeNode("roles") }),
-		@NamedEntityGraph(name = "User.detail", attributeNodes = { @NamedAttributeNode("roles"),
-				@NamedAttributeNode("manager"), @NamedAttributeNode("colleagues") }),
-		@NamedEntityGraph(name = "User.getOneWithDefinedEntityGraphById", attributeNodes = { @NamedAttributeNode("roles"),
-				@NamedAttributeNode("manager"), @NamedAttributeNode("colleagues") }),
-        @NamedEntityGraph(name = "User.withSubGraph",
-				attributeNodes = {
-        			@NamedAttributeNode("roles"),
-					@NamedAttributeNode(value="colleagues", subgraph = "User.colleagues")
-				},
-				subgraphs = {
-        			@NamedSubgraph(name = "User.colleagues", attributeNodes = {@NamedAttributeNode("colleagues"), @NamedAttributeNode("roles")})
-				}
-		)})
+@NamedEntityGraphs({ @NamedEntityGraph(name = "User.overview", attributeNodes = { @NamedAttributeNode("roles") }),
+		@NamedEntityGraph(name = "User.detail",
+				attributeNodes = { @NamedAttributeNode("roles"), @NamedAttributeNode("manager"),
+						@NamedAttributeNode("colleagues") }),
+		@NamedEntityGraph(name = "User.getOneWithDefinedEntityGraphById",
+				attributeNodes = { @NamedAttributeNode("roles"), @NamedAttributeNode("manager"),
+						@NamedAttributeNode("colleagues") }),
+		@NamedEntityGraph(name = "User.withSubGraph",
+				attributeNodes = { @NamedAttributeNode("roles"),
+						@NamedAttributeNode(value = "colleagues", subgraph = "User.colleagues") },
+				subgraphs = { @NamedSubgraph(name = "User.colleagues",
+						attributeNodes = { @NamedAttributeNode("colleagues"), @NamedAttributeNode("roles") }) }) })
 @NamedQuery(name = "User.findByEmailAddress", query = "SELECT u FROM User u WHERE u.emailAddress = ?1")
 @NamedStoredProcedureQueries({ //
-@NamedStoredProcedureQuery(name = "User.plus1", procedureName = "plus1inout", parameters = {
-		@StoredProcedureParameter(mode = ParameterMode.IN, name = "arg", type = Integer.class),
-		@StoredProcedureParameter(mode = ParameterMode.OUT, name = "res", type = Integer.class) }) //
+		@NamedStoredProcedureQuery(name = "User.plus1", procedureName = "plus1inout",
+				parameters = { @StoredProcedureParameter(mode = ParameterMode.IN, name = "arg", type = Integer.class),
+						@StoredProcedureParameter(mode = ParameterMode.OUT, name = "res", type = Integer.class) }) //
 })
-@NamedStoredProcedureQuery(name = "User.plus1IO", procedureName = "plus1inout", parameters = {
-		@StoredProcedureParameter(mode = ParameterMode.IN, name = "arg", type = Integer.class),
-		@StoredProcedureParameter(mode = ParameterMode.OUT, name = "res", type = Integer.class) })
+@NamedStoredProcedureQuery(name = "User.plus1IO", procedureName = "plus1inout",
+		parameters = { @StoredProcedureParameter(mode = ParameterMode.IN, name = "arg", type = Integer.class),
+				@StoredProcedureParameter(mode = ParameterMode.OUT, name = "res", type = Integer.class) })
 @Table(name = "SD_User")
 public class User {
 
@@ -392,7 +389,7 @@ public class User {
 	public void setDateOfBirth(Date dateOfBirth) {
 		this.dateOfBirth = dateOfBirth;
 	}
-	
+
 	public void setCreatedAt(Date createdAt) {
 		this.createdAt = createdAt;
 	}

--- a/src/test/java/org/springframework/data/jpa/domain/sample/User.java
+++ b/src/test/java/org/springframework/data/jpa/domain/sample/User.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2008-2015 the original author or authors.
+ * Copyright 2008-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,6 +37,7 @@ import javax.persistence.NamedEntityGraphs;
 import javax.persistence.NamedQuery;
 import javax.persistence.NamedStoredProcedureQueries;
 import javax.persistence.NamedStoredProcedureQuery;
+import javax.persistence.NamedSubgraph;
 import javax.persistence.ParameterMode;
 import javax.persistence.StoredProcedureParameter;
 import javax.persistence.Table;
@@ -49,6 +50,7 @@ import javax.persistence.TemporalType;
  * 
  * @author Oliver Gierke
  * @author Thomas Darimont
+ * @author Christoph Strobl
  */
 @Entity
 @NamedEntityGraphs({
@@ -56,7 +58,16 @@ import javax.persistence.TemporalType;
 		@NamedEntityGraph(name = "User.detail", attributeNodes = { @NamedAttributeNode("roles"),
 				@NamedAttributeNode("manager"), @NamedAttributeNode("colleagues") }),
 		@NamedEntityGraph(name = "User.getOneWithDefinedEntityGraphById", attributeNodes = { @NamedAttributeNode("roles"),
-				@NamedAttributeNode("manager"), @NamedAttributeNode("colleagues") }) })
+				@NamedAttributeNode("manager"), @NamedAttributeNode("colleagues") }),
+        @NamedEntityGraph(name = "User.withSubGraph",
+				attributeNodes = {
+        			@NamedAttributeNode("roles"),
+					@NamedAttributeNode(value="colleagues", subgraph = "User.colleagues")
+				},
+				subgraphs = {
+        			@NamedSubgraph(name = "User.colleagues", attributeNodes = {@NamedAttributeNode("colleagues"), @NamedAttributeNode("roles")})
+				}
+		)})
 @NamedQuery(name = "User.findByEmailAddress", query = "SELECT u FROM User u WHERE u.emailAddress = ?1")
 @NamedStoredProcedureQueries({ //
 @NamedStoredProcedureQuery(name = "User.plus1", procedureName = "plus1inout", parameters = {

--- a/src/test/java/org/springframework/data/jpa/domain/support/AuditingBeanFactoryPostProcessorUnitTests.java
+++ b/src/test/java/org/springframework/data/jpa/domain/support/AuditingBeanFactoryPostProcessorUnitTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2008-2014 the original author or authors.
+ * Copyright 2008-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -66,18 +66,12 @@ public class AuditingBeanFactoryPostProcessorUnitTests {
 		assertThat(beanFactory.isBeanNameInUse(AuditingBeanFactoryPostProcessor.BEAN_CONFIGURER_ASPECT_BEAN_NAME), is(true));
 	}
 
-	/**
-	 * @see DATAJPA-265
-	 */
-	@Test(expected = IllegalStateException.class)
+	@Test(expected = IllegalStateException.class) // DATAJPA-265
 	public void rejectsConfigurationWithoutSpringConfigured() {
 		processor.postProcessBeanFactory(new DefaultListableBeanFactory());
 	}
 
-	/**
-	 * @see DATAJPA-265
-	 */
-	@Test
+	@Test // DATAJPA-265
 	public void setsDependsOnOnEntityManagerFactory() {
 
 		processor.postProcessBeanFactory(beanFactory);
@@ -92,10 +86,7 @@ public class AuditingBeanFactoryPostProcessorUnitTests {
 		}
 	}
 
-	/**
-	 * @see DATAJPA-453
-	 */
-	@Test
+	@Test // DATAJPA-453
 	public void findsEntityManagerFactoryInParentBeanFactory() {
 
 		DefaultListableBeanFactory childFactory = new DefaultListableBeanFactory(getBeanFactory());

--- a/src/test/java/org/springframework/data/jpa/domain/support/AuditingEntityListenerTests.java
+++ b/src/test/java/org/springframework/data/jpa/domain/support/AuditingEntityListenerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2008-2013 the original author or authors.
+ * Copyright 2008-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -68,10 +68,7 @@ public class AuditingEntityListenerTests {
 		assertUserIsAuditor(user, user);
 	}
 
-	/**
-	 * @see DATAJPA-303
-	 */
-	@Test
+	@Test // DATAJPA-303
 	public void updatesLastModifiedDates() throws Exception {
 
 		Thread.sleep(200);
@@ -98,10 +95,7 @@ public class AuditingEntityListenerTests {
 		assertUserIsAuditor(user, role);
 	}
 
-	/**
-	 * @see DATAJPA-501
-	 */
-	@Test
+	@Test // DATAJPA-501
 	public void usesAnnotationMetadata() {
 
 		AnnotatedAuditableUser auditableUser = annotatedUserRepository.save(new AnnotatedAuditableUser());

--- a/src/test/java/org/springframework/data/jpa/infrastructure/HibernateMetamodelIntegrationTests.java
+++ b/src/test/java/org/springframework/data/jpa/infrastructure/HibernateMetamodelIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 the original author or authors.
+ * Copyright 2015-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,7 +37,7 @@ public class HibernateMetamodelIntegrationTests extends MetamodelIntegrationTest
 	public void considersOneToOneAttributeAnAssociation() {}
 
 	/**
-	 * @see https://hibernate.atlassian.net/browse/HHH-10341
+	 * @see <a href="https://hibernate.atlassian.net/browse/HHH-10341">HHH-10341</a>
 	 */
 	@Test
 	@Ignore

--- a/src/test/java/org/springframework/data/jpa/mapping/JpaMetamodelMappingContextIntegrationTests.java
+++ b/src/test/java/org/springframework/data/jpa/mapping/JpaMetamodelMappingContextIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2015 the original author or authors.
+ * Copyright 2012-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -113,10 +113,7 @@ public class JpaMetamodelMappingContextIntegrationTests {
 		assertThat(property.isEntity(), is(false));
 	}
 
-	/**
-	 * @see DATAJPA-608
-	 */
-	@Test
+	@Test // DATAJPA-608
 	public void detectsEntityPropertyForCollections() {
 
 		JpaPersistentEntityImpl<?> entity = context.getPersistentEntity(User.class);
@@ -125,10 +122,7 @@ public class JpaMetamodelMappingContextIntegrationTests {
 		assertThat(entity.getPersistentProperty("colleagues").isEntity(), is(true));
 	}
 
-	/**
-	 * @see DATAJPA-630
-	 */
-	@Test
+	@Test // DATAJPA-630
 	public void lookingUpIdentifierOfProxyDoesNotInitializeProxy() {
 
 		TransactionTemplate template = new TransactionTemplate(transactionManager);

--- a/src/test/java/org/springframework/data/jpa/mapping/JpaMetamodelMappingContextUnitTests.java
+++ b/src/test/java/org/springframework/data/jpa/mapping/JpaMetamodelMappingContextUnitTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 the original author or authors.
+ * Copyright 2015-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,10 +31,7 @@ import org.springframework.data.annotation.Version;
  */
 public class JpaMetamodelMappingContextUnitTests {
 
-	/**
-	 * @see DATAJPA-775
-	 */
-	@Test
+	@Test // DATAJPA-775
 	public void jpaPersistentEntityRejectsSprignDataAtVersionAnnotation() {
 
 		Metamodel metamodel = mock(Metamodel.class);

--- a/src/test/java/org/springframework/data/jpa/mapping/JpaPersistentPropertyImplUnitTests.java
+++ b/src/test/java/org/springframework/data/jpa/mapping/JpaPersistentPropertyImplUnitTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2016 the original author or authors.
+ * Copyright 2013-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -63,62 +63,41 @@ public class JpaPersistentPropertyImplUnitTests {
 		entity = context.getPersistentEntity(Sample.class);
 	}
 
-	/**
-	 * @see DATAJPA-284
-	 */
-	@Test
+	@Test // DATAJPA-284
 	public void considersOneToOneMappedPropertyAnAssociation() {
 
 		JpaPersistentProperty property = entity.getPersistentProperty("other");
 		assertThat(property.isAssociation(), is(true));
 	}
 
-	/**
-	 * @see DATAJPA-376
-	 */
-	@Test
+	@Test // DATAJPA-376
 	public void considersJpaTransientFieldsAsTransient() {
 		assertThat(entity.getPersistentProperty("transientProp"), is(nullValue()));
 	}
 
-	/**
-	 * @see DATAJPA-484
-	 */
-	@Test
+	@Test // DATAJPA-484
 	public void considersEmbeddableAnEntity() {
 		assertThat(context.getPersistentEntity(SampleEmbeddable.class), is(notNullValue()));
 	}
 
-	/**
-	 * @see DATAJPA-484
-	 */
-	@Test
+	@Test // DATAJPA-484
 	public void considersEmbeddablePropertyAnAssociation() {
 		assertThat(entity.getPersistentProperty("embeddable").isAssociation(), is(true));
 	}
 
-	/**
-	 * @see DATAJPA-484
-	 */
-	@Test
+	@Test // DATAJPA-484
 	public void considersEmbeddedPropertyAnAssociation() {
 		assertThat(entity.getPersistentProperty("embedded").isAssociation(), is(true));
 	}
 
-	/**
-	 * @see DATAJPA-619
-	 */
-	@Test
+	@Test // DATAJPA-619
 	public void considersPropertyLevelAccessTypeDefinitions() {
 
 		assertThat(getProperty(PropertyLevelPropertyAccess.class, "field").usePropertyAccess(), is(false));
 		assertThat(getProperty(PropertyLevelPropertyAccess.class, "property").usePropertyAccess(), is(true));
 	}
 
-	/**
-	 * @see DATAJPA-619
-	 */
-	@Test
+	@Test // DATAJPA-619
 	public void propertyLevelAccessTypeTrumpsTypeLevelDefinition() {
 
 		assertThat(getProperty(PropertyLevelDefinitionTrumpsTypeLevelOne.class, "field").usePropertyAccess(), is(false));
@@ -128,42 +107,27 @@ public class JpaPersistentPropertyImplUnitTests {
 		assertThat(getProperty(PropertyLevelDefinitionTrumpsTypeLevelOne2.class, "property").usePropertyAccess(), is(true));
 	}
 
-	/**
-	 * @see DATAJPA-619
-	 */
-	@Test
+	@Test // DATAJPA-619
 	public void considersJpaAccessDefinitionAnnotations() {
 		assertThat(getProperty(TypeLevelPropertyAccess.class, "id").usePropertyAccess(), is(true));
 	}
 
-	/**
-	 * @see DATAJPA-619
-	 */
-	@Test
+	@Test // DATAJPA-619
 	public void springDataAnnotationTrumpsJpaIfBothOnTypeLevel() {
 		assertThat(getProperty(CompetingTypeLevelAnnotations.class, "id").usePropertyAccess(), is(false));
 	}
 
-	/**
-	 * @see DATAJPA-619
-	 */
-	@Test
+	@Test // DATAJPA-619
 	public void springDataAnnotationTrumpsJpaIfBothOnPropertyLevel() {
 		assertThat(getProperty(CompetingPropertyLevelAnnotations.class, "id").usePropertyAccess(), is(false));
 	}
 
-	/**
-	 * @see DATAJPA-605
-	 */
-	@Test
+	@Test // DATAJPA-605
 	public void detectsJpaVersionAnnotation() {
 		assertThat(getProperty(JpaVersioned.class, "version").isVersionProperty(), is(true));
 	}
 
-	/**
-	 * @see DATAJPA-664
-	 */
-	@Test
+	@Test // DATAJPA-664
 	@SuppressWarnings("rawtypes")
 	public void considersTargetEntityTypeForPropertyType() {
 
@@ -177,19 +141,13 @@ public class JpaPersistentPropertyImplUnitTests {
 		assertThat(entityType.iterator().next(), is((TypeInformation) ClassTypeInformation.from(Implementation.class)));
 	}
 
-	/**
-	 * @see DATAJPA-716
-	 */
-	@Test
+	@Test // DATAJPA-716
 	public void considersNonUpdateablePropertyNotWriteable() {
 		assertThat(getProperty(WithReadOnly.class, "name").isWritable(), is(false));
 		assertThat(getProperty(WithReadOnly.class, "updatable").isWritable(), is(true));
 	}
 
-	/**
-	 * @see DATAJPA-904
-	 */
-	@Test
+	@Test // DATAJPA-904
 	public void isEntityWorksEvenWithManagedTypeWithNullJavaType() {
 
 		ManagedType<?> managedType = mock(ManagedType.class);

--- a/src/test/java/org/springframework/data/jpa/provider/PersistenceProviderIntegrationTests.java
+++ b/src/test/java/org/springframework/data/jpa/provider/PersistenceProviderIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Copyright 2014-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -74,10 +74,7 @@ public class PersistenceProviderIntegrationTests {
 		this.category = categories.save(new Category(product));
 	}
 
-	/**
-	 * @see DATAJPA-630
-	 */
-	@Test
+	@Test // DATAJPA-630
 	public void testname() {
 
 		new TransactionTemplate(transactionManager).execute(new TransactionCallback<Void>() {

--- a/src/test/java/org/springframework/data/jpa/provider/PersistenceProviderUnitTests.java
+++ b/src/test/java/org/springframework/data/jpa/provider/PersistenceProviderUnitTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2015 the original author or authors.
+ * Copyright 2014-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -50,10 +50,7 @@ public class PersistenceProviderUnitTests {
 		this.shadowingClassLoader = new ShadowingClassLoader(getClass().getClassLoader());
 	}
 
-	/**
-	 * @see DATAJPA-444
-	 */
-	@Test
+	@Test // DATAJPA-444
 	public void detectsHibernatePersistenceProviderForHibernateVersionLessThan4Dot3() throws Exception {
 
 		shadowingClassLoader.excludePackage("org.hibernate");
@@ -63,10 +60,7 @@ public class PersistenceProviderUnitTests {
 		assertThat(fromEntityManager(em), is(HIBERNATE));
 	}
 
-	/**
-	 * @see DATAJPA-444
-	 */
-	@Test
+	@Test // DATAJPA-444
 	public void detectsHibernatePersistenceProviderForHibernateVersionGreaterEqual4dot3() throws Exception {
 
 		shadowingClassLoader.excludePackage("org.hibernate");
@@ -104,10 +98,7 @@ public class PersistenceProviderUnitTests {
 		assertThat(fromEntityManager(em), is(GENERIC_JPA));
 	}
 
-	/**
-	 * @see DATAJPA-1019
-	 */
-	@Test
+	@Test // DATAJPA-1019
 	public void detectsHibernatePersistenceProviderForHibernateVersion52() throws Exception {
 
 		Assume.assumeThat(Version.getVersionString(), startsWith("5.2"));

--- a/src/test/java/org/springframework/data/jpa/provider/PersistenceProviderUnitTests.java
+++ b/src/test/java/org/springframework/data/jpa/provider/PersistenceProviderUnitTests.java
@@ -25,6 +25,8 @@ import java.util.List;
 
 import javax.persistence.EntityManager;
 
+import org.hibernate.Version;
+import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
@@ -100,6 +102,21 @@ public class PersistenceProviderUnitTests {
 		EntityManager em = mockProviderSpecificEntityManagerInterface("foo.bar.unknown.jpa.JpaEntityManager");
 
 		assertThat(fromEntityManager(em), is(GENERIC_JPA));
+	}
+
+	/**
+	 * @see DATAJPA-1019
+	 */
+	@Test
+	public void detectsHibernatePersistenceProviderForHibernateVersion52() throws Exception {
+
+		Assume.assumeThat(Version.getVersionString(), startsWith("5.2"));
+
+		shadowingClassLoader.excludePackage("org.hibernate");
+
+		EntityManager em = mockProviderSpecificEntityManagerInterface(HIBERNATE52_ENTITY_MANAGER_INTERFACE);
+
+		assertThat(fromEntityManager(em), is(HIBERNATE));
 	}
 
 	private EntityManager mockProviderSpecificEntityManagerInterface(String interfaceName) throws ClassNotFoundException {

--- a/src/test/java/org/springframework/data/jpa/repository/AbstractPersistableIntegrationTests.java
+++ b/src/test/java/org/springframework/data/jpa/repository/AbstractPersistableIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2016 the original author or authors.
+ * Copyright 2014-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -44,10 +44,7 @@ public class AbstractPersistableIntegrationTests {
 	@Autowired CustomAbstractPersistableRepository repository;
 	@Autowired EntityManager em;
 
-	/**
-	 * @see DATAJPA-622
-	 */
-	@Test
+	@Test // DATAJPA-622
 	public void shouldBeAbleToSaveAndLoadCustomPersistableWithUuidId() {
 
 		CustomAbstractPersistable entity = new CustomAbstractPersistable();
@@ -57,10 +54,7 @@ public class AbstractPersistableIntegrationTests {
 		assertThat(found, is(saved));
 	}
 
-	/**
-	 * @see DATAJPA-848
-	 */
-	@Test
+	@Test // DATAJPA-848
 	public void equalsWorksForProxiedEntities() {
 
 		CustomAbstractPersistable entity = repository.saveAndFlush(new CustomAbstractPersistable());

--- a/src/test/java/org/springframework/data/jpa/repository/CrudMethodMetadataUnitTests.java
+++ b/src/test/java/org/springframework/data/jpa/repository/CrudMethodMetadataUnitTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2016 the original author or authors.
+ * Copyright 2011-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -82,10 +82,7 @@ public class CrudMethodMetadataUnitTests {
 		repository = factory.getRepository(RoleRepository.class);
 	}
 
-	/**
-	 * @see DATAJPA-73, DATAJPA-173
-	 */
-	@Test
+	@Test // DATAJPA-73, DATAJPA-173
 	public void usesLockInformationAnnotatedAtRedeclaredMethod() {
 
 		when(em.getCriteriaBuilder()).thenReturn(builder);
@@ -99,10 +96,7 @@ public class CrudMethodMetadataUnitTests {
 		verify(typedQuery).setHint("foo", "bar");
 	}
 
-	/**
-	 * @see DATAJPA-359, DATAJPA-173
-	 */
-	@Test
+	@Test // DATAJPA-359, DATAJPA-173
 	public void usesMetadataAnnotatedAtRedeclaredFindOne() {
 
 		repository.findOne(1);
@@ -113,10 +107,7 @@ public class CrudMethodMetadataUnitTests {
 		verify(em).find(Role.class, 1, expectedLockModeType, expectedLinks);
 	}
 
-	/**
-	 * @see DATAJPA-574
-	 */
-	@Test
+	@Test // DATAJPA-574
 	public void appliesLockModeAndQueryHintsToQuerydslQuery() {
 
 		when(em.getDelegate()).thenReturn(mock(EntityManager.class));

--- a/src/test/java/org/springframework/data/jpa/repository/CustomAbstractPersistableIntegrationTests.java
+++ b/src/test/java/org/springframework/data/jpa/repository/CustomAbstractPersistableIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2016 the original author or authors.
+ * Copyright 2014-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -38,10 +38,7 @@ public class CustomAbstractPersistableIntegrationTests {
 
 	@Autowired CustomAbstractPersistableRepository repository;
 
-	/**
-	 * @see DATAJPA-622
-	 */
-	@Test
+	@Test // DATAJPA-622
 	public void shouldBeAbleToSaveAndLoadCustomPersistableWithUuidId() {
 
 		CustomAbstractPersistable entity = new CustomAbstractPersistable();

--- a/src/test/java/org/springframework/data/jpa/repository/CustomAbstractPersistableIntegrationTests.java
+++ b/src/test/java/org/springframework/data/jpa/repository/CustomAbstractPersistableIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Copyright 2014-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,6 +29,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 /**
  * @author Thomas Darimont
+ * @author Oliver Gierke
  */
 @Transactional
 @RunWith(SpringJUnit4ClassRunner.class)
@@ -45,10 +46,8 @@ public class CustomAbstractPersistableIntegrationTests {
 
 		CustomAbstractPersistable entity = new CustomAbstractPersistable();
 		CustomAbstractPersistable saved = repository.save(entity);
-
 		CustomAbstractPersistable found = repository.findOne(saved.getId());
 
 		assertThat(found, is(saved));
 	}
-
 }

--- a/src/test/java/org/springframework/data/jpa/repository/CustomEclipseLinkJpaVendorAdapter.java
+++ b/src/test/java/org/springframework/data/jpa/repository/CustomEclipseLinkJpaVendorAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 the original author or authors.
+ * Copyright 2015-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,7 +25,7 @@ import org.springframework.orm.jpa.vendor.EclipseLinkJpaVendorAdapter;
  * work around a bug in stored procedure execution on HSQLDB.
  * 
  * @author Oliver Gierke
- * @see https://bugs.eclipse.org/bugs/show_bug.cgi?id=467072
+ * @see <a href="https://bugs.eclipse.org/bugs/show_bug.cgi?id=467072">https://bugs.eclipse.org/bugs/show_bug.cgi?id=467072</a>
  */
 public class CustomEclipseLinkJpaVendorAdapter extends EclipseLinkJpaVendorAdapter {
 
@@ -47,7 +47,7 @@ public class CustomEclipseLinkJpaVendorAdapter extends EclipseLinkJpaVendorAdapt
 	 * Workaround {@link HSQLPlatform} to make sure EclipseLink uses the right syntax to call stored procedures on HSQL.
 	 * 
 	 * @author Oliver Gierke
-	 * @see https://bugs.eclipse.org/bugs/show_bug.cgi?id=467072
+	 * @see <a href="https://bugs.eclipse.org/bugs/show_bug.cgi?id=467072">https://bugs.eclipse.org/bugs/show_bug.cgi?id=467072</a>
 	 */
 	@SuppressWarnings("serial")
 	public static class EclipseLinkHsqlPlatform extends HSQLPlatform {

--- a/src/test/java/org/springframework/data/jpa/repository/CustomHsqlHibernateJpaVendorAdaptor.java
+++ b/src/test/java/org/springframework/data/jpa/repository/CustomHsqlHibernateJpaVendorAdaptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012 the original author or authors.
+ * Copyright 2012-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,7 +24,7 @@ import org.springframework.orm.jpa.vendor.HibernateJpaVendorAdapter;
 /**
  * Fix for missing type declarations for HSQL.
  * 
- * @see http://www.codesmell.org/blog/2008/12/hibernate-hsql-native-queries-and-booleans/
+ * @see <a href="http://www.codesmell.org/blog/2008/12/hibernate-hsql-native-queries-and-booleans/">http://www.codesmell.org/blog/2008/12/hibernate-hsql-native-queries-and-booleans/</a>
  * @author Oliver Gierke
  */
 public class CustomHsqlHibernateJpaVendorAdaptor extends HibernateJpaVendorAdapter {

--- a/src/test/java/org/springframework/data/jpa/repository/EclipseLinkEntityGraphRepositoryMethodsIntegrationTests.java
+++ b/src/test/java/org/springframework/data/jpa/repository/EclipseLinkEntityGraphRepositoryMethodsIntegrationTests.java
@@ -15,13 +15,26 @@
  */
 package org.springframework.data.jpa.repository;
 
+import org.junit.Ignore;
+import org.junit.Test;
 import org.springframework.test.context.ContextConfiguration;
 
 /**
  * @author Oliver Gierke
  */
 @ContextConfiguration("classpath:eclipselink.xml")
-public class EclipseLinkEntityGraphRepositoryMethodsIntegrationTests extends
-		EntityGraphRepositoryMethodsIntegrationTests {
+public class EclipseLinkEntityGraphRepositoryMethodsIntegrationTests
+		extends EntityGraphRepositoryMethodsIntegrationTests {
 
+	@Ignore
+	@Test
+	public void shouldRespectNamedEntitySubGraph() {}
+
+	@Ignore
+	@Test
+	public void shouldRespectMultipleSubGraphForSameAttributeWithDynamicFetchGraph() {}
+
+	@Ignore
+	@Test
+	public void shouldRespectDynamicFetchGraphForGetOneWithAttributeNamesById() {}
 }

--- a/src/test/java/org/springframework/data/jpa/repository/EntityGraphRepositoryMethodsIntegrationTests.java
+++ b/src/test/java/org/springframework/data/jpa/repository/EntityGraphRepositoryMethodsIntegrationTests.java
@@ -19,11 +19,11 @@ import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.*;
 import static org.springframework.data.jpa.support.EntityManagerTestUtils.*;
 
-import java.util.Iterator;
 import java.util.List;
-import java.util.Map;
 
-import javax.persistence.*;
+import javax.persistence.EntityManager;
+import javax.persistence.Persistence;
+import javax.persistence.PersistenceUtil;
 
 import org.junit.Assume;
 import org.junit.Before;
@@ -39,7 +39,6 @@ import org.springframework.data.jpa.repository.sample.RepositoryMethodsWithEntit
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.util.StringUtils;
 
 /**
  * Integration tests for RepositoryMethodsWithEntityGraphConfigJpaRepository.
@@ -61,6 +60,8 @@ public class EntityGraphRepositoryMethodsIntegrationTests {
 	User ollie;
 	User christoph;
 	Role role;
+
+	PersistenceUtil util = Persistence.getPersistenceUtil();
 
 	@Before
 	public void setup() {
@@ -91,7 +92,7 @@ public class EntityGraphRepositoryMethodsIntegrationTests {
 		List<User> result = repository.findAll();
 
 		assertThat(result.size(), is(3));
-		assertThat(Persistence.getPersistenceUtil().isLoaded(result.get(0), "roles"), is(true));
+		assertThat(util.isLoaded(result.get(0), "roles"), is(true));
 		assertThat(result.get(0), is(tom));
 	}
 
@@ -103,8 +104,8 @@ public class EntityGraphRepositoryMethodsIntegrationTests {
 		User user = repository.findOne(tom.getId());
 
 		assertThat(user, is(notNullValue()));
-		assertThat("colleages should be fetched with 'user.detail' fetchgraph",
-				Persistence.getPersistenceUtil().isLoaded(user, "colleagues"), is(true));
+		assertThat("colleages should be fetched with 'user.detail' fetchgraph", util.isLoaded(user, "colleagues"),
+				is(true));
 	}
 
 	@Test // DATAJPA-696
@@ -115,8 +116,8 @@ public class EntityGraphRepositoryMethodsIntegrationTests {
 		User user = repository.getOneWithDefinedEntityGraphById(tom.getId());
 
 		assertThat(user, is(notNullValue()));
-		assertThat("colleages should be fetched with 'user.detail' fetchgraph",
-				Persistence.getPersistenceUtil().isLoaded(user, "colleagues"), is(true));
+		assertThat("colleages should be fetched with 'user.detail' fetchgraph", util.isLoaded(user, "colleagues"),
+				is(true));
 	}
 
 	@Test // DATAJPA-696
@@ -130,12 +131,13 @@ public class EntityGraphRepositoryMethodsIntegrationTests {
 		User user = repository.getOneWithAttributeNamesById(tom.getId());
 
 		assertThat(user, is(notNullValue()));
-		assertThat("colleages should be fetched with 'user.detail' fetchgraph",
-				Persistence.getPersistenceUtil().isLoaded(user, "colleagues"), is(true));
-		assertThat(Persistence.getPersistenceUtil().isLoaded(user, "colleagues"), is(true));
+
+		assertThat("colleages should be fetched with 'user.detail' fetchgraph", util.isLoaded(user, "colleagues"),
+				is(true));
+		assertThat(util.isLoaded(user, "colleagues"), is(true));
 
 		for (User colleague : user.getColleagues()) {
-			assertThat(Persistence.getPersistenceUtil().isLoaded(colleague, "roles"), is(true));
+			assertThat(util.isLoaded(colleague, "roles"), is(true));
 		}
 	}
 
@@ -148,7 +150,7 @@ public class EntityGraphRepositoryMethodsIntegrationTests {
 		List<User> result = page.getContent();
 
 		assertThat(result.size(), is(3));
-		assertThat(Persistence.getPersistenceUtil().isLoaded(result.get(0).getRoles()), is(true));
+		assertThat(util.isLoaded(result.get(0).getRoles()), is(true));
 		assertThat(result.get(0), is(tom));
 	}
 
@@ -165,11 +167,11 @@ public class EntityGraphRepositoryMethodsIntegrationTests {
 		assertThat(user, is(notNullValue()));
 
 		assertThat("colleagues on root should have been fetched by named 'User.colleagues' subgraph declaration",
-				Persistence.getPersistenceUtil().isLoaded(user, "colleagues"), is(true));
+				util.isLoaded(user, "colleagues"), is(true));
 
 		for (User colleague : user.getColleagues()) {
-			assertThat(Persistence.getPersistenceUtil().isLoaded(colleague, "colleagues"), is(true));
-			assertThat(Persistence.getPersistenceUtil().isLoaded(colleague, "roles"), is(true));
+			assertThat(util.isLoaded(colleague, "colleagues"), is(true));
+			assertThat(util.isLoaded(colleague, "roles"), is(true));
 		}
 	}
 
@@ -186,55 +188,11 @@ public class EntityGraphRepositoryMethodsIntegrationTests {
 		assertThat(user, is(notNullValue()));
 
 		assertThat("colleagues on root should have been fetched by dynamic subgraph declaration",
-				Persistence.getPersistenceUtil().isLoaded(user, "colleagues"), is(true));
+				util.isLoaded(user, "colleagues"), is(true));
 
 		for (User colleague : user.getColleagues()) {
-			assertThat(Persistence.getPersistenceUtil().isLoaded(colleague, "colleagues"), is(true));
-			assertThat(Persistence.getPersistenceUtil().isLoaded(colleague, "roles"), is(true));
-		}
-	}
-
-	@Test // DATAJPA-1041 - TODO: remove when done fighting with eclipselink.
-	public void thisOneFailsWithEclipselink() {
-
-		Assume.assumeTrue(currentEntityManagerIsAJpa21EntityManager(em));
-
-		em.flush();
-		em.clear();
-
-		javax.persistence.EntityGraph<?> graph = em.getEntityGraph("User.withSubGraph");
-
-		printGraph(graph);
-
-		User result = (User) em.createQuery("Select u from User u where u.id = " + tom.getId())
-				.setHint("javax.persistence.loadgraph", graph).getResultList().get(0);
-
-		assertThat(Persistence.getPersistenceUtil().isLoaded(result, "roles"), is(true));
-		assertThat(Persistence.getPersistenceUtil().isLoaded(result, "colleagues"), is(true));
-	}
-
-	private void printGraph(javax.persistence.EntityGraph<?> graph) {
-
-		try {
-			for (AttributeNode<?> node : graph.getAttributeNodes()) {
-				System.out.println("|- node.getAttributeName(): " + node.getAttributeName());
-				for (Map.Entry<Class, Subgraph> subGraph : node.getSubgraphs().entrySet()) {
-					System.out.print("|  +- subGraph: " + subGraph.getKey().getSimpleName() + " -> [");
-
-					Iterator it = subGraph.getValue().getAttributeNodes().iterator();
-					while (it.hasNext()) {
-
-						AttributeNode<?> an = (AttributeNode<?>) it.next();
-						System.out.print(an.getAttributeName());
-						if (it.hasNext()) {
-							System.out.print(", ");
-						}
-					}
-					System.out.println("]");
-				}
-			}
-		} catch (Exception e) {
-			// o_O what happened here - ignore it - it's just debug output.
+			assertThat(util.isLoaded(colleague, "colleagues"), is(true));
+			assertThat(util.isLoaded(colleague, "roles"), is(true));
 		}
 	}
 }

--- a/src/test/java/org/springframework/data/jpa/repository/EntityGraphRepositoryMethodsIntegrationTests.java
+++ b/src/test/java/org/springframework/data/jpa/repository/EntityGraphRepositoryMethodsIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2016 the original author or authors.
+ * Copyright 2014-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -73,10 +73,7 @@ public class EntityGraphRepositoryMethodsIntegrationTests {
 		tom.getColleagues().add(ollie);
 	}
 
-	/**
-	 * @see DATAJPA-612
-	 */
-	@Test
+	@Test // DATAJPA-612
 	public void shouldRespectConfiguredJpaEntityGraph() {
 
 		Assume.assumeTrue(currentEntityManagerIsAJpa21EntityManager(em));
@@ -88,10 +85,7 @@ public class EntityGraphRepositoryMethodsIntegrationTests {
 		assertThat(result.get(0), is(tom));
 	}
 
-	/**
-	 * @see DATAJPA-689
-	 */
-	@Test
+	@Test // DATAJPA-689
 	public void shouldRespectConfiguredJpaEntityGraphInFindOne() {
 
 		Assume.assumeTrue(currentEntityManagerIsAJpa21EntityManager(em));
@@ -103,10 +97,7 @@ public class EntityGraphRepositoryMethodsIntegrationTests {
 				Persistence.getPersistenceUtil().isLoaded(user.getColleagues()), is(true));
 	}
 
-	/**
-	 * @see DATAJPA-696
-	 */
-	@Test
+	@Test // DATAJPA-696
 	public void shouldRespectInferFetchGraphFromMethodName() {
 
 		Assume.assumeTrue(currentEntityManagerIsAJpa21EntityManager(em));
@@ -118,10 +109,7 @@ public class EntityGraphRepositoryMethodsIntegrationTests {
 				Persistence.getPersistenceUtil().isLoaded(user.getColleagues()), is(true));
 	}
 
-	/**
-	 * @see DATAJPA-696
-	 */
-	@Test
+	@Test // DATAJPA-696
 	public void shouldRespectDynamicFetchGraphForGetOneWithAttributeNamesById() {
 
 		Assume.assumeTrue(currentEntityManagerIsAJpa21EntityManager(em));
@@ -133,10 +121,7 @@ public class EntityGraphRepositoryMethodsIntegrationTests {
 				Persistence.getPersistenceUtil().isLoaded(user.getColleagues()), is(true));
 	}
 
-	/**
-	 * @see DATAJPA-790
-	 */
-	@Test
+	@Test // DATAJPA-790
 	public void shouldRespectConfiguredJpaEntityGraphWithPaginationAndQueryDslPredicates() {
 
 		Assume.assumeTrue(currentEntityManagerIsAJpa21EntityManager(em));

--- a/src/test/java/org/springframework/data/jpa/repository/EntityGraphRepositoryMethodsIntegrationTests.java
+++ b/src/test/java/org/springframework/data/jpa/repository/EntityGraphRepositoryMethodsIntegrationTests.java
@@ -19,10 +19,11 @@ import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.*;
 import static org.springframework.data.jpa.support.EntityManagerTestUtils.*;
 
+import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 
-import javax.persistence.EntityManager;
-import javax.persistence.Persistence;
+import javax.persistence.*;
 
 import org.junit.Assume;
 import org.junit.Before;
@@ -38,6 +39,7 @@ import org.springframework.data.jpa.repository.sample.RepositoryMethodsWithEntit
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
 
 /**
  * Integration tests for RepositoryMethodsWithEntityGraphConfigJpaRepository.
@@ -45,6 +47,7 @@ import org.springframework.transaction.annotation.Transactional;
  * @author Thomas Darimont
  * @author Oliver Gierke
  * @author Jocelyn Ntakpe
+ * @author Christoph Strobl
  */
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration("classpath:config/namespace-autoconfig-context.xml")
@@ -56,6 +59,7 @@ public class EntityGraphRepositoryMethodsIntegrationTests {
 
 	User tom;
 	User ollie;
+	User christoph;
 	Role role;
 
 	@Before
@@ -63,6 +67,7 @@ public class EntityGraphRepositoryMethodsIntegrationTests {
 
 		tom = new User("Thomas", "Darimont", "tdarimont@example.org");
 		ollie = new User("Oliver", "Gierke", "ogierke@example.org");
+		christoph = new User("Christoph", "Strobl", "cstrobl@example.org");
 
 		role = new Role("Developer");
 		em.persist(role);
@@ -71,6 +76,11 @@ public class EntityGraphRepositoryMethodsIntegrationTests {
 
 		ollie = repository.save(ollie);
 		tom.getColleagues().add(ollie);
+
+		christoph = repository.save(christoph);
+
+		ollie.getColleagues().add(christoph);
+		repository.save(ollie);
 	}
 
 	@Test // DATAJPA-612
@@ -80,8 +90,8 @@ public class EntityGraphRepositoryMethodsIntegrationTests {
 
 		List<User> result = repository.findAll();
 
-		assertThat(result.size(), is(2));
-		assertThat(Persistence.getPersistenceUtil().isLoaded(result.get(0).getRoles()), is(true));
+		assertThat(result.size(), is(3));
+		assertThat(Persistence.getPersistenceUtil().isLoaded(result.get(0), "roles"), is(true));
 		assertThat(result.get(0), is(tom));
 	}
 
@@ -94,7 +104,7 @@ public class EntityGraphRepositoryMethodsIntegrationTests {
 
 		assertThat(user, is(notNullValue()));
 		assertThat("colleages should be fetched with 'user.detail' fetchgraph",
-				Persistence.getPersistenceUtil().isLoaded(user.getColleagues()), is(true));
+				Persistence.getPersistenceUtil().isLoaded(user, "colleagues"), is(true));
 	}
 
 	@Test // DATAJPA-696
@@ -106,7 +116,7 @@ public class EntityGraphRepositoryMethodsIntegrationTests {
 
 		assertThat(user, is(notNullValue()));
 		assertThat("colleages should be fetched with 'user.detail' fetchgraph",
-				Persistence.getPersistenceUtil().isLoaded(user.getColleagues()), is(true));
+				Persistence.getPersistenceUtil().isLoaded(user, "colleagues"), is(true));
 	}
 
 	@Test // DATAJPA-696
@@ -114,11 +124,19 @@ public class EntityGraphRepositoryMethodsIntegrationTests {
 
 		Assume.assumeTrue(currentEntityManagerIsAJpa21EntityManager(em));
 
+		em.flush();
+		em.clear();
+
 		User user = repository.getOneWithAttributeNamesById(tom.getId());
 
 		assertThat(user, is(notNullValue()));
 		assertThat("colleages should be fetched with 'user.detail' fetchgraph",
-				Persistence.getPersistenceUtil().isLoaded(user.getColleagues()), is(true));
+				Persistence.getPersistenceUtil().isLoaded(user, "colleagues"), is(true));
+		assertThat(Persistence.getPersistenceUtil().isLoaded(user, "colleagues"), is(true));
+
+		for (User colleague : user.getColleagues()) {
+			assertThat(Persistence.getPersistenceUtil().isLoaded(colleague, "roles"), is(true));
+		}
 	}
 
 	@Test // DATAJPA-790
@@ -129,8 +147,94 @@ public class EntityGraphRepositoryMethodsIntegrationTests {
 		Page<User> page = repository.findAll(QUser.user.firstname.isNotNull(), new PageRequest(0, 100));
 		List<User> result = page.getContent();
 
-		assertThat(result.size(), is(2));
+		assertThat(result.size(), is(3));
 		assertThat(Persistence.getPersistenceUtil().isLoaded(result.get(0).getRoles()), is(true));
 		assertThat(result.get(0), is(tom));
+	}
+
+	@Test // DATAJPA-1041
+	public void shouldRespectNamedEntitySubGraph() {
+
+		Assume.assumeTrue(currentEntityManagerIsAJpa21EntityManager(em));
+
+		em.flush();
+		em.clear();
+
+		User user = repository.findOneWithMultipleSubGraphsUsingNamedEntityGraphById(tom.getId());
+
+		assertThat(user, is(notNullValue()));
+
+		assertThat("colleagues on root should have been fetched by named 'User.colleagues' subgraph declaration",
+				Persistence.getPersistenceUtil().isLoaded(user, "colleagues"), is(true));
+
+		for (User colleague : user.getColleagues()) {
+			assertThat(Persistence.getPersistenceUtil().isLoaded(colleague, "colleagues"), is(true));
+			assertThat(Persistence.getPersistenceUtil().isLoaded(colleague, "roles"), is(true));
+		}
+	}
+
+	@Test // DATAJPA-1041
+	public void shouldRespectMultipleSubGraphForSameAttributeWithDynamicFetchGraph() {
+
+		Assume.assumeTrue(currentEntityManagerIsAJpa21EntityManager(em));
+
+		em.flush();
+		em.clear();
+
+		User user = repository.findOneWithMultipleSubGraphsById(tom.getId());
+
+		assertThat(user, is(notNullValue()));
+
+		assertThat("colleagues on root should have been fetched by dynamic subgraph declaration",
+				Persistence.getPersistenceUtil().isLoaded(user, "colleagues"), is(true));
+
+		for (User colleague : user.getColleagues()) {
+			assertThat(Persistence.getPersistenceUtil().isLoaded(colleague, "colleagues"), is(true));
+			assertThat(Persistence.getPersistenceUtil().isLoaded(colleague, "roles"), is(true));
+		}
+	}
+
+	@Test // DATAJPA-1041 - TODO: remove when done fighting with eclipselink.
+	public void thisOneFailsWithEclipselink() {
+
+		Assume.assumeTrue(currentEntityManagerIsAJpa21EntityManager(em));
+
+		em.flush();
+		em.clear();
+
+		javax.persistence.EntityGraph<?> graph = em.getEntityGraph("User.withSubGraph");
+
+		printGraph(graph);
+
+		User result = (User) em.createQuery("Select u from User u where u.id = " + tom.getId())
+				.setHint("javax.persistence.loadgraph", graph).getResultList().get(0);
+
+		assertThat(Persistence.getPersistenceUtil().isLoaded(result, "roles"), is(true));
+		assertThat(Persistence.getPersistenceUtil().isLoaded(result, "colleagues"), is(true));
+	}
+
+	private void printGraph(javax.persistence.EntityGraph<?> graph) {
+
+		try {
+			for (AttributeNode<?> node : graph.getAttributeNodes()) {
+				System.out.println("|- node.getAttributeName(): " + node.getAttributeName());
+				for (Map.Entry<Class, Subgraph> subGraph : node.getSubgraphs().entrySet()) {
+					System.out.print("|  +- subGraph: " + subGraph.getKey().getSimpleName() + " -> [");
+
+					Iterator it = subGraph.getValue().getAttributeNodes().iterator();
+					while (it.hasNext()) {
+
+						AttributeNode<?> an = (AttributeNode<?>) it.next();
+						System.out.print(an.getAttributeName());
+						if (it.hasNext()) {
+							System.out.print(", ");
+						}
+					}
+					System.out.println("]");
+				}
+			}
+		} catch (Exception e) {
+			// o_O what happened here - ignore it - it's just debug output.
+		}
 	}
 }

--- a/src/test/java/org/springframework/data/jpa/repository/JavaConfigUserRepositoryTests.java
+++ b/src/test/java/org/springframework/data/jpa/repository/JavaConfigUserRepositoryTests.java
@@ -76,10 +76,10 @@ public class JavaConfigUserRepositoryTests extends UserRepositoryTests {
 					extensions);
 			evaluationContextProvider.setApplicationContext(applicationContext);
 
-			JpaRepositoryFactoryBean<UserRepository, User, Integer> factory = new JpaRepositoryFactoryBean<UserRepository, User, Integer>();
+			JpaRepositoryFactoryBean<UserRepository, User, Integer> factory = new JpaRepositoryFactoryBean<UserRepository, User, Integer>(
+					UserRepository.class);
 			factory.setEntityManager(entityManager);
 			factory.setBeanFactory(applicationContext);
-			factory.setRepositoryInterface(UserRepository.class);
 			factory
 					.setCustomImplementation(new UserRepositoryImpl(new DefaultJpaContext(Collections.singleton(entityManager))));
 			factory.setNamedQueries(namedQueries());

--- a/src/test/java/org/springframework/data/jpa/repository/JavaConfigUserRepositoryTests.java
+++ b/src/test/java/org/springframework/data/jpa/repository/JavaConfigUserRepositoryTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2015 the original author or authors.
+ * Copyright 2012-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -99,10 +99,7 @@ public class JavaConfigUserRepositoryTests extends UserRepositoryTests {
 		}
 	}
 
-	/**
-	 * @see DATAJPA-317
-	 */
-	@Test(expected = NoSuchBeanDefinitionException.class)
+	@Test(expected = NoSuchBeanDefinitionException.class) // DATAJPA-317
 	public void doesNotPickUpJpaRepository() {
 
 		ConfigurableApplicationContext context = new AnnotationConfigApplicationContext(JpaRepositoryConfig.class);

--- a/src/test/java/org/springframework/data/jpa/repository/MappedTypeRepositoryIntegrationTests.java
+++ b/src/test/java/org/springframework/data/jpa/repository/MappedTypeRepositoryIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 the original author or authors.
+ * Copyright 2013-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -49,10 +49,7 @@ public class MappedTypeRepositoryIntegrationTests {
 	@Autowired ConcreteRepository1 concreteRepository1;
 	@Autowired ConcreteRepository2 concreteRepository2;
 
-	/**
-	 * @see DATAJPA-170
-	 */
-	@Test
+	@Test // DATAJPA-170
 	public void supportForExpressionBasedQueryMethods() {
 
 		concreteRepository1.save(new ConcreteType1("foo"));
@@ -65,10 +62,7 @@ public class MappedTypeRepositoryIntegrationTests {
 		assertThat(concretes2.size(), is(1));
 	}
 
-	/**
-	 * @see DATAJPA-424
-	 */
-	@Test
+	@Test // DATAJPA-424
 	public void supportForPaginationCustomQueryMethodsWithEntityExpression() {
 
 		concreteRepository1.save(new ConcreteType1("foo"));

--- a/src/test/java/org/springframework/data/jpa/repository/ParentRepositoryIntegrationTests.java
+++ b/src/test/java/org/springframework/data/jpa/repository/ParentRepositoryIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2014 the original author or authors.
+ * Copyright 2013-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -59,10 +59,7 @@ public class ParentRepositoryIntegrationTests {
 		repository.flush();
 	}
 
-	/**
-	 * @see DATAJPA-287
-	 */
-	@Test
+	@Test // DATAJPA-287
 	public void testWithoutJoin() throws Exception {
 
 		Page<Parent> page = repository.findAll(new Specification<Parent>() {
@@ -82,10 +79,7 @@ public class ParentRepositoryIntegrationTests {
 		assertThat(page.getTotalPages(), is(1));
 	}
 
-	/**
-	 * @see DATAJPA-287
-	 */
-	@Test
+	@Test // DATAJPA-287
 	public void testWithJoin() throws Exception {
 		Page<Parent> page = repository.findAll(new Specification<Parent>() {
 			public Predicate toPredicate(Root<Parent> root, CriteriaQuery<?> query, CriteriaBuilder cb) {

--- a/src/test/java/org/springframework/data/jpa/repository/RedeclaringRepositoryMethodsTests.java
+++ b/src/test/java/org/springframework/data/jpa/repository/RedeclaringRepositoryMethodsTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 the original author or authors.
+ * Copyright 2013-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -52,10 +52,7 @@ public class RedeclaringRepositoryMethodsTests {
 		tom = new User("Thomas", "Darimont", "tdarimont@gopivotal.com");
 	}
 
-	/**
-	 * @see DATAJPA-398
-	 */
-	@Test
+	@Test // DATAJPA-398
 	public void adjustedWellKnownPagedFindAllMethodShouldReturnOnlyTheUserWithFirstnameOliver() {
 
 		ollie = repository.save(ollie);
@@ -67,10 +64,7 @@ public class RedeclaringRepositoryMethodsTests {
 		assertThat(page.getContent().get(0).getFirstname(), is("Oliver"));
 	}
 
-	/**
-	 * @see DATAJPA-398
-	 */
-	@Test
+	@Test // DATAJPA-398
 	public void adjustedWllKnownFindAllMethodShouldReturnAnEmptyList() {
 
 		ollie = repository.save(ollie);

--- a/src/test/java/org/springframework/data/jpa/repository/RepositoryWithCompositeKeyTests.java
+++ b/src/test/java/org/springframework/data/jpa/repository/RepositoryWithCompositeKeyTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2016 the original author or authors.
+ * Copyright 2013-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -61,10 +61,9 @@ public class RepositoryWithCompositeKeyTests {
 	@Autowired EmployeeRepositoryWithEmbeddedId employeeRepositoryWithEmbeddedId;
 
 	/**
-	 * @see DATAJPA-269
 	 * @see Final JPA 2.0 Specification 2.4.1.3 Derived Identities Example 2
 	 */
-	@Test
+	@Test // DATAJPA-269
 	public void shouldSupportSavingEntitiesWithCompositeKeyClassesWithIdClassAndDerivedIdentities() {
 
 		IdClassExampleDepartment dep = new IdClassExampleDepartment();
@@ -87,10 +86,9 @@ public class RepositoryWithCompositeKeyTests {
 	}
 
 	/**
-	 * @see DATAJPA-269
 	 * @see Final JPA 2.0 Specification 2.4.1.3 Derived Identities Example 3
 	 */
-	@Test
+	@Test // DATAJPA-269
 	public void shouldSupportSavingEntitiesWithCompositeKeyClassesWithEmbeddedIdsAndDerivedIdentities() {
 
 		EmbeddedIdExampleDepartment dep = new EmbeddedIdExampleDepartment();
@@ -113,11 +111,7 @@ public class RepositoryWithCompositeKeyTests {
 		assertThat(persistedEmp.getDepartment().getName(), is(dep.getName()));
 	}
 
-	/**
-	 * @see DATAJPA-472
-	 * @see DATAJPA-912
-	 */
-	@Test
+	@Test // DATAJPA-472, DATAJPA-912
 	public void shouldSupportFindAllWithPageableAndEntityWithIdClass() throws Exception {
 
 		if (Package.getPackage("org.hibernate.cfg").getImplementationVersion().startsWith("4.1.")) {
@@ -141,10 +135,7 @@ public class RepositoryWithCompositeKeyTests {
 		assertThat(page.getTotalElements(), is(1L));
 	}
 
-	/**
-	 * @see DATAJPA-497
-	 */
-	@Test
+	@Test // DATAJPA-497
 	public void sortByEmbeddedPkFieldInCompositePkWithEmbeddedIdInQueryDsl() {
 
 		EmbeddedIdExampleDepartment dep1 = new EmbeddedIdExampleDepartment();
@@ -180,10 +171,7 @@ public class RepositoryWithCompositeKeyTests {
 		assertThat(result.get(1), is(emp1));
 	}
 
-	/**
-	 * @see DATAJPA-497
-	 */
-	@Test
+	@Test // DATAJPA-497
 	public void sortByEmbeddedPkFieldInCompositePkWithIdClassInQueryDsl() {
 
 		IdClassExampleDepartment dep1 = new IdClassExampleDepartment();
@@ -219,10 +207,7 @@ public class RepositoryWithCompositeKeyTests {
 		assertThat(result.get(1), is(emp1));
 	}
 
-	/**
-	 * @see DATAJPA-527
-	 */
-	@Test
+	@Test // DATAJPA-527
 	public void testExistsWithIdClass() {
 
 		IdClassExampleDepartment dep = new IdClassExampleDepartment();
@@ -241,10 +226,7 @@ public class RepositoryWithCompositeKeyTests {
 		assertThat(employeeRepositoryWithIdClass.exists(key), is(true));
 	}
 
-	/**
-	 * @see DATAJPA-527
-	 */
-	@Test
+	@Test // DATAJPA-527
 	public void testExistsWithEmbeddedId() {
 
 		EmbeddedIdExampleDepartment dep1 = new EmbeddedIdExampleDepartment();
@@ -267,10 +249,7 @@ public class RepositoryWithCompositeKeyTests {
 		assertThat(employeeRepositoryWithEmbeddedId.exists(key), is(true));
 	}
 
-	/**
-	 * @see DATAJPA-611
-	 */
-	@Test
+	@Test // DATAJPA-611
 	public void shouldAllowFindAllWithIdsForEntitiesWithCompoundIdClassKeys() {
 
 		IdClassExampleDepartment dep2 = new IdClassExampleDepartment();
@@ -304,10 +283,7 @@ public class RepositoryWithCompositeKeyTests {
 		assertThat(result, hasSize(2));
 	}
 
-	/**
-	 * @see DATAJPA-920
-	 */
-	@Test
+	@Test // DATAJPA-920
 	public void shouldExecuteExistsQueryForEntitiesWithEmbeddedId() {
 
 		EmbeddedIdExampleDepartment dep1 = new EmbeddedIdExampleDepartment();
@@ -328,10 +304,7 @@ public class RepositoryWithCompositeKeyTests {
 		assertThat(employeeRepositoryWithEmbeddedId.existsByName(emp.getName()), is(true));
 	}
 
-	/**
-	 * @see DATAJPA-920
-	 */
-	@Test
+	@Test // DATAJPA-920
 	public void shouldExecuteExistsQueryForEntitiesWithCompoundIdClassKeys() {
 
 		IdClassExampleDepartment dep2 = new IdClassExampleDepartment();

--- a/src/test/java/org/springframework/data/jpa/repository/RepositoryWithCompositeKeyTests.java
+++ b/src/test/java/org/springframework/data/jpa/repository/RepositoryWithCompositeKeyTests.java
@@ -25,6 +25,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.dao.InvalidDataAccessApiUsageException;
 import org.springframework.data.domain.Page;
@@ -61,7 +62,8 @@ public class RepositoryWithCompositeKeyTests {
 	@Autowired EmployeeRepositoryWithEmbeddedId employeeRepositoryWithEmbeddedId;
 
 	/**
-	 * @see Final JPA 2.0 Specification 2.4.1.3 Derived Identities Example 2
+	 * @see <a href="download.oracle.com/otn-pub/jcp/persistence-2_1-fr-eval-spec/JavaPersistence.pdf">Final JPA 2.0
+	 *      Specification 2.4.1.3 Derived Identities Example 2</a>
 	 */
 	@Test // DATAJPA-269
 	public void shouldSupportSavingEntitiesWithCompositeKeyClassesWithIdClassAndDerivedIdentities() {
@@ -86,7 +88,8 @@ public class RepositoryWithCompositeKeyTests {
 	}
 
 	/**
-	 * @see Final JPA 2.0 Specification 2.4.1.3 Derived Identities Example 3
+	 * @see <a href="download.oracle.com/otn-pub/jcp/persistence-2_1-fr-eval-spec/JavaPersistence.pdf">Final JPA 2.0
+	 *      Specification 2.4.1.3 Derived Identities Example 3</a>
 	 */
 	@Test // DATAJPA-269
 	public void shouldSupportSavingEntitiesWithCompositeKeyClassesWithEmbeddedIdsAndDerivedIdentities() {
@@ -162,8 +165,8 @@ public class RepositoryWithCompositeKeyTests {
 		emp3 = employeeRepositoryWithEmbeddedId.save(emp3);
 
 		QEmbeddedIdExampleEmployee emp = QEmbeddedIdExampleEmployee.embeddedIdExampleEmployee;
-		List<EmbeddedIdExampleEmployee> result = employeeRepositoryWithEmbeddedId.findAll(
-				emp.employeePk.departmentId.eq(dep2.getDepartmentId()), emp.employeePk.employeeId.asc());
+		List<EmbeddedIdExampleEmployee> result = employeeRepositoryWithEmbeddedId
+				.findAll(emp.employeePk.departmentId.eq(dep2.getDepartmentId()), emp.employeePk.employeeId.asc());
 
 		assertThat(result, is(notNullValue()));
 		assertThat(result, hasSize(2));
@@ -198,8 +201,8 @@ public class RepositoryWithCompositeKeyTests {
 		emp3 = employeeRepositoryWithIdClass.save(emp3);
 
 		QIdClassExampleEmployee emp = QIdClassExampleEmployee.idClassExampleEmployee;
-		List<IdClassExampleEmployee> result = employeeRepositoryWithIdClass.findAll(
-				emp.department.departmentId.eq(dep2.getDepartmentId()), emp.empId.asc());
+		List<IdClassExampleEmployee> result = employeeRepositoryWithIdClass
+				.findAll(emp.department.departmentId.eq(dep2.getDepartmentId()), emp.empId.asc());
 
 		assertThat(result, is(notNullValue()));
 		assertThat(result, hasSize(2));

--- a/src/test/java/org/springframework/data/jpa/repository/RepositoryWithCompositeKeyTests.java
+++ b/src/test/java/org/springframework/data/jpa/repository/RepositoryWithCompositeKeyTests.java
@@ -46,7 +46,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 /**
  * Tests some usage variants of composite keys with spring data jpa.
- * 
+ *
  * @author Thomas Darimont
  * @author Mark Paluch
  */
@@ -302,5 +302,50 @@ public class RepositoryWithCompositeKeyTests {
 		List<IdClassExampleEmployee> result = employeeRepositoryWithIdClass.findAll(Arrays.asList(emp1PK, emp2PK));
 
 		assertThat(result, hasSize(2));
+	}
+
+	/**
+	 * @see DATAJPA-920
+	 */
+	@Test
+	public void shouldExecuteExistsQueryForEntitiesWithEmbeddedId() {
+
+		EmbeddedIdExampleDepartment dep1 = new EmbeddedIdExampleDepartment();
+		dep1.setDepartmentId(1L);
+		dep1.setName("Dep1");
+
+		EmbeddedIdExampleEmployeePK key = new EmbeddedIdExampleEmployeePK();
+		key.setDepartmentId(1L);
+		key.setEmployeeId(1L);
+
+		EmbeddedIdExampleEmployee emp = new EmbeddedIdExampleEmployee();
+		emp.setDepartment(dep1);
+		emp.setEmployeePk(key);
+		emp.setName("White");
+
+		employeeRepositoryWithEmbeddedId.save(emp);
+
+		assertThat(employeeRepositoryWithEmbeddedId.existsByName(emp.getName()), is(true));
+	}
+
+	/**
+	 * @see DATAJPA-920
+	 */
+	@Test
+	public void shouldExecuteExistsQueryForEntitiesWithCompoundIdClassKeys() {
+
+		IdClassExampleDepartment dep2 = new IdClassExampleDepartment();
+		dep2.setDepartmentId(2L);
+		dep2.setName("Dep2");
+
+		IdClassExampleEmployee emp1 = new IdClassExampleEmployee();
+		emp1.setEmpId(3L);
+		emp1.setDepartment(dep2);
+		emp1.setName("White");
+
+		employeeRepositoryWithIdClass.save(emp1);
+
+		assertThat(employeeRepositoryWithIdClass.existsByName(emp1.getName()), is(true));
+		assertThat(employeeRepositoryWithIdClass.existsByName("Walter"), is(false));
 	}
 }

--- a/src/test/java/org/springframework/data/jpa/repository/RepositoryWithIdClassKeyTests.java
+++ b/src/test/java/org/springframework/data/jpa/repository/RepositoryWithIdClassKeyTests.java
@@ -22,6 +22,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.ImportResource;
@@ -69,7 +70,8 @@ public class RepositoryWithIdClassKeyTests {
 	}
 
 	/**
-	 * @see Final JPA 2.1 Specification 2.4.1.3 Derived Identities Example 2
+	 * @see <a href="download.oracle.com/otn-pub/jcp/persistence-2_1-fr-eval-spec/JavaPersistence.pdf">Final JPA 2.1
+	 *      Specification 2.4.1.3 Derived Identities Example 2</a>
 	 */
 	@Test // DATAJPA-413
 	public void shouldSaveAndLoadEntitiesWithDerivedIdentities() throws Exception {

--- a/src/test/java/org/springframework/data/jpa/repository/RepositoryWithIdClassKeyTests.java
+++ b/src/test/java/org/springframework/data/jpa/repository/RepositoryWithIdClassKeyTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 the original author or authors.
+ * Copyright 2016-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -69,10 +69,9 @@ public class RepositoryWithIdClassKeyTests {
 	}
 
 	/**
-	 * @see DATAJPA-413
 	 * @see Final JPA 2.1 Specification 2.4.1.3 Derived Identities Example 2
 	 */
-	@Test
+	@Test // DATAJPA-413
 	public void shouldSaveAndLoadEntitiesWithDerivedIdentities() throws Exception {
 
 		Site site = siteRepository.save(new Site());

--- a/src/test/java/org/springframework/data/jpa/repository/RoleRepositoryIntegrationTests.java
+++ b/src/test/java/org/springframework/data/jpa/repository/RoleRepositoryIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2014 the original author or authors.
+ * Copyright 2011-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -63,10 +63,7 @@ public class RoleRepositoryIntegrationTests {
 		assertThat(repository.findOne(result.getId()), is(reference));
 	}
 
-	/**
-	 * @see DATAJPA-509
-	 */
-	@Test
+	@Test // DATAJPA-509
 	public void shouldUseExplicitlyConfiguredEntityNameInOrmXmlInCountQueries() {
 
 		Role reference = new Role("ADMIN");
@@ -75,10 +72,7 @@ public class RoleRepositoryIntegrationTests {
 		assertThat(repository.count(), is(1L));
 	}
 
-	/**
-	 * @see DATAJPA-509
-	 */
-	@Test
+	@Test // DATAJPA-509
 	public void shouldUseExplicitlyConfiguredEntityNameInOrmXmlInExistsQueries() {
 
 		Role reference = new Role("ADMIN");
@@ -87,10 +81,7 @@ public class RoleRepositoryIntegrationTests {
 		assertThat(repository.exists(reference.getId()), is(true));
 	}
 
-	/**
-	 * @see DATAJPA-509
-	 */
-	@Test
+	@Test // DATAJPA-509
 	public void shouldUseExplicitlyConfiguredEntityNameInDerivedCountQueries() {
 
 		Role reference = new Role("ADMIN");

--- a/src/test/java/org/springframework/data/jpa/repository/StoredProcedureIntegrationTests.java
+++ b/src/test/java/org/springframework/data/jpa/repository/StoredProcedureIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 the original author or authors.
+ * Copyright 2015-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -71,34 +71,22 @@ public class StoredProcedureIntegrationTests {
 		assumeTrue(currentEntityManagerIsAJpa21EntityManager(em));
 	}
 
-	/**
-	 * @see DATAJPA-652
-	 */
-	@Test
+	@Test // DATAJPA-652
 	public void shouldExecuteAdHocProcedureWithNoInputAnd1OutputParameter() {
 		assertThat(repository.adHocProcedureWithNoInputAnd1OutputParameter(), is(42));
 	}
 
-	/**
-	 * @see DATAJPA-652
-	 */
-	@Test
+	@Test // DATAJPA-652
 	public void shouldExecuteAdHocProcedureWith1InputAnd1OutputParameter() {
 		assertThat(repository.adHocProcedureWith1InputAnd1OutputParameter(23), is(24));
 	}
 
-	/**
-	 * @see DATAJPA-652
-	 */
-	@Test
+	@Test // DATAJPA-652
 	public void shouldExecuteAdHocProcedureWith1InputAndNoOutputParameter() {
 		repository.adHocProcedureWith1InputAndNoOutputParameter(42);
 	}
 
-	/**
-	 * @see DATAJPA-652
-	 */
-	@Test
+	@Test // DATAJPA-652
 	@Ignore(NOT_SUPPORTED)
 	public void shouldExecuteAdHocProcedureWith1InputAnd1OutputParameterWithResultSet() {
 
@@ -108,10 +96,7 @@ public class StoredProcedureIntegrationTests {
 		assertThat(dummies.size(), is(equalTo(3)));
 	}
 
-	/**
-	 * @see DATAJPA-652
-	 */
-	@Test
+	@Test // DATAJPA-652
 	@Ignore(NOT_SUPPORTED)
 	public void shouldExecuteAdHocProcedureWith1InputAnd1OutputParameterWithResultSetWithUpdate() {
 
@@ -121,42 +106,27 @@ public class StoredProcedureIntegrationTests {
 		assertThat(dummies.size(), is(equalTo(3)));
 	}
 
-	/**
-	 * @see DATAJPA-652
-	 */
-	@Test
+	@Test // DATAJPA-652
 	public void shouldExecuteAdHocProcedureWith1InputAnd1OutputParameterWithUpdate() {
 		repository.adHocProcedureWith1InputAndNoOutputParameterWithUpdate("FOO");
 	}
 
-	/**
-	 * @see DATAJPA-652
-	 */
-	@Test
+	@Test // DATAJPA-652
 	public void shouldExecuteProcedureWithNoInputAnd1OutputParameter() {
 		assertThat(repository.procedureWithNoInputAnd1OutputParameter(), is(42));
 	}
 
-	/**
-	 * @see DATAJPA-652
-	 */
-	@Test
+	@Test // DATAJPA-652
 	public void shouldExecuteProcedureWith1InputAnd1OutputParameter() {
 		assertThat(repository.procedureWith1InputAnd1OutputParameter(23), is(24));
 	}
 
-	/**
-	 * @see DATAJPA-652
-	 */
-	@Test
+	@Test // DATAJPA-652
 	public void shouldExecuteProcedureWith1InputAndNoOutputParameter() {
 		repository.procedureWith1InputAndNoOutputParameter(42);
 	}
 
-	/**
-	 * @see DATAJPA-652
-	 */
-	@Test
+	@Test // DATAJPA-652
 	@Ignore(NOT_SUPPORTED)
 	public void shouldExecuteProcedureWith1InputAnd1OutputParameterWithResultSet() {
 
@@ -166,10 +136,7 @@ public class StoredProcedureIntegrationTests {
 		assertThat(dummies.size(), is(equalTo(3)));
 	}
 
-	/**
-	 * @see DATAJPA-652
-	 */
-	@Test
+	@Test // DATAJPA-652
 	@Ignore(NOT_SUPPORTED)
 	public void shouldExecuteProcedureWith1InputAnd1OutputParameterWithResultSetWithUpdate() {
 
@@ -179,10 +146,7 @@ public class StoredProcedureIntegrationTests {
 		assertThat(dummies.size(), is(equalTo(3)));
 	}
 
-	/**
-	 * @see DATAJPA-652
-	 */
-	@Test
+	@Test // DATAJPA-652
 	public void shouldExecuteProcedureWith1InputAnd1OutputParameterWithUpdate() {
 		repository.procedureWith1InputAndNoOutputParameterWithUpdate("FOO");
 	}

--- a/src/test/java/org/springframework/data/jpa/repository/UserRepositoryFinderTests.java
+++ b/src/test/java/org/springframework/data/jpa/repository/UserRepositoryFinderTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2008-2016 the original author or authors.
+ * Copyright 2008-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -147,40 +147,28 @@ public class UserRepositoryFinderTests {
 		assertThat(result.get(0), is(oliver));
 	}
 
-	/**
-	 * @see DATAJPA-92
-	 */
-	@Test
+	@Test // DATAJPA-92
 	public void findsByLastnameIgnoringCase() throws Exception {
 		List<User> result = userRepository.findByLastnameIgnoringCase("BeAUfoRd");
 		assertThat(result.size(), is(1));
 		assertThat(result.get(0), is(carter));
 	}
 
-	/**
-	 * @see DATAJPA-92
-	 */
-	@Test
+	@Test // DATAJPA-92
 	public void findsByLastnameIgnoringCaseLike() throws Exception {
 		List<User> result = userRepository.findByLastnameIgnoringCaseLike("BeAUfo%");
 		assertThat(result.size(), is(1));
 		assertThat(result.get(0), is(carter));
 	}
 
-	/**
-	 * @see DATAJPA-92
-	 */
-	@Test
+	@Test // DATAJPA-92
 	public void findByLastnameAndFirstnameAllIgnoringCase() throws Exception {
 		List<User> result = userRepository.findByLastnameAndFirstnameAllIgnoringCase("MaTTheWs", "DaVe");
 		assertThat(result.size(), is(1));
 		assertThat(result.get(0), is(dave));
 	}
 
-	/**
-	 * @see DATAJPA-94
-	 */
-	@Test
+	@Test // DATAJPA-94
 	public void respectsPageableOrderOnQueryGenerateFromMethodName() throws Exception {
 		Page<User> ascending = userRepository.findByLastnameIgnoringCase(new PageRequest(0, 10, new Sort(ASC, "firstname")),
 				"Matthews");
@@ -196,10 +184,7 @@ public class UserRepositoryFinderTests {
 				is(equalTo(descending.getContent().get(0).getFirstname())));
 	}
 
-	/**
-	 * @see DATAJPA-486
-	 */
-	@Test
+	@Test // DATAJPA-486
 	public void executesQueryToSlice() {
 
 		Slice<User> slice = userRepository.findSliceByLastname("Matthews", new PageRequest(0, 1, ASC, "firstname"));
@@ -208,18 +193,12 @@ public class UserRepositoryFinderTests {
 		assertThat(slice.hasNext(), is(true));
 	}
 
-	/**
-	 * @see DATAJPA-830
-	 */
-	@Test
+	@Test // DATAJPA-830
 	public void executesMethodWithNotContainingOnStringCorrectly() {
 		assertThat(userRepository.findByLastnameNotContaining("u"), containsInAnyOrder(dave, oliver));
 	}
 
-	/**
-	 * @see DATAJPA-829
-	 */
-	@Test
+	@Test // DATAJPA-829
 	public void translatesContainsToMemberOf() {
 
 		List<User> singers = userRepository.findByRolesContaining(singer);
@@ -229,26 +208,17 @@ public class UserRepositoryFinderTests {
 		assertThat(userRepository.findByRolesContaining(drummer), contains(carter));
 	}
 
-	/**
-	 * @see DATAJPA-829
-	 */
-	@Test
+	@Test // DATAJPA-829
 	public void translatesNotContainsToNotMemberOf() {
 		assertThat(userRepository.findByRolesNotContaining(drummer), hasItems(dave, oliver));
 	}
 
-	/**
-	 * @see DATAJPA-974
-	 */
-	@Test
+	@Test // DATAJPA-974
 	public void executesQueryWithProjectionContainingReferenceToPluralAttribute() {
 		assertThat(userRepository.findRolesAndFirstnameBy(), is(notNullValue()));
 	}
 
-	/**
-	 * @see DATAJPA-1023, DATACMNS-959
-	 */
-	@Test(expected = InvalidDataAccessApiUsageException.class)
+	@Test(expected = InvalidDataAccessApiUsageException.class) // DATAJPA-1023, DATACMNS-959
 	@Transactional(propagation = Propagation.NOT_SUPPORTED)
 	public void rejectsStreamExecutionIfNoSurroundingTransactionActive() {
 		userRepository.findAllByCustomQueryAndStream();

--- a/src/test/java/org/springframework/data/jpa/repository/UserRepositoryStoredProcedureTests.java
+++ b/src/test/java/org/springframework/data/jpa/repository/UserRepositoryStoredProcedureTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Copyright 2014-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -50,10 +50,7 @@ public class UserRepositoryStoredProcedureTests {
 	@Autowired UserRepository repository;
 	@PersistenceContext EntityManager em;
 
-	/**
-	 * @see DATAJPA-455
-	 */
-	@Test
+	@Test // DATAJPA-455
 	public void callProcedureWithInAndOutParameters() {
 
 		assumeTrue(currentEntityManagerIsAJpa21EntityManager(em));
@@ -61,10 +58,7 @@ public class UserRepositoryStoredProcedureTests {
 		assertThat(repository.plus1inout(1), is(2));
 	}
 
-	/**
-	 * @see DATAJPA-455
-	 */
-	@Test
+	@Test // DATAJPA-455
 	public void callProcedureExplicitNameWithInAndOutParameters() {
 
 		assumeTrue(currentEntityManagerIsAJpa21EntityManager(em));
@@ -72,10 +66,7 @@ public class UserRepositoryStoredProcedureTests {
 		assertThat(repository.explicitlyNamedPlus1inout(1), is(2));
 	}
 
-	/**
-	 * @see DATAJPA-455
-	 */
-	@Test
+	@Test // DATAJPA-455
 	public void entityAnnotatedCustomNamedProcedurePlus1IO() {
 
 		assumeTrue(currentEntityManagerIsAJpa21EntityManager(em));
@@ -83,10 +74,7 @@ public class UserRepositoryStoredProcedureTests {
 		assertThat(repository.entityAnnotatedCustomNamedProcedurePlus1IO(1), is(2));
 	}
 
-	/**
-	 * @see DATAJPA-455
-	 */
-	@Test
+	@Test // DATAJPA-455
 	@Ignore
 	public void plainJpa21() {
 
@@ -102,10 +90,7 @@ public class UserRepositoryStoredProcedureTests {
 		assertThat(proc.getOutputParameterValue(2), is((Object) 2));
 	}
 
-	/**
-	 * @see DATAJPA-455
-	 */
-	@Test
+	@Test // DATAJPA-455
 	@Ignore
 	public void plainJpa21_entityAnnotatedCustomNamedProcedurePlus1IO() {
 

--- a/src/test/java/org/springframework/data/jpa/repository/UserRepositoryTests.java
+++ b/src/test/java/org/springframework/data/jpa/repository/UserRepositoryTests.java
@@ -1326,7 +1326,7 @@ public class UserRepositoryTests {
 	}
 
 	/**
-	 * @see https://issues.apache.org/jira/browse/OPENJPA-2484
+	 * @see <a href="https://issues.apache.org/jira/browse/OPENJPA-2484">OPENJPA-2484</a>
 	 */
 	@Test // DATAJPA-505
 	@Ignore

--- a/src/test/java/org/springframework/data/jpa/repository/UserRepositoryTests.java
+++ b/src/test/java/org/springframework/data/jpa/repository/UserRepositoryTests.java
@@ -1097,6 +1097,18 @@ public class UserRepositoryTests {
 	}
 
 	/**
+	 * @see DATAJPA-231
+	 */
+	@Test
+	public void executesDerivedExistsQuery() {
+
+		flushTestUsers();
+
+		assertThat(repository.existsByLastname("Matthews"), is(true));
+		assertThat(repository.existsByLastname("Hans Peter"), is(false));
+	}
+
+	/**
 	 * @see DATAJPA-332
 	 */
 	@Test

--- a/src/test/java/org/springframework/data/jpa/repository/UserRepositoryTests.java
+++ b/src/test/java/org/springframework/data/jpa/repository/UserRepositoryTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2008-2016 the original author or authors.
+ * Copyright 2008-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -236,11 +236,7 @@ public class UserRepositoryTests {
 		assertThat(result.get(3), is(fourthUser));
 	}
 
-	/**
-	 * @see DATAJPA-296
-	 * @author Kevin Raymond
-	 */
-	@Test
+	@Test // DATAJPA-296
 	public void returnsAllIgnoreCaseSortedCorrectly() throws Exception {
 
 		flushTestUsers();
@@ -360,10 +356,7 @@ public class UserRepositoryTests {
 		assertThat(repository.count(), is(0L));
 	}
 
-	/**
-	 * @see DATAJPA-137
-	 */
-	@Test
+	@Test // DATAJPA-137
 	public void deleteAllInBatch() {
 
 		flushTestUsers();
@@ -498,10 +491,7 @@ public class UserRepositoryTests {
 		assertThat(repository.findAll(spec), hasSize(2));
 	}
 
-	/**
-	 * @see DATAJPA-253
-	 */
-	@Test
+	@Test // DATAJPA-253
 	public void executesNegatingSpecificationCorrectly() {
 
 		flushTestUsers();
@@ -730,10 +720,7 @@ public class UserRepositoryTests {
 		assertThat(result, hasItem(firstUser));
 	}
 
-	/**
-	 * @see DATADOC-86
-	 */
-	@Test
+	@Test // DATADOC-86
 	public void readsPageWithGroupByClauseCorrectly() {
 
 		flushTestUsers();
@@ -762,10 +749,7 @@ public class UserRepositoryTests {
 		assertThat(result, hasItems(secondUser, thirdUser));
 	}
 
-	/**
-	 * @see DATAJPA-117
-	 */
-	@Test
+	@Test // DATAJPA-117
 	public void executesNativeQueryCorrectly() {
 
 		flushTestUsers();
@@ -776,10 +760,7 @@ public class UserRepositoryTests {
 		assertThat(result.size(), is(1));
 	}
 
-	/**
-	 * @see DATAJPA-132
-	 */
-	@Test
+	@Test // DATAJPA-132
 	public void executesFinderWithTrueKeywordCorrectly() {
 
 		flushTestUsers();
@@ -791,10 +772,7 @@ public class UserRepositoryTests {
 		assertThat(result, hasItems(secondUser, thirdUser, fourthUser));
 	}
 
-	/**
-	 * @see DATAJPA-132
-	 */
-	@Test
+	@Test // DATAJPA-132
 	public void executesFinderWithFalseKeywordCorrectly() {
 
 		flushTestUsers();
@@ -822,10 +800,7 @@ public class UserRepositoryTests {
 		assertThat(result, hasItem(thirdUser));
 	}
 
-	/**
-	 * @see DATAJPA-188
-	 */
-	@Test
+	@Test // DATAJPA-188
 	public void executesFinderWithAfterKeywordCorrectly() {
 
 		flushTestUsers();
@@ -835,10 +810,7 @@ public class UserRepositoryTests {
 		assertThat(result, hasItems(thirdUser, fourthUser));
 	}
 
-	/**
-	 * @see DATAJPA-188
-	 */
-	@Test
+	@Test // DATAJPA-188
 	public void executesFinderWithBeforeKeywordCorrectly() {
 
 		flushTestUsers();
@@ -848,10 +820,7 @@ public class UserRepositoryTests {
 		assertThat(result, hasItems(firstUser, secondUser));
 	}
 
-	/**
-	 * @see DATAJPA-180
-	 */
-	@Test
+	@Test // DATAJPA-180
 	public void executesFinderWithStartingWithCorrectly() {
 
 		flushTestUsers();
@@ -860,10 +829,7 @@ public class UserRepositoryTests {
 		assertThat(result, hasItem(firstUser));
 	}
 
-	/**
-	 * @see DATAJPA-180
-	 */
-	@Test
+	@Test // DATAJPA-180
 	public void executesFinderWithEndingWithCorrectly() {
 
 		flushTestUsers();
@@ -872,10 +838,7 @@ public class UserRepositoryTests {
 		assertThat(result, hasItem(firstUser));
 	}
 
-	/**
-	 * @see DATAJPA-180
-	 */
-	@Test
+	@Test // DATAJPA-180
 	public void executesFinderWithContainingCorrectly() {
 
 		flushTestUsers();
@@ -884,10 +847,7 @@ public class UserRepositoryTests {
 		assertThat(result, hasItems(secondUser, thirdUser));
 	}
 
-	/**
-	 * @see DATAJPA-201
-	 */
-	@Test
+	@Test // DATAJPA-201
 	public void allowsExecutingPageableMethodWithNullPageable() {
 
 		flushTestUsers();
@@ -905,10 +865,7 @@ public class UserRepositoryTests {
 		assertThat(page.getContent(), hasItems(firstUser, secondUser, thirdUser, fourthUser));
 	}
 
-	/**
-	 * @see DATAJPA-207
-	 */
-	@Test
+	@Test // DATAJPA-207
 	public void executesNativeQueryForNonEntitiesCorrectly() {
 
 		flushTestUsers();
@@ -919,10 +876,7 @@ public class UserRepositoryTests {
 		assertThat(result, hasItem(1));
 	}
 
-	/**
-	 * @see DATAJPA-232
-	 */
-	@Test
+	@Test // DATAJPA-232
 	public void handlesIterableOfIdsCorrectly() {
 
 		flushTestUsers();
@@ -993,10 +947,7 @@ public class UserRepositoryTests {
 		assertThat(all.getContent().isEmpty(), is(false));
 	}
 
-	/**
-	 * @see DATAJPA-252
-	 */
-	@Test
+	@Test // DATAJPA-252
 	public void bindsSortingToOuterJoinCorrectly() {
 
 		flushTestUsers();
@@ -1006,10 +957,7 @@ public class UserRepositoryTests {
 		assertThat(result.getContent(), hasSize((int) repository.count()));
 	}
 
-	/**
-	 * @see DATAJPA-277
-	 */
-	@Test
+	@Test // DATAJPA-277
 	public void doesNotDropNullValuesOnPagedSpecificationExecution() {
 
 		flushTestUsers();
@@ -1024,10 +972,7 @@ public class UserRepositoryTests {
 		assertThat(page, hasItem(firstUser));
 	}
 
-	/**
-	 * @see DATAJPA-346
-	 */
-	@Test
+	@Test // DATAJPA-346
 	public void shouldGenerateLeftOuterJoinInfindAllWithPaginationAndSortOnNestedPropertyPath() {
 
 		firstUser.setManager(null);
@@ -1046,10 +991,7 @@ public class UserRepositoryTests {
 		assertThat(pages.getTotalElements(), is(4L));
 	}
 
-	/**
-	 * @see DATAJPA-292
-	 */
-	@Test
+	@Test // DATAJPA-292
 	public void executesManualQueryWithPositionLikeExpressionCorrectly() {
 
 		flushTestUsers();
@@ -1060,10 +1002,7 @@ public class UserRepositoryTests {
 		assertThat(result, hasItem(thirdUser));
 	}
 
-	/**
-	 * @see DATAJPA-292
-	 */
-	@Test
+	@Test // DATAJPA-292
 	public void executesManualQueryWithNamedLikeExpressionCorrectly() {
 
 		flushTestUsers();
@@ -1074,10 +1013,7 @@ public class UserRepositoryTests {
 		assertThat(result, hasItem(thirdUser));
 	}
 
-	/**
-	 * @see DATAJPA-231
-	 */
-	@Test
+	@Test // DATAJPA-231
 	public void executesDerivedCountQueryToLong() {
 
 		flushTestUsers();
@@ -1085,10 +1021,7 @@ public class UserRepositoryTests {
 		assertThat(repository.countByLastname("Matthews"), is(1L));
 	}
 
-	/**
-	 * @see DATAJPA-231
-	 */
-	@Test
+	@Test // DATAJPA-231
 	public void executesDerivedCountQueryToInt() {
 
 		flushTestUsers();
@@ -1096,10 +1029,7 @@ public class UserRepositoryTests {
 		assertThat(repository.countUsersByFirstname("Dave"), is(1));
 	}
 
-	/**
-	 * @see DATAJPA-231
-	 */
-	@Test
+	@Test // DATAJPA-231
 	public void executesDerivedExistsQuery() {
 
 		flushTestUsers();
@@ -1108,20 +1038,14 @@ public class UserRepositoryTests {
 		assertThat(repository.existsByLastname("Hans Peter"), is(false));
 	}
 
-	/**
-	 * @see DATAJPA-332
-	 */
-	@Test
+	@Test // DATAJPA-332
 	public void findAllReturnsEmptyIterableIfNoIdsGiven() {
 
 		assertThat(repository.findAll(Collections.<Integer> emptySet()), is(emptyIterable()));
 		assertThat(repository.findAll((Iterable<Integer>) null), is(emptyIterable()));
 	}
 
-	/**
-	 * @see DATAJPA-391
-	 */
-	@Test
+	@Test // DATAJPA-391
 	public void executesManuallyDefinedQueryWithFieldProjection() {
 
 		flushTestUsers();
@@ -1131,10 +1055,7 @@ public class UserRepositoryTests {
 		assertThat(lastname, hasItem("Dave"));
 	}
 
-	/**
-	 * @see DATAJPA-83
-	 */
-	@Test
+	@Test // DATAJPA-83
 	public void looksUpEntityReference() {
 
 		flushTestUsers();
@@ -1143,10 +1064,7 @@ public class UserRepositoryTests {
 		assertThat(result, is(firstUser));
 	}
 
-	/**
-	 * @see DATAJPA-415
-	 */
-	@Test
+	@Test // DATAJPA-415
 	public void invokesQueryWithVarargsParametersCorrectly() {
 
 		flushTestUsers();
@@ -1157,10 +1075,7 @@ public class UserRepositoryTests {
 		assertThat(result, hasItems(firstUser, secondUser));
 	}
 
-	/**
-	 * @see DATAJPA-415
-	 */
-	@Test
+	@Test // DATAJPA-415
 	public void shouldSupportModifyingQueryWithVarArgs() {
 
 		flushTestUsers();
@@ -1173,10 +1088,7 @@ public class UserRepositoryTests {
 		assertThat(repository.findByActiveTrue().size(), is(0));
 	}
 
-	/**
-	 * @see DATAJPA-405
-	 */
-	@Test
+	@Test // DATAJPA-405
 	public void executesFinderWithOrderClauseOnly() {
 
 		flushTestUsers();
@@ -1187,10 +1099,7 @@ public class UserRepositoryTests {
 		assertThat(result, contains(secondUser, firstUser, thirdUser, fourthUser));
 	}
 
-	/**
-	 * @see DATAJPA-427
-	 */
-	@Test
+	@Test // DATAJPA-427
 	public void sortByAssociationPropertyShouldUseLeftOuterJoin() {
 
 		secondUser.getColleagues().add(firstUser);
@@ -1202,10 +1111,7 @@ public class UserRepositoryTests {
 		assertThat(result, hasSize(4));
 	}
 
-	/**
-	 * @see DATAJPA-427
-	 */
-	@Test
+	@Test // DATAJPA-427
 	public void sortByAssociationPropertyInPageableShouldUseLeftOuterJoin() {
 
 		secondUser.getColleagues().add(firstUser);
@@ -1217,10 +1123,7 @@ public class UserRepositoryTests {
 		assertThat(page.getContent(), hasSize(4));
 	}
 
-	/**
-	 * @see DATAJPA-427
-	 */
-	@Test
+	@Test // DATAJPA-427
 	public void sortByEmbeddedProperty() {
 
 		thirdUser.setAddress(new Address("Germany", "Saarbrücken", "HaveItYourWay", "123"));
@@ -1232,10 +1135,7 @@ public class UserRepositoryTests {
 		assertThat(page.getContent().get(3), is(thirdUser));
 	}
 
-	/**
-	 * @see DATAJPA-454
-	 */
-	@Test
+	@Test // DATAJPA-454
 	public void findsUserByBinaryDataReference() throws Exception {
 
 		byte[] data = "Woho!!".getBytes("UTF-8");
@@ -1249,10 +1149,7 @@ public class UserRepositoryTests {
 		assertThat(result.get(0).getBinaryData(), is(data));
 	}
 
-	/**
-	 * @see DATAJPA-461
-	 */
-	@Test
+	@Test // DATAJPA-461
 	public void customFindByQueryWithPositionalVarargsParameters() {
 
 		flushTestUsers();
@@ -1263,10 +1160,7 @@ public class UserRepositoryTests {
 		assertThat(result, hasItems(firstUser, secondUser));
 	}
 
-	/**
-	 * @see DATAJPA-461
-	 */
-	@Test
+	@Test // DATAJPA-461
 	public void customFindByQueryWithNamedVarargsParameters() {
 
 		flushTestUsers();
@@ -1277,10 +1171,7 @@ public class UserRepositoryTests {
 		assertThat(result, hasItems(firstUser, secondUser));
 	}
 
-	/**
-	 * @see DATAJPA-464
-	 */
-	@Test
+	@Test // DATAJPA-464
 	public void saveAndFlushShouldSupportReturningSubTypesOfRepositoryEntity() {
 
 		repository.deleteAll();
@@ -1294,10 +1185,7 @@ public class UserRepositoryTests {
 		assertThat(user.getEmailAddress(), is(savedUser.getEmailAddress()));
 	}
 
-	/**
-	 * @see DATAJPA-218
-	 */
-	@Test
+	@Test // DATAJPA-218
 	public void findAllByUntypedExampleShouldReturnSubTypesOfRepositoryEntity() {
 
 		flushTestUsers();
@@ -1314,10 +1202,7 @@ public class UserRepositoryTests {
 		assertThat(result, hasSize(5));
 	}
 
-	/**
-	 * @see DATAJPA-218
-	 */
-	@Test
+	@Test // DATAJPA-218
 	public void findAllByTypedUserExampleShouldReturnSubTypesOfRepositoryEntity() {
 
 		flushTestUsers();
@@ -1334,10 +1219,7 @@ public class UserRepositoryTests {
 		assertThat(result, hasSize(5));
 	}
 
-	/**
-	 * @see DATAJPA-218
-	 */
-	@Test
+	@Test // DATAJPA-218
 	public void findAllByTypedSpecialUserExampleShouldReturnSubTypesOfRepositoryEntity() {
 
 		flushTestUsers();
@@ -1355,10 +1237,7 @@ public class UserRepositoryTests {
 		assertThat(result, hasSize(1));
 	}
 
-	/**
-	 * @see DATAJPA-491
-	 */
-	@Test
+	@Test // DATAJPA-491
 	public void sortByNestedAssociationPropertyWithSortInPageable() {
 
 		firstUser.setManager(thirdUser);
@@ -1373,10 +1252,7 @@ public class UserRepositoryTests {
 		assertThat(page.getContent().get(3), is(firstUser));
 	}
 
-	/**
-	 * @see DATAJPA-510
-	 */
-	@Test
+	@Test // DATAJPA-510
 	public void sortByNestedAssociationPropertyWithSortOrderIgnoreCaseInPageable() {
 
 		firstUser.setManager(thirdUser);
@@ -1391,10 +1267,7 @@ public class UserRepositoryTests {
 		assertThat(page.getContent().get(3), is(firstUser));
 	}
 
-	/**
-	 * @see DATAJPA-496
-	 */
-	@Test
+	@Test // DATAJPA-496
 	public void findByElementCollectionAttribute() {
 
 		firstUser.getAttributes().add("cool");
@@ -1409,10 +1282,7 @@ public class UserRepositoryTests {
 		assertThat(result, hasItems(firstUser, secondUser));
 	}
 
-	/**
-	 * @see DATAJPA-460
-	 */
-	@Test
+	@Test // DATAJPA-460
 	public void deleteByShouldReturnListOfDeletedElementsWhenRetunTypeIsCollectionLike() {
 
 		flushTestUsers();
@@ -1422,10 +1292,7 @@ public class UserRepositoryTests {
 		assertThat(result, hasSize(1));
 	}
 
-	/**
-	 * @see DATAJPA-460
-	 */
-	@Test
+	@Test // DATAJPA-460
 	public void deleteByShouldRemoveElementsMatchingDerivedQuery() {
 
 		flushTestUsers();
@@ -1434,10 +1301,7 @@ public class UserRepositoryTests {
 		assertThat(repository.countByLastname(firstUser.getLastname()), is(0L));
 	}
 
-	/**
-	 * @see DATAJPA-460
-	 */
-	@Test
+	@Test // DATAJPA-460
 	public void deleteByShouldReturnNumberOfEntitiesRemovedIfReturnTypeIsLong() {
 
 		flushTestUsers();
@@ -1445,10 +1309,7 @@ public class UserRepositoryTests {
 		assertThat(repository.removeByLastname(firstUser.getLastname()), is(1L));
 	}
 
-	/**
-	 * @see DATAJPA-460
-	 */
-	@Test
+	@Test // DATAJPA-460
 	public void deleteByShouldReturnZeroInCaseNoEntityHasBeenRemovedAndReturnTypeIsNumber() {
 
 		flushTestUsers();
@@ -1456,10 +1317,7 @@ public class UserRepositoryTests {
 		assertThat(repository.removeByLastname("bubu"), is(0L));
 	}
 
-	/**
-	 * @see DATAJPA-460
-	 */
-	@Test
+	@Test // DATAJPA-460
 	public void deleteByShouldReturnEmptyListInCaseNoEntityHasBeenRemovedAndReturnTypeIsCollectionLike() {
 
 		flushTestUsers();
@@ -1468,10 +1326,9 @@ public class UserRepositoryTests {
 	}
 
 	/**
-	 * @see DATAJPA-505
 	 * @see https://issues.apache.org/jira/browse/OPENJPA-2484
 	 */
-	@Test
+	@Test // DATAJPA-505
 	@Ignore
 	public void findBinaryDataByIdJpaQl() throws Exception {
 
@@ -1486,10 +1343,7 @@ public class UserRepositoryTests {
 		assertThat(result, is(data));
 	}
 
-	/**
-	 * @see DATAJPA-506
-	 */
-	@Test
+	@Test // DATAJPA-506
 	public void findBinaryDataByIdNative() throws Exception {
 
 		byte[] data = "Woho!!".getBytes("UTF-8");
@@ -1502,10 +1356,7 @@ public class UserRepositoryTests {
 		assertThat(result, is(data));
 	}
 
-	/**
-	 * @see DATAJPA-456
-	 */
-	@Test
+	@Test // DATAJPA-456
 	public void findPaginatedExplicitQueryWithCountQueryProjection() {
 
 		firstUser.setFirstname(null);
@@ -1517,10 +1368,7 @@ public class UserRepositoryTests {
 		assertThat(result.getContent().size(), is(3));
 	}
 
-	/**
-	 * @see DATAJPA-456
-	 */
-	@Test
+	@Test // DATAJPA-456
 	public void findPaginatedNamedQueryWithCountQueryProjection() {
 
 		flushTestUsers();
@@ -1530,10 +1378,7 @@ public class UserRepositoryTests {
 		assertThat(result.getContent().size(), is(1));
 	}
 
-	/**
-	 * @see DATAJPA-551
-	 */
-	@Test
+	@Test // DATAJPA-551
 	public void findOldestUser() {
 
 		flushTestUsers();
@@ -1544,10 +1389,7 @@ public class UserRepositoryTests {
 		assertThat(repository.findFirst1ByOrderByAgeDesc(), is(oldest));
 	}
 
-	/**
-	 * @see DATAJPA-551
-	 */
-	@Test
+	@Test // DATAJPA-551
 	public void findYoungestUser() {
 
 		flushTestUsers();
@@ -1558,10 +1400,7 @@ public class UserRepositoryTests {
 		assertThat(repository.findTop1ByOrderByAgeAsc(), is(youngest));
 	}
 
-	/**
-	 * @see DATAJPA-551
-	 */
-	@Test
+	@Test // DATAJPA-551
 	public void find2OldestUsers() {
 
 		flushTestUsers();
@@ -1573,10 +1412,7 @@ public class UserRepositoryTests {
 		assertThat(repository.findTop2ByOrderByAgeDesc(), hasItems(oldest1, oldest2));
 	}
 
-	/**
-	 * @see DATAJPA-551
-	 */
-	@Test
+	@Test // DATAJPA-551
 	public void find2YoungestUsers() {
 
 		flushTestUsers();
@@ -1588,10 +1424,7 @@ public class UserRepositoryTests {
 		assertThat(repository.findTop2UsersBy(new Sort(ASC, "age")), hasItems(youngest1, youngest2));
 	}
 
-	/**
-	 * @see DATAJPA-551
-	 */
-	@Test
+	@Test // DATAJPA-551
 	public void find3YoungestUsersPageableWithPageSize2() {
 
 		flushTestUsers();
@@ -1607,10 +1440,7 @@ public class UserRepositoryTests {
 		assertThat(secondPage.getContent(), hasItems(youngest3));
 	}
 
-	/**
-	 * @see DATAJPA-551
-	 */
-	@Test
+	@Test // DATAJPA-551
 	public void find2YoungestUsersPageableWithPageSize3() {
 
 		flushTestUsers();
@@ -1626,10 +1456,7 @@ public class UserRepositoryTests {
 		assertThat(secondPage.getContent(), hasItems(youngest3));
 	}
 
-	/**
-	 * @see DATAJPA-551
-	 */
-	@Test
+	@Test // DATAJPA-551
 	public void find3YoungestUsersPageableWithPageSize2Sliced() {
 
 		flushTestUsers();
@@ -1645,10 +1472,7 @@ public class UserRepositoryTests {
 		assertThat(secondPage.getContent(), hasItems(youngest3));
 	}
 
-	/**
-	 * @see DATAJPA-551
-	 */
-	@Test
+	@Test // DATAJPA-551
 	public void find2YoungestUsersPageableWithPageSize3Sliced() {
 
 		flushTestUsers();
@@ -1664,10 +1488,7 @@ public class UserRepositoryTests {
 		assertThat(secondPage.getContent(), hasItems(youngest3));
 	}
 
-	/**
-	 * @see DATAJPA-912
-	 */
-	@Test
+	@Test // DATAJPA-912
 	public void pageableQueryReportsTotalFromResult() {
 
 		flushTestUsers();
@@ -1681,10 +1502,7 @@ public class UserRepositoryTests {
 		assertThat(secondPage.getTotalElements(), is(4L));
 	}
 
-	/**
-	 * @see DATAJPA-912
-	 */
-	@Test
+	@Test // DATAJPA-912
 	public void pageableQueryReportsTotalFromCount() {
 
 		flushTestUsers();
@@ -1698,10 +1516,7 @@ public class UserRepositoryTests {
 		assertThat(secondPage.getTotalElements(), is(4L));
 	}
 
-	/**
-	 * @see DATAJPA-506
-	 */
-	@Test
+	@Test // DATAJPA-506
 	public void invokesQueryWithWrapperType() {
 
 		flushTestUsers();
@@ -1712,10 +1527,7 @@ public class UserRepositoryTests {
 		assertThat(result.get(), is(firstUser));
 	}
 
-	/**
-	 * @see DATAJPA-564
-	 */
-	@Test
+	@Test // DATAJPA-564
 	public void shouldFindUserByFirstnameAndLastnameWithSpelExpressionInStringBasedQuery() {
 
 		flushTestUsers();
@@ -1725,10 +1537,7 @@ public class UserRepositoryTests {
 		assertThat(users.get(0), is(firstUser));
 	}
 
-	/**
-	 * @see DATAJPA-564
-	 */
-	@Test
+	@Test // DATAJPA-564
 	public void shouldFindUserByLastnameWithSpelExpressionInStringBasedQuery() {
 
 		flushTestUsers();
@@ -1738,10 +1547,7 @@ public class UserRepositoryTests {
 		assertThat(users.get(0), is(firstUser));
 	}
 
-	/**
-	 * @see DATAJPA-564
-	 */
-	@Test
+	@Test // DATAJPA-564
 	public void shouldFindBySpELExpressionWithoutArgumentsWithQuestionmark() {
 
 		flushTestUsers();
@@ -1751,10 +1557,7 @@ public class UserRepositoryTests {
 		assertThat(users.get(0), is(firstUser));
 	}
 
-	/**
-	 * @see DATAJPA-564
-	 */
-	@Test
+	@Test // DATAJPA-564
 	public void shouldFindBySpELExpressionWithoutArgumentsWithColon() {
 
 		flushTestUsers();
@@ -1764,10 +1567,7 @@ public class UserRepositoryTests {
 		assertThat(users.get(0), is(firstUser));
 	}
 
-	/**
-	 * @see DATAJPA-564
-	 */
-	@Test
+	@Test // DATAJPA-564
 	public void shouldFindUsersByAgeForSpELExpression() {
 
 		flushTestUsers();
@@ -1777,10 +1577,7 @@ public class UserRepositoryTests {
 		assertThat(users.get(0), is(secondUser));
 	}
 
-	/**
-	 * @see DATAJPA-564
-	 */
-	@Test
+	@Test // DATAJPA-564
 	public void shouldfindUsersByFirstnameForSpELExpressionWithParameterNameVariableReference() {
 
 		flushTestUsers();
@@ -1790,10 +1587,7 @@ public class UserRepositoryTests {
 		assertThat(users.get(0), is(secondUser));
 	}
 
-	/**
-	 * @see DATAJPA-564
-	 */
-	@Test
+	@Test // DATAJPA-564
 	public void shouldFindCurrentUserWithCustomQueryDependingOnSecurityContext() {
 
 		flushTestUsers();
@@ -1811,10 +1605,7 @@ public class UserRepositoryTests {
 		assertThat(users.get(0), is(firstUser));
 	}
 
-	/**
-	 * @see DATAJPA-564
-	 */
-	@Test
+	@Test // DATAJPA-564
 	public void shouldFindByFirstnameAndCurrentUserWithCustomQuery() {
 
 		flushTestUsers();
@@ -1826,10 +1617,7 @@ public class UserRepositoryTests {
 		assertThat(users.get(0), is(secondUser));
 	}
 
-	/**
-	 * @see DATAJPA-564
-	 */
-	@Test
+	@Test // DATAJPA-564
 	public void shouldfindUsersByFirstnameForSpELExpressionOnlyWithParameterNameVariableReference() {
 
 		flushTestUsers();
@@ -1839,10 +1627,7 @@ public class UserRepositoryTests {
 		assertThat(users.get(0), is(secondUser));
 	}
 
-	/**
-	 * @see DATAJPA-564
-	 */
-	@Test
+	@Test // DATAJPA-564
 	public void shouldfindUsersByFirstnameForSpELExpressionOnlyWithParameterIndexReference() {
 
 		flushTestUsers();
@@ -1852,10 +1637,7 @@ public class UserRepositoryTests {
 		assertThat(users.get(0), is(secondUser));
 	}
 
-	/**
-	 * @see DATAJPA-564
-	 */
-	@Test
+	@Test // DATAJPA-564
 	public void shouldFindUsersInNativeQueryWithPagination() {
 
 		flushTestUsers();
@@ -1873,10 +1655,7 @@ public class UserRepositoryTests {
 		assertThat(users.getContent().get(1), is(fourthUser));
 	}
 
-	/**
-	 * @see DATAJPA-629
-	 */
-	@Test
+	@Test // DATAJPA-629
 	public void shouldfindUsersBySpELExpressionParametersWithSpelTemplateExpression() {
 
 		flushTestUsers();
@@ -1887,10 +1666,7 @@ public class UserRepositoryTests {
 		assertThat(users.get(0), is(secondUser));
 	}
 
-	/**
-	 * @see DATAJPA-606
-	 */
-	@Test
+	@Test // DATAJPA-606
 	public void findByEmptyCollectionOfStrings() throws Exception {
 
 		flushTestUsers();
@@ -1899,10 +1675,7 @@ public class UserRepositoryTests {
 		assertThat(users, hasSize(0));
 	}
 
-	/**
-	 * @see DATAJPA-606
-	 */
-	@Test
+	@Test // DATAJPA-606
 	public void findByEmptyCollectionOfIntegers() throws Exception {
 
 		flushTestUsers();
@@ -1911,10 +1684,7 @@ public class UserRepositoryTests {
 		assertThat(users, hasSize(0));
 	}
 
-	/**
-	 * @see DATAJPA-606
-	 */
-	@Test
+	@Test // DATAJPA-606
 	public void findByEmptyArrayOfIntegers() throws Exception {
 
 		flushTestUsers();
@@ -1923,10 +1693,7 @@ public class UserRepositoryTests {
 		assertThat(users, hasSize(0));
 	}
 
-	/**
-	 * @see DATAJPA-606
-	 */
-	@Test
+	@Test // DATAJPA-606
 	public void findByAgeWithEmptyArrayOfIntegersOrFirstName() {
 
 		flushTestUsers();
@@ -1936,10 +1703,7 @@ public class UserRepositoryTests {
 		assertThat(users.get(0), is(secondUser));
 	}
 
-	/**
-	 * @see DATAJPA-677
-	 */
-	@Test
+	@Test // DATAJPA-677
 	public void shouldSupportJava8StreamsForRepositoryFinderMethods() {
 
 		flushTestUsers();
@@ -1965,10 +1729,7 @@ public class UserRepositoryTests {
 		assertThat(users, hasSize(4));
 	}
 
-	/**
-	 * @see DATAJPA-677
-	 */
-	@Test
+	@Test // DATAJPA-677
 	public void shouldSupportJava8StreamsForRepositoryDerivedFinderMethods() {
 
 		flushTestUsers();
@@ -1994,10 +1755,7 @@ public class UserRepositoryTests {
 		assertThat(users, hasSize(4));
 	}
 
-	/**
-	 * @see DATAJPA-677
-	 */
-	@Test
+	@Test // DATAJPA-677
 	public void supportsJava8StreamForPageableMethod() {
 
 		flushTestUsers();
@@ -2023,10 +1781,7 @@ public class UserRepositoryTests {
 		assertThat(users, hasSize(2));
 	}
 
-	/**
-	 * @see DATAJPA-218
-	 */
-	@Test
+	@Test // DATAJPA-218
 	public void findAllByExample() {
 
 		flushTestUsers();
@@ -2041,10 +1796,7 @@ public class UserRepositoryTests {
 		assertThat(users.get(0), is(firstUser));
 	}
 
-	/**
-	 * @see DATAJPA-218
-	 */
-	@Test
+	@Test // DATAJPA-218
 	public void findAllByExampleWithEmptyProbe() {
 
 		flushTestUsers();
@@ -2058,18 +1810,12 @@ public class UserRepositoryTests {
 		assertThat(users, hasSize(4));
 	}
 
-	/**
-	 * @see DATAJPA-218
-	 */
-	@Test(expected = InvalidDataAccessApiUsageException.class)
+	@Test(expected = InvalidDataAccessApiUsageException.class) // DATAJPA-218
 	public void findAllByNullExample() {
 		repository.findAll((Example<User>) null);
 	}
 
-	/**
-	 * @see DATAJPA-218
-	 */
-	@Test
+	@Test // DATAJPA-218
 	public void findAllByExampleWithExcludedAttributes() {
 
 		flushTestUsers();
@@ -2084,10 +1830,7 @@ public class UserRepositoryTests {
 		assertThat(users.get(0), is(firstUser));
 	}
 
-	/**
-	 * @see DATAJPA-218
-	 */
-	@Test
+	@Test // DATAJPA-218
 	public void findAllByExampleWithAssociation() {
 
 		flushTestUsers();
@@ -2112,10 +1855,7 @@ public class UserRepositoryTests {
 		assertThat(users.get(0), is(firstUser));
 	}
 
-	/**
-	 * @see DATAJPA-218
-	 */
-	@Test
+	@Test // DATAJPA-218
 	public void findAllByExampleWithEmbedded() {
 
 		flushTestUsers();
@@ -2134,10 +1874,7 @@ public class UserRepositoryTests {
 		assertThat(users.get(0), is(firstUser));
 	}
 
-	/**
-	 * @see DATAJPA-218
-	 */
-	@Test
+	@Test // DATAJPA-218
 	public void findAllByExampleWithStartingStringMatcher() {
 
 		flushTestUsers();
@@ -2153,10 +1890,7 @@ public class UserRepositoryTests {
 		assertThat(users.get(0), is(firstUser));
 	}
 
-	/**
-	 * @see DATAJPA-218
-	 */
-	@Test
+	@Test // DATAJPA-218
 	public void findAllByExampleWithEndingStringMatcher() {
 
 		flushTestUsers();
@@ -2172,10 +1906,7 @@ public class UserRepositoryTests {
 		assertThat(users.get(0), is(firstUser));
 	}
 
-	/**
-	 * @see DATAJPA-218
-	 */
-	@Test(expected = InvalidDataAccessApiUsageException.class)
+	@Test(expected = InvalidDataAccessApiUsageException.class) // DATAJPA-218
 	public void findAllByExampleWithRegexStringMatcher() {
 
 		flushTestUsers();
@@ -2187,10 +1918,7 @@ public class UserRepositoryTests {
 		repository.findAll(example);
 	}
 
-	/**
-	 * @see DATAJPA-218
-	 */
-	@Test
+	@Test // DATAJPA-218
 	public void findAllByExampleWithIgnoreCase() {
 
 		flushTestUsers();
@@ -2206,10 +1934,7 @@ public class UserRepositoryTests {
 		assertThat(users.get(0), is(firstUser));
 	}
 
-	/**
-	 * @see DATAJPA-218
-	 */
-	@Test
+	@Test // DATAJPA-218
 	public void findAllByExampleWithStringMatcherAndIgnoreCase() {
 
 		flushTestUsers();
@@ -2226,10 +1951,7 @@ public class UserRepositoryTests {
 		assertThat(users.get(0), is(firstUser));
 	}
 
-	/**
-	 * @see DATAJPA-218
-	 */
-	@Test
+	@Test // DATAJPA-218
 	public void findAllByExampleWithIncludeNull() {
 
 		// something is wrong with OpenJPA - I do not know what
@@ -2260,10 +1982,7 @@ public class UserRepositoryTests {
 		assertThat(users.get(0), is(fifthUser));
 	}
 
-	/**
-	 * @see DATAJPA-218
-	 */
-	@Test
+	@Test // DATAJPA-218
 	public void findAllByExampleWithPropertySpecifier() {
 
 		flushTestUsers();
@@ -2280,10 +1999,7 @@ public class UserRepositoryTests {
 		assertThat(users.get(0), is(firstUser));
 	}
 
-	/**
-	 * @see DATAJPA-218
-	 */
-	@Test
+	@Test // DATAJPA-218
 	public void findAllByExampleWithSort() {
 
 		flushTestUsers();
@@ -2306,10 +2022,7 @@ public class UserRepositoryTests {
 		assertThat(users.get(1), is(firstUser));
 	}
 
-	/**
-	 * @see DATAJPA-218
-	 */
-	@Test
+	@Test // DATAJPA-218
 	public void findAllByExampleWithPageable() {
 
 		flushTestUsers();
@@ -2334,10 +2047,7 @@ public class UserRepositoryTests {
 		assertThat(users.getTotalElements(), is(100L));
 	}
 
-	/**
-	 * @see DATAJPA-218
-	 */
-	@Test(expected = InvalidDataAccessApiUsageException.class)
+	@Test(expected = InvalidDataAccessApiUsageException.class) // DATAJPA-218
 	public void findAllByExampleShouldNotAllowCycles() {
 
 		flushTestUsers();
@@ -2353,10 +2063,7 @@ public class UserRepositoryTests {
 		repository.findAll(example, new PageRequest(0, 10, new Sort(DESC, "age")));
 	}
 
-	/**
-	 * @see DATAJPA-218
-	 */
-	@Test(expected = InvalidDataAccessApiUsageException.class)
+	@Test(expected = InvalidDataAccessApiUsageException.class) // DATAJPA-218
 	public void findAllByExampleShouldNotAllowCyclesOverSeveralInstances() {
 
 		flushTestUsers();
@@ -2376,10 +2083,7 @@ public class UserRepositoryTests {
 		repository.findAll(example, new PageRequest(0, 10, new Sort(DESC, "age")));
 	}
 
-	/**
-	 * @see DATAJPA-218
-	 */
-	@Test
+	@Test // DATAJPA-218
 	public void findOneByExampleWithExcludedAttributes() {
 
 		flushTestUsers();
@@ -2393,10 +2097,7 @@ public class UserRepositoryTests {
 		assertThat(users, is(firstUser));
 	}
 
-	/**
-	 * @see DATAJPA-218
-	 */
-	@Test
+	@Test // DATAJPA-218
 	public void countByExampleWithExcludedAttributes() {
 
 		flushTestUsers();
@@ -2410,10 +2111,7 @@ public class UserRepositoryTests {
 		assertThat(count, is(1L));
 	}
 
-	/**
-	 * @see DATAJPA-218
-	 */
-	@Test
+	@Test // DATAJPA-218
 	public void existsByExampleWithExcludedAttributes() {
 
 		flushTestUsers();
@@ -2427,10 +2125,7 @@ public class UserRepositoryTests {
 		assertThat(exists, is(true));
 	}
 
-	/**
-	 * @see DATAJPA-905
-	 */
-	@Test
+	@Test // DATAJPA-905
 	public void excutesPagedSpecificationSettingAnOrder() {
 
 		flushTestUsers();

--- a/src/test/java/org/springframework/data/jpa/repository/cdi/CdiExtensionIntegrationTests.java
+++ b/src/test/java/org/springframework/data/jpa/repository/cdi/CdiExtensionIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2014 the original author or authors.
+ * Copyright 2011-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -52,10 +52,7 @@ public class CdiExtensionIntegrationTests {
 		LOGGER.debug("CDI container bootstrapped!");
 	}
 
-	/**
-	 * @see DATAJPA-319
-	 */
-	@Test
+	@Test // DATAJPA-319
 	@SuppressWarnings("rawtypes")
 	public void foo() {
 
@@ -75,20 +72,14 @@ public class CdiExtensionIntegrationTests {
 		repositoryConsumer.findAll();
 	}
 
-	/**
-	 * @see DATAJPA-584
-	 */
-	@Test
+	@Test // DATAJPA-584
 	public void returnOneFromCustomImpl() {
 
 		RepositoryConsumer repositoryConsumer = container.getInstance(RepositoryConsumer.class);
 		assertThat(repositoryConsumer.returnOne(), is(1));
 	}
 
-	/**
-	 * @see DATAJPA-584
-	 */
-	@Test
+	@Test // DATAJPA-584
 	public void useQualifiedCustomizedUserRepo() {
 
 		RepositoryConsumer repositoryConsumer = container.getInstance(RepositoryConsumer.class);

--- a/src/test/java/org/springframework/data/jpa/repository/cdi/EntityManagerFactoryProducer.java
+++ b/src/test/java/org/springframework/data/jpa/repository/cdi/EntityManagerFactoryProducer.java
@@ -21,12 +21,16 @@ import javax.enterprise.inject.Produces;
 import javax.persistence.EntityManagerFactory;
 import javax.persistence.Persistence;
 
+import org.hibernate.Version;
+
 class EntityManagerFactoryProducer {
 
 	@Produces
 	@ApplicationScoped
 	public EntityManagerFactory createEntityManagerFactory() {
-		return Persistence.createEntityManagerFactory("cdi");
+
+		String hibernateVersion = Version.getVersionString();
+		return Persistence.createEntityManagerFactory(hibernateVersion.startsWith("5.2") ? "cdi-52" : "cdi");
 	}
 
 	public void close(@Disposes EntityManagerFactory entityManagerFactory) {

--- a/src/test/java/org/springframework/data/jpa/repository/cdi/JpaRepositoryExtensionUnitTests.java
+++ b/src/test/java/org/springframework/data/jpa/repository/cdi/JpaRepositoryExtensionUnitTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 the original author or authors.
+ * Copyright 2013-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -66,10 +66,7 @@ public class JpaRepositoryExtensionUnitTests {
 		assertEntityManagerRegistered(extension, em);
 	}
 
-	/**
-	 * @see DATAJPA-388
-	 */
-	@Test
+	@Test // DATAJPA-388
 	public void alternativeEntityManagerOverridesDefault() {
 
 		JpaRepositoryExtension extension = new JpaRepositoryExtension();
@@ -79,10 +76,7 @@ public class JpaRepositoryExtensionUnitTests {
 		assertEntityManagerRegistered(extension, alternativeEm);
 	}
 
-	/**
-	 * @see DATAJPA-388
-	 */
-	@Test
+	@Test // DATAJPA-388
 	public void alternativeEntityManagerDoesNotGetOverridden() {
 
 		JpaRepositoryExtension extension = new JpaRepositoryExtension();

--- a/src/test/java/org/springframework/data/jpa/repository/cdi/QualifiedCustomizedCdiConfiguration.java
+++ b/src/test/java/org/springframework/data/jpa/repository/cdi/QualifiedCustomizedCdiConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Copyright 2014-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,7 +19,6 @@ package org.springframework.data.jpa.repository.cdi;
 import org.springframework.data.repository.cdi.CdiRepositoryConfiguration;
 
 /**
- * @see DATAJPA-584
  * @author Mark Paluch
  */
 @UserDB

--- a/src/test/java/org/springframework/data/jpa/repository/cdi/QualifiedCustomizedUserRepository.java
+++ b/src/test/java/org/springframework/data/jpa/repository/cdi/QualifiedCustomizedUserRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Copyright 2014-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,7 +20,6 @@ import org.springframework.data.jpa.domain.sample.User;
 import org.springframework.data.repository.Repository;
 
 /**
- * @see DATAJPA-584
  * @author Mark Paluch
  */
 @UserDB

--- a/src/test/java/org/springframework/data/jpa/repository/cdi/QualifiedCustomizedUserRepositoryBean.java
+++ b/src/test/java/org/springframework/data/jpa/repository/cdi/QualifiedCustomizedUserRepositoryBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Copyright 2014-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,6 @@
 package org.springframework.data.jpa.repository.cdi;
 
 /**
- * @see DATAJPA-584
  * @author Mark Paluch
  */
 @UserDB

--- a/src/test/java/org/springframework/data/jpa/repository/cdi/QualifiedCustomizedUserRepositoryCustom.java
+++ b/src/test/java/org/springframework/data/jpa/repository/cdi/QualifiedCustomizedUserRepositoryCustom.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Copyright 2014-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,6 @@
 package org.springframework.data.jpa.repository.cdi;
 
 /**
- * @see DATAJPA-584
  * @author Mark Paluch
  */
 public interface QualifiedCustomizedUserRepositoryCustom {

--- a/src/test/java/org/springframework/data/jpa/repository/cdi/SamplePersonRepository.java
+++ b/src/test/java/org/springframework/data/jpa/repository/cdi/SamplePersonRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Copyright 2014-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,7 +19,6 @@ package org.springframework.data.jpa.repository.cdi;
 import org.springframework.data.repository.Repository;
 
 /**
- * @see DATAJPA-584
  * @author Mark Paluch
  */
 public interface SamplePersonRepository extends Repository<Person, Long>, SamplePersonRepositoryCustom {}

--- a/src/test/java/org/springframework/data/jpa/repository/cdi/SamplePersonRepositoryCustom.java
+++ b/src/test/java/org/springframework/data/jpa/repository/cdi/SamplePersonRepositoryCustom.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Copyright 2014-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,6 @@
 package org.springframework.data.jpa.repository.cdi;
 
 /**
- * @see DATAJPA-584
  * @author Mark Paluch
  */
 interface SamplePersonRepositoryCustom {

--- a/src/test/java/org/springframework/data/jpa/repository/cdi/SamplePersonRepositoryImpl.java
+++ b/src/test/java/org/springframework/data/jpa/repository/cdi/SamplePersonRepositoryImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Copyright 2014-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,6 @@
 package org.springframework.data.jpa.repository.cdi;
 
 /**
- * @see DATAJPA-584
  * @author Mark Paluch
  */
 class SamplePersonRepositoryImpl implements SamplePersonRepositoryCustom {

--- a/src/test/java/org/springframework/data/jpa/repository/cdi/UserDB.java
+++ b/src/test/java/org/springframework/data/jpa/repository/cdi/UserDB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Copyright 2014-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,7 +23,6 @@ import java.lang.annotation.Target;
 import javax.inject.Qualifier;
 
 /**
- * @see DATAJPA-584
  * @author Mark Paluch
  */
 @Qualifier

--- a/src/test/java/org/springframework/data/jpa/repository/config/AbstractAuditingViaJavaConfigRepositoriesTests.java
+++ b/src/test/java/org/springframework/data/jpa/repository/config/AbstractAuditingViaJavaConfigRepositoriesTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2015 the original author or authors.
+ * Copyright 2013-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -102,10 +102,7 @@ public abstract class AbstractAuditingViaJavaConfigRepositoriesTests {
 		assertThat(createdBy.getFirstname(), is(this.auditor.getFirstname()));
 	}
 
-	/**
-	 * @see DATAJPA-382
-	 */
-	@Test
+	@Test // DATAJPA-382
 	public void shouldAllowUseOfDynamicSpelParametersInUpdateQueries() {
 
 		AuditableUser oliver = auditableUserRepository.save(new AuditableUser(null, "oliver"));

--- a/src/test/java/org/springframework/data/jpa/repository/config/AbstractRepositoryConfigTests.java
+++ b/src/test/java/org/springframework/data/jpa/repository/config/AbstractRepositoryConfigTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2008-2014 the original author or authors.
+ * Copyright 2008-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -51,10 +51,7 @@ public abstract class AbstractRepositoryConfigTests {
 		assertNotNull(auditableUserRepository);
 	}
 
-	/**
-	 * @see DATAJPA-330
-	 */
-	@Test
+	@Test // DATAJPA-330
 	public void repositoriesHaveExceptionTranslationApplied() {
 
 		JpaRepositoriesRegistrarIntegrationTests.assertExceptionTranslationActive(userRepository);
@@ -62,10 +59,7 @@ public abstract class AbstractRepositoryConfigTests {
 		JpaRepositoriesRegistrarIntegrationTests.assertExceptionTranslationActive(auditableUserRepository);
 	}
 
-	/**
-	 * @see DATAJPA-???
-	 */
-	@Test
+	@Test // DATAJPA-484
 	public void exposesJpaMappingContext() {
 		assertNotNull(mappingContext);
 	}

--- a/src/test/java/org/springframework/data/jpa/repository/config/AllowNestedRepositoriesRepositoryConfigTests.java
+++ b/src/test/java/org/springframework/data/jpa/repository/config/AllowNestedRepositoriesRepositoryConfigTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 the original author or authors.
+ * Copyright 2013-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,10 +34,7 @@ public class AllowNestedRepositoriesRepositoryConfigTests extends AbstractReposi
 
 	@Autowired NestedUserRepository fooRepository;
 
-	/**
-	 * @see DATAJPA-416
-	 */
-	@Test
+	@Test // DATAJPA-416
 	public void shouldFindNestedRepository() {
 		assertThat(fooRepository, is(notNullValue()));
 	}

--- a/src/test/java/org/springframework/data/jpa/repository/config/AuditingBeanDefinitionParserTests.java
+++ b/src/test/java/org/springframework/data/jpa/repository/config/AuditingBeanDefinitionParserTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2008-2014 the original author or authors.
+ * Copyright 2008-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -47,10 +47,7 @@ public class AuditingBeanDefinitionParserTests {
 		assertSetDatesIsSetTo("auditing/auditing-namespace-context2.xml", "false");
 	}
 
-	/**
-	 * @see DATAJPA-9
-	 */
-	@Test
+	@Test // DATAJPA-9
 	public void wiresDateTimeProviderIfConfigured() {
 
 		BeanDefinition definition = getBeanDefinition("auditing/auditing-namespace-context3.xml");
@@ -65,10 +62,7 @@ public class AuditingBeanDefinitionParserTests {
 		assertThat(bean, is(notNullValue()));
 	}
 
-	/**
-	 * @see DATAJPA-367
-	 */
-	@Test(expected = BeanDefinitionParsingException.class)
+	@Test(expected = BeanDefinitionParsingException.class) // DATAJPA-367
 	public void shouldThrowBeanDefinitionParsingExceptionIfClassFromSpringAspectsJarCannotBeFound() {
 
 		ShadowingClassLoader scl = new ShadowingClassLoader(getClass().getClassLoader());

--- a/src/test/java/org/springframework/data/jpa/repository/config/CustomRepositoryFactoryConfigTests.java
+++ b/src/test/java/org/springframework/data/jpa/repository/config/CustomRepositoryFactoryConfigTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2008-2011 the original author or authors.
+ * Copyright 2008-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -38,6 +38,7 @@ import org.springframework.util.Assert;
  * intermediate interface.
  * 
  * @author Oliver Gierke
+ * @author Mark Paluch
  */
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration(locations = "classpath:config/namespace-customfactory-context.xml")
@@ -57,8 +58,6 @@ public class CustomRepositoryFactoryConfigTests {
 
 	@Test(expected = UnsupportedOperationException.class)
 	public void testCustomFactoryUsed() {
-
-		Assert.notNull(userRepository);
 		userRepository.customMethod(1);
 	}
 

--- a/src/test/java/org/springframework/data/jpa/repository/config/JpaAuditingRegistrarUnitTests.java
+++ b/src/test/java/org/springframework/data/jpa/repository/config/JpaAuditingRegistrarUnitTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 the original author or authors.
+ * Copyright 2013-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,7 +25,6 @@ import org.springframework.core.type.AnnotationMetadata;
 /**
  * Unit tests for {@link JpaAuditingRegistrar}.
  * 
- * @see DATAJPA-265
  * @author Oliver Gierke
  */
 @RunWith(MockitoJUnitRunner.class)
@@ -36,12 +35,12 @@ public class JpaAuditingRegistrarUnitTests {
 	@Mock AnnotationMetadata metadata;
 	@Mock BeanDefinitionRegistry registry;
 
-	@Test(expected = IllegalArgumentException.class)
+	@Test(expected = IllegalArgumentException.class) // DATAJPA-265
 	public void rejectsNullAnnotationMetadata() {
 		registrar.registerBeanDefinitions(null, registry);
 	}
 
-	@Test(expected = IllegalArgumentException.class)
+	@Test(expected = IllegalArgumentException.class) // DATAJPA-265
 	public void rejectsNullBeanDefinitionRegistry() {
 		registrar.registerBeanDefinitions(metadata, null);
 	}

--- a/src/test/java/org/springframework/data/jpa/repository/config/JpaRepositoriesRegistrarIntegrationTests.java
+++ b/src/test/java/org/springframework/data/jpa/repository/config/JpaRepositoriesRegistrarIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2014 the original author or authors.
+ * Copyright 2012-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -99,10 +99,7 @@ public class JpaRepositoriesRegistrarIntegrationTests {
 		assertThat(repository, is(notNullValue()));
 	}
 
-	/**
-	 * @see DATAJPA-330
-	 */
-	@Test
+	@Test // DATAJPA-330
 	public void doesNotProxyPlainAtRepositoryBeans() {
 
 		assertThat(sampleRepository, is(notNullValue()));

--- a/src/test/java/org/springframework/data/jpa/repository/config/JpaRepositoryConfigExtensionUnitTests.java
+++ b/src/test/java/org/springframework/data/jpa/repository/config/JpaRepositoryConfigExtensionUnitTests.java
@@ -41,7 +41,6 @@ import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.AnnotationConfigUtils;
 import org.springframework.data.repository.config.RepositoryConfigurationExtension;
 import org.springframework.data.repository.config.RepositoryConfigurationSource;
-import org.springframework.data.repository.core.support.RepositoryFactoryBeanSupport;
 import org.springframework.orm.jpa.support.PersistenceAnnotationBeanPostProcessor;
 
 /**
@@ -51,8 +50,6 @@ import org.springframework.orm.jpa.support.PersistenceAnnotationBeanPostProcesso
  */
 @RunWith(MockitoJUnitRunner.class)
 public class JpaRepositoryConfigExtensionUnitTests {
-
-	private static final String RIABPP_CLASS_NAME = RepositoryFactoryBeanSupport.class.getName().concat("_Predictor");
 
 	@Mock RepositoryConfigurationSource configSource;
 
@@ -68,7 +65,7 @@ public class JpaRepositoryConfigExtensionUnitTests {
 
 		Iterable<String> names = Arrays.asList(factory.getBeanDefinitionNames());
 
-		assertThat(names, hasItems(AnnotationConfigUtils.PERSISTENCE_ANNOTATION_PROCESSOR_BEAN_NAME, RIABPP_CLASS_NAME));
+		assertThat(names, hasItems(AnnotationConfigUtils.PERSISTENCE_ANNOTATION_PROCESSOR_BEAN_NAME));
 	}
 
 	@Test

--- a/src/test/java/org/springframework/data/jpa/repository/config/JpaRepositoryConfigExtensionUnitTests.java
+++ b/src/test/java/org/springframework/data/jpa/repository/config/JpaRepositoryConfigExtensionUnitTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2016 the original author or authors.
+ * Copyright 2013-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -90,10 +90,7 @@ public class JpaRepositoryConfigExtensionUnitTests {
 		assertOnlyOnePersistenceAnnotationBeanPostProcessorRegistered(factory, beanName);
 	}
 
-	/**
-	 * @see DATAJPA-525
-	 */
-	@Test
+	@Test // DATAJPA-525
 	public void guardsAgainstNullJavaTypesReturnedFromJpaMetamodel() throws Exception {
 
 		ApplicationContext context = mock(ApplicationContext.class);

--- a/src/test/java/org/springframework/data/jpa/repository/config/NestedRepositoriesJavaConfigTests.java
+++ b/src/test/java/org/springframework/data/jpa/repository/config/NestedRepositoriesJavaConfigTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 the original author or authors.
+ * Copyright 2013-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -46,10 +46,7 @@ public class NestedRepositoriesJavaConfigTests {
 
 	@Autowired NestedUserRepository nestedUserRepository;
 
-	/**
-	 * @see DATAJPA-416
-	 */
-	@Test
+	@Test // DATAJPA-416
 	public void shouldSupportNestedRepositories() {
 		assertThat(nestedUserRepository, is(notNullValue()));
 	}

--- a/src/test/java/org/springframework/data/jpa/repository/config/RepositoriesJavaConfigTests.java
+++ b/src/test/java/org/springframework/data/jpa/repository/config/RepositoriesJavaConfigTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 the original author or authors.
+ * Copyright 2013-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -57,10 +57,7 @@ public class RepositoriesJavaConfigTests {
 	@Autowired
 	Repositories repositories;
 
-	/**
-	 * @see DATAJPA-323
-	 */
-	@Test
+	@Test // DATAJPA-323
 	public void foo() {
 		assertThat(repositories.hasRepositoryFor(User.class), is(true));
 	}

--- a/src/test/java/org/springframework/data/jpa/repository/custom/CustomGenericJpaRepositoryFactoryBean.java
+++ b/src/test/java/org/springframework/data/jpa/repository/custom/CustomGenericJpaRepositoryFactoryBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2008-2011 the original author or authors.
+ * Copyright 2008-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,8 +29,12 @@ import org.springframework.data.repository.core.support.RepositoryFactorySupport
  * @author Gil Markham
  * @author Oliver Gierke
  */
-public class CustomGenericJpaRepositoryFactoryBean<T extends JpaRepository<Object, Serializable>> extends
-		JpaRepositoryFactoryBean<T, Object, Serializable> {
+public class CustomGenericJpaRepositoryFactoryBean<T extends JpaRepository<Object, Serializable>>
+		extends JpaRepositoryFactoryBean<T, Object, Serializable> {
+
+	public CustomGenericJpaRepositoryFactoryBean(Class<? extends T> repositoryInterface) {
+		super(repositoryInterface);
+	}
 
 	/*
 	 * (non-Javadoc)

--- a/src/test/java/org/springframework/data/jpa/repository/query/AbstractJpaQueryTests.java
+++ b/src/test/java/org/springframework/data/jpa/repository/query/AbstractJpaQueryTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2008-2015 the original author or authors.
+ * Copyright 2008-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -68,11 +68,7 @@ public class AbstractJpaQueryTests {
 		countQuery = mock(TypedQuery.class);
 	}
 
-	/**
-	 * @see DATADOC-97
-	 * @throws Exception
-	 */
-	@Test
+	@Test // DATADOC-97
 	public void addsHintsToQueryObject() throws Exception {
 
 		JpaQueryMethod queryMethod = getMethod("findByLastname", String.class);
@@ -86,11 +82,7 @@ public class AbstractJpaQueryTests {
 		verify(result).setHint("foo", "bar");
 	}
 
-	/**
-	 * @see DATAJPA-54
-	 * @throws Exception
-	 */
-	@Test
+	@Test // DATAJPA-54
 	public void skipsHintsForCountQueryIfConfigured() throws Exception {
 
 		JpaQueryMethod queryMethod = getMethod("findByFirstname", String.class);
@@ -103,10 +95,7 @@ public class AbstractJpaQueryTests {
 		verify(result, never()).setHint("bar", "foo");
 	}
 
-	/**
-	 * @see DATAJPA-73
-	 */
-	@Test
+	@Test // DATAJPA-73
 	public void addsLockingModeToQueryObject() throws Exception {
 
 		when(query.setLockMode(any(LockModeType.class))).thenReturn(query);
@@ -118,10 +107,7 @@ public class AbstractJpaQueryTests {
 		verify(result).setLockMode(LockModeType.PESSIMISTIC_WRITE);
 	}
 
-	/**
-	 * @see DATAJPA-466
-	 */
-	@Test
+	@Test // DATAJPA-466
 	@Transactional
 	public void shouldAddEntityGraphHintForFetch() throws Exception {
 
@@ -137,10 +123,7 @@ public class AbstractJpaQueryTests {
 		verify(result).setHint("javax.persistence.fetchgraph", entityGraph);
 	}
 
-	/**
-	 * @see DATAJPA-466
-	 */
-	@Test
+	@Test // DATAJPA-466
 	@Transactional
 	public void shouldAddEntityGraphHintForLoad() throws Exception {
 
@@ -177,15 +160,11 @@ public class AbstractJpaQueryTests {
 		@org.springframework.data.jpa.repository.Query("select u from User u where u.id = ?1")
 		List<User> findOneLocked(Integer primaryKey);
 
-		/**
-		 * @see DATAJPA-466
-		 */
+		// DATAJPA-466
 		@EntityGraph(value = "User.detail", type = EntityGraphType.LOAD)
 		User getById(Integer id);
 
-		/**
-		 * @see DATAJPA-466
-		 */
+		// DATAJPA-466
 		@EntityGraph("User.overview")
 		List<User> findAll();
 	}

--- a/src/test/java/org/springframework/data/jpa/repository/query/AbstractStringBasedJpaQueryIntegrationTests.java
+++ b/src/test/java/org/springframework/data/jpa/repository/query/AbstractStringBasedJpaQueryIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 the original author or authors.
+ * Copyright 2016-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -50,10 +50,7 @@ public class AbstractStringBasedJpaQueryIntegrationTests {
 
 	@PersistenceContext EntityManager em;
 
-	/**
-	 * @see DATAJPA-885
-	 */
-	@Test
+	@Test // DATAJPA-885
 	public void createsNormalQueryForJpaManagedReturnTypes() throws Exception {
 
 		EntityManager mock = mock(EntityManager.class);

--- a/src/test/java/org/springframework/data/jpa/repository/query/ExpressionBasedStringQueryUnitTests.java
+++ b/src/test/java/org/springframework/data/jpa/repository/query/ExpressionBasedStringQueryUnitTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 the original author or authors.
+ * Copyright 2013-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,14 +15,15 @@
  */
 package org.springframework.data.jpa.repository.query;
 
-import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.when;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
+
 import org.springframework.expression.spel.standard.SpelExpressionParser;
 
 /**
@@ -38,10 +39,7 @@ public class ExpressionBasedStringQueryUnitTests {
 
 	static final SpelExpressionParser SPEL_PARSER = new SpelExpressionParser();
 
-	/**
-	 * @see DATAJPA-170
-	 */
-	@Test
+	@Test // DATAJPA-170
 	public void shouldReturnQueryWithDomainTypeExpressionReplacedWithSimpleDomainTypeName() {
 
 		when(metadata.getEntityName()).thenReturn("User");
@@ -51,10 +49,7 @@ public class ExpressionBasedStringQueryUnitTests {
 		assertThat(query.getQueryString(), is("select from User u where u.firstname like :firstname"));
 	}
 
-	/**
-	 * @DATAJPA-424
-	 */
-	@Test
+	@Test // DATAJPA-424
 	public void renderAliasInExpressionQueryCorrectly() {
 
 		when(metadata.getEntityName()).thenReturn("User");

--- a/src/test/java/org/springframework/data/jpa/repository/query/Jpa21UtilsUnitTests.java
+++ b/src/test/java/org/springframework/data/jpa/repository/query/Jpa21UtilsUnitTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 the original author or authors.
+ * Copyright 2015-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,10 +32,7 @@ import org.springframework.data.jpa.repository.EntityGraph.EntityGraphType;
  */
 public class Jpa21UtilsUnitTests {
 
-	/**
-	 * @see DATAJPA-696
-	 */
-	@Test
+	@Test // DATAJPA-696
 	public void shouldBuildCorrectSubgraphForJpaEntityGraph() throws Exception {
 
 		EntityGraph<?> entityGraph = mock(EntityGraph.class);

--- a/src/test/java/org/springframework/data/jpa/repository/query/JpaCountQueryCreatorIntegrationTests.java
+++ b/src/test/java/org/springframework/data/jpa/repository/query/JpaCountQueryCreatorIntegrationTests.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.jpa.repository.query;
+
+import static org.hamcrest.CoreMatchers.*;
+import static org.junit.Assert.*;
+
+import java.lang.reflect.Method;
+import java.util.List;
+
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+import javax.persistence.TypedQuery;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.data.jpa.domain.sample.Role;
+import org.springframework.data.jpa.domain.sample.User;
+import org.springframework.data.jpa.provider.HibernateUtils;
+import org.springframework.data.jpa.provider.PersistenceProvider;
+import org.springframework.data.projection.SpelAwareProxyProjectionFactory;
+import org.springframework.data.repository.Repository;
+import org.springframework.data.repository.core.support.AbstractRepositoryMetadata;
+import org.springframework.data.repository.query.parser.PartTree;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+/**
+ * Integration tests for {@link JpaCountQueryCreator}.
+ * 
+ * @author Oliver Gierke
+ */
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration("classpath:infrastructure.xml")
+public class JpaCountQueryCreatorIntegrationTests {
+
+	@PersistenceContext EntityManager entityManager;
+
+	@Test // DATAJPA-1044
+	public void distinctFlagOnCountQueryIssuesCountDistinct() throws Exception {
+
+		Method method = SomeRepository.class.getMethod("findDistinctByRolesIn", List.class);
+
+		PersistenceProvider provider = PersistenceProvider.fromEntityManager(entityManager);
+		JpaQueryMethod queryMethod = new JpaQueryMethod(method,
+				AbstractRepositoryMetadata.getMetadata(SomeRepository.class), new SpelAwareProxyProjectionFactory(), provider);
+
+		PartTree tree = new PartTree("findDistinctByRolesIn", User.class);
+		ParameterMetadataProvider metadataProvider = new ParameterMetadataProvider(entityManager.getCriteriaBuilder(),
+				queryMethod.getParameters(), provider);
+
+		JpaCountQueryCreator creator = new JpaCountQueryCreator(tree, queryMethod.getResultProcessor().getReturnedType(),
+				entityManager.getCriteriaBuilder(), metadataProvider);
+
+		TypedQuery<? extends Object> query = entityManager.createQuery(creator.createQuery());
+
+		assertThat(HibernateUtils.getHibernateQuery(query), startsWith("select distinct count(distinct"));
+	}
+
+	interface SomeRepository extends Repository<User, Long> {
+		void findDistinctByRolesIn(List<Role> roles);
+	}
+}

--- a/src/test/java/org/springframework/data/jpa/repository/query/JpaQueryExecutionUnitTests.java
+++ b/src/test/java/org/springframework/data/jpa/repository/query/JpaQueryExecutionUnitTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2008-2016 the original author or authors.
+ * Copyright 2008-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -116,11 +116,7 @@ public class JpaQueryExecutionUnitTests {
 		new ModifyingExecution(method, em);
 	}
 
-	/**
-	 * @see DATAJPA-124
-	 * @see DATAJPA-912
-	 */
-	@Test
+	@Test // DATAJPA-124, DATAJPA-912
 	public void pagedExecutionRetrievesObjectsForPageableOutOfRange() throws Exception {
 
 		Parameters<?, ?> parameters = new DefaultParameters(getClass().getMethod("sampleMethod", Pageable.class));
@@ -135,11 +131,7 @@ public class JpaQueryExecutionUnitTests {
 		verify(countQuery).getResultList();
 	}
 
-	/**
-	 * @see DATAJPA-477
-	 * @see DATAJPA-912
-	 */
-	@Test
+	@Test // DATAJPA-477, DATAJPA-912
 	public void pagedExecutionShouldNotGenerateCountQueryIfQueryReportedNoResults() throws Exception {
 
 		Parameters<?, ?> parameters = new DefaultParameters(getClass().getMethod("sampleMethod", Pageable.class));
@@ -153,10 +145,7 @@ public class JpaQueryExecutionUnitTests {
 		verify(jpaQuery, times(0)).createCountQuery((Object[]) any());
 	}
 
-	/**
-	 * @see DATAJPA-912
-	 */
-	@Test
+	@Test // DATAJPA-912
 	public void pagedExecutionShouldUseCountFromResultIfOffsetIsZeroAndResultsWithinPageSize() throws Exception {
 
 		Parameters<?, ?> parameters = new DefaultParameters(getClass().getMethod("sampleMethod", Pageable.class));
@@ -169,10 +158,7 @@ public class JpaQueryExecutionUnitTests {
 		verify(jpaQuery, times(0)).createCountQuery((Object[]) any());
 	}
 
-	/**
-	 * @see DATAJPA-912
-	 */
-	@Test
+	@Test // DATAJPA-912
 	public void pagedExecutionShouldUseCountFromResultWithOffsetAndResultsWithinPageSize() throws Exception {
 
 		Parameters<?, ?> parameters = new DefaultParameters(getClass().getMethod("sampleMethod", Pageable.class));
@@ -185,10 +171,7 @@ public class JpaQueryExecutionUnitTests {
 		verify(jpaQuery, times(0)).createCountQuery((Object[]) any());
 	}
 
-	/**
-	 * @see DATAJPA-912
-	 */
-	@Test
+	@Test // DATAJPA-912
 	public void pagedExecutionShouldUseRequestCountFromResultWithOffsetAndResultsHitLowerPageSizeBounds() throws Exception {
 
 		Parameters<?, ?> parameters = new DefaultParameters(getClass().getMethod("sampleMethod", Pageable.class));
@@ -203,10 +186,7 @@ public class JpaQueryExecutionUnitTests {
 		verify(jpaQuery).createCountQuery((Object[]) any());
 	}
 
-	/**
-	 * @see DATAJPA-912
-	 */
-	@Test
+	@Test // DATAJPA-912
 	public void pagedExecutionShouldUseRequestCountFromResultWithOffsetAndResultsHitUpperPageSizeBounds() throws Exception {
 
 		Parameters<?, ?> parameters = new DefaultParameters(getClass().getMethod("sampleMethod", Pageable.class));
@@ -221,10 +201,7 @@ public class JpaQueryExecutionUnitTests {
 		verify(jpaQuery).createCountQuery((Object[]) any());
 	}
 
-	/**
-	 * @see DATAJPA-951
-	 */
-	@Test
+	@Test // DATAJPA-951
 	public void doesNotPreemtivelyWrapResultIntoOptional() throws Exception {
 
 		doReturn(method).when(jpaQuery).getQueryMethod();

--- a/src/test/java/org/springframework/data/jpa/repository/query/JpaQueryLookupStrategyUnitTests.java
+++ b/src/test/java/org/springframework/data/jpa/repository/query/JpaQueryLookupStrategyUnitTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2016 the original author or authors.
+ * Copyright 2012-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -76,10 +76,7 @@ public class JpaQueryLookupStrategyUnitTests {
 		when(em.getDelegate()).thenReturn(em);
 	}
 
-	/**
-	 * @see DATAJPA-226
-	 */
-	@Test
+	@Test // DATAJPA-226
 	public void invalidAnnotatedQueryCausesException() throws Exception {
 
 		QueryLookupStrategy strategy = JpaQueryLookupStrategy.create(em, Key.CREATE_IF_NOT_FOUND, extractor,
@@ -98,10 +95,7 @@ public class JpaQueryLookupStrategyUnitTests {
 		}
 	}
 
-	/**
-	 * @see DATAJPA-554
-	 */
-	@Test
+	@Test // DATAJPA-554
 	public void sholdThrowMorePreciseExceptionIfTryingToUsePaginationInNativeQueries() throws Exception {
 
 		QueryLookupStrategy strategy = JpaQueryLookupStrategy.create(em, Key.CREATE_IF_NOT_FOUND, extractor,

--- a/src/test/java/org/springframework/data/jpa/repository/query/JpaQueryMethodUnitTests.java
+++ b/src/test/java/org/springframework/data/jpa/repository/query/JpaQueryMethodUnitTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2008-2016 the original author or authors.
+ * Copyright 2008-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -220,30 +220,21 @@ public class JpaQueryMethodUnitTests {
 		assertThat(queryMethod.getNamedQueryName(), is("SpecialUser.findSpecialUsersByLastname"));
 	}
 
-	/**
-	 * @see DATAJPA-117
-	 */
-	@Test
+	@Test // DATAJPA-117
 	public void discoversNativeQuery() throws Exception {
 
 		JpaQueryMethod method = getQueryMethod(ValidRepository.class, "findByLastname", String.class);
 		assertThat(method.isNativeQuery(), is(true));
 	}
 
-	/**
-	 * @see DATAJPA-129
-	 */
-	@Test
+	@Test // DATAJPA-129
 	public void considersAnnotatedNamedQueryName() throws Exception {
 
 		JpaQueryMethod queryMethod = getQueryMethod(ValidRepository.class, "findByNamedQuery");
 		assertThat(queryMethod.getNamedQueryName(), is("HateoasAwareSpringDataWebConfiguration.bar"));
 	}
 
-	/**
-	 * @see DATAJPA-73
-	 */
-	@Test
+	@Test // DATAJPA-73
 	public void discoversLockModeCorrectly() throws Exception {
 
 		JpaQueryMethod method = getQueryMethod(ValidRepository.class, "findOneLocked", Integer.class);
@@ -252,30 +243,21 @@ public class JpaQueryMethodUnitTests {
 		assertEquals(LockModeType.PESSIMISTIC_WRITE, lockMode);
 	}
 
-	/**
-	 * @see DATAJPA-142
-	 */
-	@Test
+	@Test // DATAJPA-142
 	public void returnsDefaultCountQueryName() throws Exception {
 
 		JpaQueryMethod method = getQueryMethod(UserRepository.class, "findByLastname", String.class);
 		assertThat(method.getNamedCountQueryName(), is("User.findByLastname.count"));
 	}
 
-	/**
-	 * @see DATAJPA-142
-	 */
-	@Test
+	@Test // DATAJPA-142
 	public void returnsDefaultCountQueryNameBasedOnConfiguredNamedQueryName() throws Exception {
 
 		JpaQueryMethod method = getQueryMethod(ValidRepository.class, "findByNamedQuery");
 		assertThat(method.getNamedCountQueryName(), is("HateoasAwareSpringDataWebConfiguration.bar.count"));
 	}
 
-	/**
-	 * @see DATAJPA-185
-	 */
-	@Test
+	@Test // DATAJPA-185
 	public void rejectsInvalidNamedParameter() throws Exception {
 
 		try {
@@ -291,10 +273,7 @@ public class JpaQueryMethodUnitTests {
 		}
 	}
 
-	/**
-	 * @see DATAJPA-207
-	 */
-	@Test
+	@Test // DATAJPA-207
 	@SuppressWarnings({ "rawtypes", "unchecked" })
 	public void returnsTrueIfReturnTypeIsEntity() {
 
@@ -306,10 +285,7 @@ public class JpaQueryMethodUnitTests {
 		assertThat(new JpaQueryMethod(findsProjection, metadata, factory, extractor).isQueryForEntity(), is(false));
 	}
 
-	/**
-	 * @see DATAJPA-345
-	 */
-	@Test
+	@Test // DATAJPA-345
 	public void detectsLockAndQueryHintsOnIfUsedAsMetaAnnotation() throws Exception {
 
 		JpaQueryMethod method = getQueryMethod(ValidRepository.class, "withMetaAnnotation");
@@ -320,10 +296,7 @@ public class JpaQueryMethodUnitTests {
 		assertThat(method.getHints().get(0).value(), is("bar"));
 	}
 
-	/**
-	 * @see DATAJPA-466
-	 */
-	@Test
+	@Test // DATAJPA-466
 	public void shouldStoreJpa21FetchGraphInformationAsHint() {
 
 		doReturn(User.class).when(metadata).getDomainType();
@@ -336,10 +309,7 @@ public class JpaQueryMethodUnitTests {
 		assertThat(method.getEntityGraph().getType(), is(EntityGraphType.LOAD));
 	}
 
-	/**
-	 * @see DATAJPA-612
-	 */
-	@Test
+	@Test // DATAJPA-612
 	public void shouldFindEntityGraphAnnotationOnOverriddenSimpleJpaRepositoryMethod() throws Exception {
 
 		doReturn(User.class).when(metadata).getDomainType();
@@ -353,10 +323,7 @@ public class JpaQueryMethodUnitTests {
 		assertThat(method.getEntityGraph().getType(), is(EntityGraphType.FETCH));
 	}
 
-	/**
-	 * @see DATAJPA-689
-	 */
-	@Test
+	@Test // DATAJPA-689
 	public void shouldFindEntityGraphAnnotationOnOverriddenSimpleJpaRepositoryMethodFindOne() throws Exception {
 
 		doReturn(User.class).when(metadata).getDomainType();
@@ -387,18 +354,12 @@ public class JpaQueryMethodUnitTests {
 		assertThat(method.getEntityGraph().getType(), is(EntityGraphType.FETCH));
 	}
 
-	/**
-	 * @see DATAJPA-758
-	 */
-	@Test
+	@Test // DATAJPA-758
 	public void allowsPositionalBindingEvenIfParametersAreNamed() throws Exception {
 		getQueryMethod(ValidRepository.class, "queryWithPositionalBinding", String.class);
 	}
 
-	/**
-	 * @see DATAJPA-871
-	 */
-	@Test
+	@Test // DATAJPA-871
 	public void usesAliasedValueForLockLockMode() throws Exception {
 
 		JpaQueryMethod method = getQueryMethod(ValidRepository.class, "withMetaAnnotationUsingAliasFor");
@@ -406,10 +367,7 @@ public class JpaQueryMethodUnitTests {
 		assertThat(method.getLockModeType(), is(LockModeType.PESSIMISTIC_FORCE_INCREMENT));
 	}
 
-	/**
-	 * @see DATAJPA-871
-	 */
-	@Test
+	@Test // DATAJPA-871
 	public void usesAliasedValueForQueryHints() throws Exception {
 
 		JpaQueryMethod method = getQueryMethod(ValidRepository.class, "withMetaAnnotationUsingAliasFor");
@@ -420,10 +378,7 @@ public class JpaQueryMethodUnitTests {
 
 	}
 
-	/**
-	 * @see DATAJPA-871
-	 */
-	@Test
+	@Test // DATAJPA-871
 	public void usesAliasedValueForQueryHintsCounting() throws Exception {
 
 		JpaQueryMethod method = getQueryMethod(ValidRepository.class, "withMetaAnnotationUsingAliasFor");
@@ -431,10 +386,7 @@ public class JpaQueryMethodUnitTests {
 		assertThat(method.applyHintsToCountQuery(), is(true));
 	}
 
-	/**
-	 * @see DATAJPA-871
-	 */
-	@Test
+	@Test // DATAJPA-871
 	public void usesAliasedValueForModifyingClearAutomatically() throws Exception {
 
 		JpaQueryMethod method = getQueryMethod(ValidRepository.class, "withMetaAnnotationUsingAliasFor");
@@ -443,10 +395,7 @@ public class JpaQueryMethodUnitTests {
 		assertThat(method.getClearAutomatically(), is(true));
 	}
 
-	/**
-	 * @see DATAJPA-871
-	 */
-	@Test
+	@Test // DATAJPA-871
 	public void usesAliasedValueForHintsApplyToCountQuery() throws Exception {
 
 		JpaQueryMethod method = getQueryMethod(ValidRepository.class, "withMetaAnnotationUsingAliasFor");
@@ -454,10 +403,7 @@ public class JpaQueryMethodUnitTests {
 		assertThat(method.applyHintsToCountQuery(), is(true));
 	}
 
-	/**
-	 * @see DATAJPA-871
-	 */
-	@Test
+	@Test // DATAJPA-871
 	public void usesAliasedValueForQueryValue() throws Exception {
 
 		JpaQueryMethod method = getQueryMethod(ValidRepository.class, "withMetaAnnotationUsingAliasFor");
@@ -465,10 +411,7 @@ public class JpaQueryMethodUnitTests {
 		assertThat(method.getAnnotatedQuery(), is(equalTo("select u from User u where u.firstname = ?1")));
 	}
 
-	/**
-	 * @see DATAJPA-871
-	 */
-	@Test
+	@Test // DATAJPA-871
 	public void usesAliasedValueForQueryCountQuery() throws Exception {
 
 		JpaQueryMethod method = getQueryMethod(ValidRepository.class, "withMetaAnnotationUsingAliasFor");
@@ -476,10 +419,7 @@ public class JpaQueryMethodUnitTests {
 		assertThat(method.getCountQuery(), is(equalTo("select u from User u where u.lastname = ?1")));
 	}
 
-	/**
-	 * @see DATAJPA-871
-	 */
-	@Test
+	@Test // DATAJPA-871
 	public void usesAliasedValueForQueryCountQueryProjection() throws Exception {
 
 		JpaQueryMethod method = getQueryMethod(ValidRepository.class, "withMetaAnnotationUsingAliasFor");
@@ -487,10 +427,7 @@ public class JpaQueryMethodUnitTests {
 		assertThat(method.getCountQueryProjection(), is(equalTo("foo-bar")));
 	}
 
-	/**
-	 * @see DATAJPA-871
-	 */
-	@Test
+	@Test // DATAJPA-871
 	public void usesAliasedValueForQueryNamedQueryName() throws Exception {
 
 		JpaQueryMethod method = getQueryMethod(ValidRepository.class, "withMetaAnnotationUsingAliasFor");
@@ -498,10 +435,7 @@ public class JpaQueryMethodUnitTests {
 		assertThat(method.getNamedQueryName(), is(equalTo("namedQueryName")));
 	}
 
-	/**
-	 * @see DATAJPA-871
-	 */
-	@Test
+	@Test // DATAJPA-871
 	public void usesAliasedValueForQueryNamedCountQueryName() throws Exception {
 
 		JpaQueryMethod method = getQueryMethod(ValidRepository.class, "withMetaAnnotationUsingAliasFor");
@@ -509,10 +443,7 @@ public class JpaQueryMethodUnitTests {
 		assertThat(method.getNamedCountQueryName(), is(equalTo("namedCountQueryName")));
 	}
 
-	/**
-	 * @see DATAJPA-871
-	 */
-	@Test
+	@Test // DATAJPA-871
 	public void usesAliasedValueForQueryNativeQuery() throws Exception {
 
 		JpaQueryMethod method = getQueryMethod(ValidRepository.class, "withMetaAnnotationUsingAliasFor");
@@ -520,10 +451,7 @@ public class JpaQueryMethodUnitTests {
 		assertThat(method.isNativeQuery(), is(true));
 	}
 
-	/**
-	 * @see DATAJPA-871
-	 */
-	@Test
+	@Test // DATAJPA-871
 	public void usesAliasedValueForEntityGraph() throws Exception {
 
 		doReturn(User.class).when(metadata).getDomainType();
@@ -592,9 +520,7 @@ public class JpaQueryMethodUnitTests {
 		@CustomAnnotation
 		void withMetaAnnotation();
 
-		/**
-		 * @see DATAJPA-466
-		 */
+		// DATAJPA-466
 		@EntityGraph(value = "User.propertyLoadPath", type = EntityGraphType.LOAD)
 		User queryMethodWithCustomEntityFetchGraph(Integer id);
 

--- a/src/test/java/org/springframework/data/jpa/repository/query/NamedQueryUnitTests.java
+++ b/src/test/java/org/springframework/data/jpa/repository/query/NamedQueryUnitTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2008-2014 the original author or authors.
+ * Copyright 2008-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -79,10 +79,7 @@ public class NamedQueryUnitTests {
 		NamedQuery.lookupFrom(queryMethod, em);
 	}
 
-	/**
-	 * @see DATAJPA-142
-	 */
-	@Test
+	@Test // DATAJPA-142
 	public void doesNotRejectPersistenceProviderIfNamedCountQueryIsAvailable() {
 
 		when(extractor.canExtractQuery()).thenReturn(false);

--- a/src/test/java/org/springframework/data/jpa/repository/query/ParameterBinderUnitTests.java
+++ b/src/test/java/org/springframework/data/jpa/repository/query/ParameterBinderUnitTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2008-2015 the original author or authors.
+ * Copyright 2008-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -182,10 +182,7 @@ public class ParameterBinderUnitTests {
 		assertThat(binder.getSort(), is(sort));
 	}
 
-	/**
-	 * @see DATAJPA-107
-	 */
-	@Test
+	@Test // DATAJPA-107
 	public void shouldSetTemporalQueryParameterToDate() throws Exception {
 
 		Method method = SampleRepository.class.getMethod("validWithDefaultTemporalTypeParameter", Date.class);
@@ -197,10 +194,7 @@ public class ParameterBinderUnitTests {
 		verify(query).setParameter(eq(1), eq(date), eq(TemporalType.DATE));
 	}
 
-	/**
-	 * @see DATAJPA-107
-	 */
-	@Test
+	@Test // DATAJPA-107
 	public void shouldSetTemporalQueryParameterToTimestamp() throws Exception {
 
 		Method method = SampleRepository.class.getMethod("validWithCustomTemporalTypeParameter", Date.class);
@@ -212,10 +206,7 @@ public class ParameterBinderUnitTests {
 		verify(query).setParameter(eq(1), eq(date), eq(TemporalType.TIMESTAMP));
 	}
 
-	/**
-	 * @see DATAJPA-107
-	 */
-	@Test(expected = IllegalArgumentException.class)
+	@Test(expected = IllegalArgumentException.class) // DATAJPA-107
 	public void shouldThrowIllegalArgumentExceptionIfIsAnnotatedWithTemporalParamAndParameterTypeIsNotDate()
 			throws Exception {
 		Method method = SampleRepository.class.getMethod("invalidWithTemporalTypeParameter", String.class);
@@ -224,10 +215,7 @@ public class ParameterBinderUnitTests {
 		new ParameterBinder(parameters, new Object[] { "foo", "" });
 	}
 
-	/**
-	 * @see DATAJPA-461
-	 */
-	@Test
+	@Test // DATAJPA-461
 	public void shouldAllowBindingOfVarArgsAsIs() throws Exception {
 
 		Method method = SampleRepository.class.getMethod("validWithVarArgs", Integer[].class);
@@ -238,10 +226,7 @@ public class ParameterBinderUnitTests {
 		verify(query).setParameter(eq(1), eq(ids));
 	}
 
-	/**
-	 * @see DATAJPA-809
-	 */
-	@Test
+	@Test // DATAJPA-809
 	public void unwrapsOptionalParameter() throws Exception {
 
 		Method method = SampleRepository.class.getMethod("optionalParameter", Optional.class);

--- a/src/test/java/org/springframework/data/jpa/repository/query/ParameterExpressionProviderTests.java
+++ b/src/test/java/org/springframework/data/jpa/repository/query/ParameterExpressionProviderTests.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.springframework.data.jpa.repository.query;
 
 import static org.hamcrest.Matchers.*;
@@ -32,10 +47,7 @@ public class ParameterExpressionProviderTests {
 
 	@PersistenceContext EntityManager em;
 
-	/**
-	 * @see DATADOC-99
-	 */
-	@Test
+	@Test // DATADOC-99
 	@SuppressWarnings("rawtypes")
 	public void createsParameterExpressionWithMostConcreteType() throws Exception {
 

--- a/src/test/java/org/springframework/data/jpa/repository/query/ParameterMetadataProviderIntegrationTests.java
+++ b/src/test/java/org/springframework/data/jpa/repository/query/ParameterMetadataProviderIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 the original author or authors.
+ * Copyright 2015-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -48,10 +48,7 @@ public class ParameterMetadataProviderIntegrationTests {
 
 	@PersistenceContext EntityManager em;
 
-	/**
-	 * @see DATAJPA-758
-	 */
-	@Test
+	@Test // DATAJPA-758
 	public void forwardsParameterNameIfTransparentlyNamed() throws Exception {
 
 		ParameterMetadataProvider provider = createProvider(Sample.class.getMethod("findByFirstname", String.class));
@@ -60,10 +57,7 @@ public class ParameterMetadataProviderIntegrationTests {
 		assertThat(metadata.getExpression().getName(), is("name"));
 	}
 
-	/**
-	 * @see DATAJPA-758
-	 */
-	@Test
+	@Test // DATAJPA-758
 	public void forwardsParameterNameIfExplicitlyAnnotated() throws Exception {
 
 		ParameterMetadataProvider provider = createProvider(Sample.class.getMethod("findByLastname", String.class));
@@ -72,10 +66,7 @@ public class ParameterMetadataProviderIntegrationTests {
 		assertThat(metadata.getExpression().getName(), is(nullValue()));
 	}
 
-	/**
-	 * @see DATAJPA-772
-	 */
-	@Test
+	@Test // DATAJPA-772
 	public void doesNotApplyLikeExpansionOnNonStringProperties() throws Exception {
 
 		ParameterMetadataProvider provider = createProvider(Sample.class.getMethod("findByAgeContaining", Integer.class));

--- a/src/test/java/org/springframework/data/jpa/repository/query/PartTreeJpaQueryIntegrationTests.java
+++ b/src/test/java/org/springframework/data/jpa/repository/query/PartTreeJpaQueryIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2016 the original author or authors.
+ * Copyright 2011-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License
 import org.springframework.aop.framework.Advised;
@@ -75,11 +75,7 @@ public class PartTreeJpaQueryIntegrationTests {
 		this.provider = PersistenceProvider.fromEntityManager(entityManager);
 	}
 
-	/**
-	 * @see DATADOC-90
-	 * @throws Exception
-	 */
-	@Test
+	@Test // DATADOC-90
 	public void test() throws Exception {
 
 		JpaQueryMethod queryMethod = getQueryMethod("findByFirstname", String.class, Pageable.class);
@@ -103,10 +99,7 @@ public class PartTreeJpaQueryIntegrationTests {
 		testIgnoreCase("findByIdAllIgnoringCase", 3);
 	}
 
-	/**
-	 * @see DATAJPA-121
-	 */
-	@Test
+	@Test // DATAJPA-121
 	public void recreatesQueryIfNullValueIsGiven() throws Exception {
 
 		JpaQueryMethod queryMethod = getQueryMethod("findByFirstname", String.class, Pageable.class);
@@ -121,10 +114,7 @@ public class PartTreeJpaQueryIntegrationTests {
 		assertThat(HibernateUtils.getHibernateQuery(getValue(query, PROPERTY)), endsWith("firstname is null"));
 	}
 
-	/**
-	 * @see DATAJPA-920
-	 */
-	@Test
+	@Test // DATAJPA-920
 	public void shouldLimitExistsProjectionQueries() throws Exception {
 
 		JpaQueryMethod queryMethod = getQueryMethod("existsByFirstname", String.class);
@@ -135,10 +125,7 @@ public class PartTreeJpaQueryIntegrationTests {
 		assertThat(query.getMaxResults(), is(1));
 	}
 
-	/**
-	 * @see DATAJPA-920
-	 */
-	@Test
+	@Test // DATAJPA-920
 	public void shouldSelectAliasedIdForExistsProjectionQueries() throws Exception {
 
 		JpaQueryMethod queryMethod = getQueryMethod("existsByFirstname", String.class);

--- a/src/test/java/org/springframework/data/jpa/repository/query/QueryUtilsIntegrationTests.java
+++ b/src/test/java/org/springframework/data/jpa/repository/query/QueryUtilsIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2016 the original author or authors.
+ * Copyright 2013-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -61,10 +61,7 @@ public class QueryUtilsIntegrationTests {
 
 	@PersistenceContext EntityManager em;
 
-	/**
-	 * @see DATAJPA-403
-	 */
-	@Test
+	@Test // DATAJPA-403
 	public void reusesExistingJoinForExpression() {
 
 		CriteriaBuilder builder = em.getCriteriaBuilder();
@@ -80,10 +77,7 @@ public class QueryUtilsIntegrationTests {
 		assertThat(from.getJoins(), hasSize(1));
 	}
 
-	/**
-	 * @see DATAJPA-401
-	 */
-	@Test
+	@Test // DATAJPA-401
 	public void createsJoinForOptionalAssociation() {
 
 		CriteriaBuilder builder = em.getCriteriaBuilder();
@@ -95,10 +89,7 @@ public class QueryUtilsIntegrationTests {
 		assertThat(root.getJoins(), hasSize(1));
 	}
 
-	/**
-	 * @see DATAJPA-401
-	 */
-	@Test
+	@Test // DATAJPA-401
 	public void doesNotCreateAJoinForNonOptionalAssociation() {
 
 		CriteriaBuilder builder = em.getCriteriaBuilder();
@@ -108,10 +99,7 @@ public class QueryUtilsIntegrationTests {
 		QueryUtils.toExpressionRecursively(root, PropertyPath.from("customer", Order.class));
 	}
 
-	/**
-	 * @see DATAJPA-454
-	 */
-	@Test
+	@Test // DATAJPA-454
 	public void createsJoingToTraverseCollectionPath() {
 
 		CriteriaBuilder builder = em.getCriteriaBuilder();
@@ -123,10 +111,7 @@ public class QueryUtilsIntegrationTests {
 		assertThat(root.getJoins(), hasSize(1));
 	}
 
-	/**
-	 * @see DATAJPA-476
-	 */
-	@Test
+	@Test // DATAJPA-476
 	public void traversesPluralAttributeCorrectly() {
 
 		PersistenceProviderResolver originalPersistenceProviderResolver = PersistenceProviderResolverHolder
@@ -147,10 +132,7 @@ public class QueryUtilsIntegrationTests {
 		}
 	}
 
-	/**
-	 * @see DATAJPA-763
-	 */
-	@Test
+	@Test // DATAJPA-763
 	@SuppressWarnings("unchecked")
 	public void doesNotCreateAJoinForAlreadyFetchedAssociation() {
 

--- a/src/test/java/org/springframework/data/jpa/repository/query/QueryUtilsUnitTests.java
+++ b/src/test/java/org/springframework/data/jpa/repository/query/QueryUtilsUnitTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2008-2016 the original author or authors.
+ * Copyright 2008-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -51,9 +51,6 @@ public class QueryUtilsUnitTests {
 		assertCountQuery(QUERY, COUNT_QUERY);
 	}
 
-	/**
-	 * @see #303
-	 */
 	@Test
 	public void createsCountQueriesCorrectlyForCapitalLetterJPQL() {
 
@@ -62,9 +59,6 @@ public class QueryUtilsUnitTests {
 		assertCountQuery("SELECT u FROM User u where u.foo.bar = ?", "select count(u) FROM User u where u.foo.bar = ?");
 	}
 
-	/**
-	 * @see #351
-	 */
 	@Test
 	public void createsCountQueryForDistinctQueries() throws Exception {
 
@@ -72,9 +66,6 @@ public class QueryUtilsUnitTests {
 				"select count(distinct u) from User u where u.foo = ?");
 	}
 
-	/**
-	 * @see #351
-	 */
 	@Test
 	public void createsCountQueryForConstructorQueries() throws Exception {
 
@@ -82,9 +73,6 @@ public class QueryUtilsUnitTests {
 				"select count(distinct u) from User u where u.foo = ?");
 	}
 
-	/**
-	 * @see #352
-	 */
 	@Test
 	public void createsCountQueryForJoins() throws Exception {
 
@@ -92,9 +80,6 @@ public class QueryUtilsUnitTests {
 				"select count(distinct u) from User u left outer join u.roles r WHERE r = ?");
 	}
 
-	/**
-	 * @see #352
-	 */
 	@Test
 	public void createsCountQueryForQueriesWithSubSelects() throws Exception {
 
@@ -102,9 +87,6 @@ public class QueryUtilsUnitTests {
 				"select count(u) from User u left outer join u.roles r where r in (select r from Role)");
 	}
 
-	/**
-	 * @see #355
-	 */
 	@Test
 	public void createsCountQueryForAliasesCorrectly() throws Exception {
 
@@ -137,10 +119,7 @@ public class QueryUtilsUnitTests {
 		assertCountQuery(FQ_QUERY, "select count(u) from org.acme.domain.User$Foo_Bar u");
 	}
 
-	/**
-	 * @see DATAJPA-252
-	 */
-	@Test
+	@Test // DATAJPA-252
 	public void detectsJoinAliasesCorrectly() {
 
 		Set<String> aliases = getOuterJoinAliases("select p from Person p left outer join x.foo b2_$ar where …");
@@ -162,10 +141,7 @@ public class QueryUtilsUnitTests {
 		assertThat(aliases, hasItems("b2_$ar", "foo"));
 	}
 
-	/**
-	 * @see DATAJPA-252
-	 */
-	@Test
+	@Test // DATAJPA-252
 	public void doesNotPrefixOrderReferenceIfOuterJoinAliasDetected() {
 
 		String query = "select p from Person p left join p.address address";
@@ -174,20 +150,14 @@ public class QueryUtilsUnitTests {
 				endsWith("order by address.city asc, p.lastname asc"));
 	}
 
-	/**
-	 * @see DATAJPA-252
-	 */
-	@Test
+	@Test // DATAJPA-252
 	public void extendsExistingOrderByClausesCorrectly() {
 
 		String query = "select p from Person p order by p.lastname asc";
 		assertThat(applySorting(query, new Sort("firstname"), "p"), endsWith("order by p.lastname asc, p.firstname asc"));
 	}
 
-	/**
-	 * @see DATAJPA-296
-	 */
-	@Test
+	@Test // DATAJPA-296
 	public void appliesIgnoreCaseOrderingCorrectly() {
 
 		Sort sort = new Sort(new Sort.Order("firstname").ignoreCase());
@@ -196,10 +166,7 @@ public class QueryUtilsUnitTests {
 		assertThat(applySorting(query, sort, "p"), endsWith("order by lower(p.firstname) asc"));
 	}
 
-	/**
-	 * @see DATAJPA-296
-	 */
-	@Test
+	@Test // DATAJPA-296
 	public void appendsIgnoreCaseOrderingCorrectly() {
 
 		Sort sort = new Sort(new Sort.Order("firstname").ignoreCase());
@@ -208,50 +175,35 @@ public class QueryUtilsUnitTests {
 		assertThat(applySorting(query, sort, "p"), endsWith("order by p.lastname asc, lower(p.firstname) asc"));
 	}
 
-	/**
-	 * @see DATAJPA-342
-	 */
-	@Test
+	@Test // DATAJPA-342
 	public void usesReturnedVariableInCOuntProjectionIfSet() {
 
 		assertCountQuery("select distinct m.genre from Media m where m.user = ?1 order by m.genre asc",
 				"select count(distinct m.genre) from Media m where m.user = ?1");
 	}
 
-	/**
-	 * @see DATAJPA-343
-	 */
-	@Test
+	@Test // DATAJPA-343
 	public void projectsCOuntQueriesForQueriesWithSubselects() {
 
 		assertCountQuery("select o from Foo o where cb.id in (select b from Bar b)",
 				"select count(o) from Foo o where cb.id in (select b from Bar b)");
 	}
 
-	/**
-	 * @see DATAJPA-148
-	 */
-	@Test(expected = InvalidDataAccessApiUsageException.class)
+	@Test(expected = InvalidDataAccessApiUsageException.class) // DATAJPA-148
 	public void doesNotPrefixSortsIfFunction() {
 
 		Sort sort = new Sort("sum(foo)");
 		assertThat(applySorting("select p from Person p", sort, "p"), endsWith("order by sum(foo) asc"));
 	}
 
-	/**
-	 * @see DATAJPA-377
-	 */
-	@Test
+	@Test // DATAJPA-377
 	public void removesOrderByInGeneratedCountQueryFromOriginalQueryIfPresent() {
 
 		assertCountQuery("select distinct m.genre from Media m where m.user = ?1 OrDer  By   m.genre ASC",
 				"select count(distinct m.genre) from Media m where m.user = ?1");
 	}
 
-	/**
-	 * @see DATAJPA-375
-	 */
-	@Test
+	@Test // DATAJPA-375
 	public void findsExistingOrderByIndependentOfCase() {
 
 		Sort sort = new Sort("lastname");
@@ -259,35 +211,23 @@ public class QueryUtilsUnitTests {
 		assertThat(query, endsWith("ORDER BY p.firstname, p.lastname asc"));
 	}
 
-	/**
-	 * @see DATAJPA-409
-	 */
-	@Test
+	@Test // DATAJPA-409
 	public void createsCountQueryForNestedReferenceCorrectly() {
 		assertCountQuery("select a.b from A a", "select count(a.b) from A a");
 	}
 
-	/**
-	 * @see DATAJPA-420
-	 */
-	@Test
+	@Test // DATAJPA-420
 	public void createsCountQueryForScalarSelects() {
 		assertCountQuery("select p.lastname,p.firstname from Person p", "select count(p) from Person p");
 	}
 
-	/**
-	 * @see DATAJPA-456
-	 */
-	@Test
+	@Test // DATAJPA-456
 	public void createCountQueryFromTheGivenCountProjection() {
 		assertThat(createCountQueryFor("select p.lastname,p.firstname from Person p", "p.lastname"),
 				is("select count(p.lastname) from Person p"));
 	}
 
-	/**
-	 * @see DATAJPA-726
-	 */
-	@Test
+	@Test // DATAJPA-726
 	public void detectsAliassesInPlainJoins() {
 
 		String query = "select p from Customer c join c.productOrder p where p.delayed = true";
@@ -296,26 +236,17 @@ public class QueryUtilsUnitTests {
 		assertThat(applySorting(query, sort, "c"), endsWith("order by p.lineItems asc"));
 	}
 
-	/**
-	 * @see DATAJPA-736
-	 */
-	@Test
+	@Test // DATAJPA-736
 	public void supportsNonAsciiCharactersInEntityNames() {
 		assertThat(createCountQueryFor("select u from Usèr u"), is("select count(u) from Usèr u"));
 	}
 
-	/**
-	 * @see DATAJPA-798
-	 */
-	@Test
+	@Test // DATAJPA-798
 	public void detectsAliasInQueryContainingLineBreaks() {
 		assertThat(detectAlias("select \n u \n from \n User \nu"), is("u"));
 	}
 
-	/**
-	 * @see DATAJPA-815
-	 */
-	@Test
+	@Test // DATAJPA-815
 	public void doesPrefixPropertyWith() {
 
 		String query = "from Cat c join Dog d";
@@ -324,18 +255,12 @@ public class QueryUtilsUnitTests {
 		assertThat(applySorting(query, sort, "c"), endsWith("order by c.dPropertyStartingWithJoinAlias asc"));
 	}
 
-	/**
-	 * @see DATAJPA-938
-	 */
-	@Test
+	@Test // DATAJPA-938
 	public void detectsConstructorExpressionInDistinctQuery() {
 		assertThat(hasConstructorExpression("select distinct new Foo() from Bar b"), is(true));
 	}
 
-	/**
-	 * @see DATAJPA-938
-	 */
-	@Test
+	@Test // DATAJPA-938
 	public void detectsComplexConstructorExpression() {
 
 		assertThat(hasConstructorExpression("select new foo.bar.Foo(ip.id, ip.name, sum(lp.amount)) " //
@@ -345,50 +270,32 @@ public class QueryUtilsUnitTests {
 				+ "order by ip.name ASC"), is(true));
 	}
 
-	/**
-	 * @see DATAJPA-938
-	 */
-	@Test
+	@Test // DATAJPA-938
 	public void detectsConstructorExpressionWithLineBreaks() {
 		assertThat(hasConstructorExpression("select new foo.bar.FooBar(\na.id) from DtoA a "), is(true));
 	}
 
-	/**
-	 * @see DATAJPA-960
-	 */
-	@Test
+	@Test // DATAJPA-960
 	public void doesNotQualifySortIfNoAliasDetected() {
 		assertThat(applySorting("from mytable where ?1 is null", new Sort("firstname")),
 				endsWith("order by firstname asc"));
 	}
 
-	/**
-	 * @see DATAJPA-965
-	 * @see DATAJPA-970
-	 */
-	@Test(expected = InvalidDataAccessApiUsageException.class)
+	@Test(expected = InvalidDataAccessApiUsageException.class) // DATAJPA-965, DATAJPA-970
 	public void doesNotAllowWhitespaceInSort() {
 
 		Sort sort = new Sort("case when foo then bar");
 		applySorting("select p from Person p", sort, "p");
 	}
 
-	/**
-	 * @see DATAJPA-965
-	 * @see DATAJPA-970
-	 */
-	@Test
+	@Test // DATAJPA-965, DATAJPA-970
 	public void doesNotPrefixUnsageJpaSortFunctionCalls() {
 
 		JpaSort sort = JpaSort.unsafe("sum(foo)");
 		assertThat(applySorting("select p from Person p", sort, "p"), endsWith("order by sum(foo) asc"));
 	}
 
-	/**
-	 * @see DATAJPA-965
-	 * @see DATAJPA-970
-	 */
-	@Test
+	@Test // DATAJPA-965, DATAJPA-970
 	public void doesNotPrefixMultipleAliasedFunctionCalls() {
 
 		String query = "SELECT AVG(m.price) AS avgPrice, SUM(m.stocks) AS sumStocks FROM Magazine m";
@@ -397,11 +304,7 @@ public class QueryUtilsUnitTests {
 		assertThat(applySorting(query, sort, "m"), endsWith("order by avgPrice asc, sumStocks asc"));
 	}
 
-	/**
-	 * @see DATAJPA-965
-	 * @see DATAJPA-970
-	 */
-	@Test
+	@Test // DATAJPA-965, DATAJPA-970
 	public void doesNotPrefixSingleAliasedFunctionCalls() {
 
 		String query = "SELECT AVG(m.price) AS avgPrice FROM Magazine m";
@@ -410,11 +313,7 @@ public class QueryUtilsUnitTests {
 		assertThat(applySorting(query, sort, "m"), endsWith("order by avgPrice asc"));
 	}
 
-	/**
-	 * @see DATAJPA-965
-	 * @see DATAJPA-970
-	 */
-	@Test
+	@Test // DATAJPA-965, DATAJPA-970
 	public void prefixesSingleNonAliasedFunctionCallRelatedSortProperty() {
 
 		String query = "SELECT AVG(m.price) AS avgPrice FROM Magazine m";
@@ -423,11 +322,7 @@ public class QueryUtilsUnitTests {
 		assertThat(applySorting(query, sort, "m"), endsWith("order by m.someOtherProperty asc"));
 	}
 
-	/**
-	 * @see DATAJPA-965
-	 * @see DATAJPA-970
-	 */
-	@Test
+	@Test // DATAJPA-965, DATAJPA-970
 	public void prefixesNonAliasedFunctionCallRelatedSortPropertyWhenSelectClauseContainesAliasedFunctionForDifferentProperty() {
 
 		String query = "SELECT m.name, AVG(m.price) AS avgPrice FROM Magazine m";
@@ -436,11 +331,7 @@ public class QueryUtilsUnitTests {
 		assertThat(applySorting(query, sort, "m"), endsWith("order by m.name asc, avgPrice asc"));
 	}
 
-	/**
-	 * @see DATAJPA-965
-	 * @see DATAJPA-970
-	 */
-	@Test
+	@Test // DATAJPA-965, DATAJPA-970
 	public void doesNotPrefixAliasedFunctionCallNameWithMultipleNumericParameters() {
 
 		String query = "SELECT SUBSTRING(m.name, 2, 5) AS trimmedName FROM Magazine m";
@@ -449,11 +340,7 @@ public class QueryUtilsUnitTests {
 		assertThat(applySorting(query, sort, "m"), endsWith("order by trimmedName asc"));
 	}
 
-	/**
-	 * @see DATAJPA-965
-	 * @see DATAJPA-970
-	 */
-	@Test
+	@Test // DATAJPA-965, DATAJPA-970
 	public void doesNotPrefixAliasedFunctionCallNameWithMultipleStringParameters() {
 
 		String query = "SELECT CONCAT(m.name, 'foo') AS extendedName FROM Magazine m";
@@ -462,11 +349,7 @@ public class QueryUtilsUnitTests {
 		assertThat(applySorting(query, sort, "m"), endsWith("order by extendedName asc"));
 	}
 
-	/**
-	 * @see DATAJPA-965
-	 * @see DATAJPA-970
-	 */
-	@Test
+	@Test // DATAJPA-965, DATAJPA-970
 	public void doesNotPrefixAliasedFunctionCallNameWithUnderscores() {
 
 		String query = "SELECT AVG(m.price) AS avg_price FROM Magazine m";
@@ -475,11 +358,7 @@ public class QueryUtilsUnitTests {
 		assertThat(applySorting(query, sort, "m"), endsWith("order by avg_price asc"));
 	}
 
-	/**
-	 * @see DATAJPA-965
-	 * @see DATAJPA-970
-	 */
-	@Test
+	@Test // DATAJPA-965, DATAJPA-970
 	public void doesNotPrefixAliasedFunctionCallNameWithDots() {
 
 		String query = "SELECT AVG(m.price) AS m.avg FROM Magazine m";
@@ -488,11 +367,7 @@ public class QueryUtilsUnitTests {
 		assertThat(applySorting(query, sort, "m"), endsWith("order by m.avg asc"));
 	}
 
-	/**
-	 * @see DATAJPA-965
-	 * @see DATAJPA-970
-	 */
-	@Test
+	@Test // DATAJPA-965, DATAJPA-970
 	public void doesNotPrefixAliasedFunctionCallNameWhenQueryStringContainsMultipleWhiteSpaces() {
 
 		String query = "SELECT  AVG(  m.price  )   AS   avgPrice   FROM Magazine   m";
@@ -501,10 +376,7 @@ public class QueryUtilsUnitTests {
 		assertThat(applySorting(query, sort, "m"), endsWith("order by avgPrice asc"));
 	}
 
-	/**
-	 * @see DATAJPA-1000
-	 */
-	@Test
+	@Test // DATAJPA-1000
 	public void discoversCorrectAliasForJoinFetch() {
 
 		Set<String> aliases = QueryUtils

--- a/src/test/java/org/springframework/data/jpa/repository/query/SimpleJpaQueryUnitTests.java
+++ b/src/test/java/org/springframework/data/jpa/repository/query/SimpleJpaQueryUnitTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2008-2016 the original author or authors.
+ * Copyright 2008-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -111,10 +111,7 @@ public class SimpleJpaQueryUnitTests {
 		assertThat(jpaQuery.createCountQuery(new Object[] {}), is((javax.persistence.Query) typedQuery));
 	}
 
-	/**
-	 * @see DATAJPA-77
-	 */
-	@Test
+	@Test // DATAJPA-77
 	public void doesNotApplyPaginationToCountQuery() throws Exception {
 
 		when(em.createQuery(Mockito.anyString())).thenReturn(query);
@@ -150,31 +147,21 @@ public class SimpleJpaQueryUnitTests {
 		verify(em).createNativeQuery("SELECT u FROM User u WHERE u.lastname = ?1", User.class);
 	}
 
-	/**
-	 * @see DATAJPA-554
-	 */
-	@Test(expected = InvalidJpaQueryMethodException.class)
+	@Test(expected = InvalidJpaQueryMethodException.class) // DATAJPA-554
 	public void rejectsNativeQueryWithDynamicSort() throws Exception {
 
 		Method method = SampleRepository.class.getMethod("findNativeByLastname", String.class, Sort.class);
 		createJpaQuery(method);
 	}
 
-	/**
-	 * @see DATAJPA-554
-	 */
-	@Test(expected = InvalidJpaQueryMethodException.class)
+	@Test(expected = InvalidJpaQueryMethodException.class) // DATAJPA-554
 	public void rejectsNativeQueryWithPageable() throws Exception {
 
 		Method method = SampleRepository.class.getMethod("findNativeByLastname", String.class, Pageable.class);
 		createJpaQuery(method);
 	}
 
-	/**
-	 * @see DATAJPA-352
-	 * @throws Exception
-	 */
-	@Test
+	@Test // DATAJPA-352
 	@SuppressWarnings("unchecked")
 	public void doesNotValidateCountQueryIfNotPagingMethod() throws Exception {
 
@@ -184,10 +171,7 @@ public class SimpleJpaQueryUnitTests {
 		createJpaQuery(method);
 	}
 
-	/**
-	 * @see DATAJPA-352
-	 */
-	@Test
+	@Test // DATAJPA-352
 	@SuppressWarnings("unchecked")
 	public void validatesAndRejectsCountQueryIfPagingMethod() throws Exception {
 
@@ -215,10 +199,7 @@ public class SimpleJpaQueryUnitTests {
 		assertThat(query instanceof NativeJpaQuery, is(true));
 	}
 
-	/**
-	 * @see DATAJPA-757
-	 */
-	@Test
+	@Test // DATAJPA-757
 	public void createsNativeCountQuery() throws Exception {
 
 		when(em.createNativeQuery(anyString())).thenReturn(query);
@@ -231,10 +212,7 @@ public class SimpleJpaQueryUnitTests {
 		verify(em).createNativeQuery(anyString());
 	}
 
-	/**
-	 * @see DATAJPA-885
-	 */
-	@Test
+	@Test // DATAJPA-885
 	public void projectsWithManuallyDeclaredQuery() throws Exception {
 
 		AbstractJpaQuery jpaQuery = createJpaQuery(SampleRepository.class.getMethod("projectWithExplicitQuery"));

--- a/src/test/java/org/springframework/data/jpa/repository/query/StoredProcedureAttributeSourceUnitTests.java
+++ b/src/test/java/org/springframework/data/jpa/repository/query/StoredProcedureAttributeSourceUnitTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2016 the original author or authors.
+ * Copyright 2014-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -59,10 +59,7 @@ public class StoredProcedureAttributeSourceUnitTests {
 		when(entityMetadata.getEntityName()).thenReturn("User");
 	}
 
-	/**
-	 * @see DATAJPA-455
-	 */
-	@Test
+	@Test // DATAJPA-455
 	public void shouldCreateStoredProcedureAttributesFromProcedureMethodWithImplicitProcedureName() {
 
 		StoredProcedureAttributes attr = creator.createFrom(method("plus1inout", Integer.class), entityMetadata);
@@ -72,10 +69,7 @@ public class StoredProcedureAttributeSourceUnitTests {
 		assertThat(attr.getOutputParameterName(), is(StoredProcedureAttributes.SYNTHETIC_OUTPUT_PARAMETER_NAME));
 	}
 
-	/**
-	 * @see DATAJPA-455
-	 */
-	@Test
+	@Test // DATAJPA-455
 	public void shouldCreateStoredProcedureAttributesFromProcedureMethodWithExplictName() {
 
 		StoredProcedureAttributes attr = creator.createFrom(method("explicitlyNamedPlus1inout", Integer.class),
@@ -86,10 +80,7 @@ public class StoredProcedureAttributeSourceUnitTests {
 		assertThat(attr.getOutputParameterName(), is(StoredProcedureAttributes.SYNTHETIC_OUTPUT_PARAMETER_NAME));
 	}
 
-	/**
-	 * @see DATAJPA-455
-	 */
-	@Test
+	@Test // DATAJPA-455
 	public void shouldCreateStoredProcedureAttributesFromProcedureMethodWithExplictProcedureNameValue() {
 
 		StoredProcedureAttributes attr = creator.createFrom(method("explicitlyNamedPlus1inout", Integer.class),
@@ -100,10 +91,7 @@ public class StoredProcedureAttributeSourceUnitTests {
 		assertThat(attr.getOutputParameterName(), is(StoredProcedureAttributes.SYNTHETIC_OUTPUT_PARAMETER_NAME));
 	}
 
-	/**
-	 * @see DATAJPA-455
-	 */
-	@Test
+	@Test // DATAJPA-455
 	public void shouldCreateStoredProcedureAttributesFromProcedureMethodWithExplictProcedureNameAlias() {
 
 		StoredProcedureAttributes attr = creator
@@ -114,10 +102,7 @@ public class StoredProcedureAttributeSourceUnitTests {
 		assertThat(attr.getOutputParameterName(), is(StoredProcedureAttributes.SYNTHETIC_OUTPUT_PARAMETER_NAME));
 	}
 
-	/**
-	 * @see DATAJPA-455
-	 */
-	@Test
+	@Test // DATAJPA-455
 	public void shouldCreateStoredProcedureAttributesFromProcedureMethodBackedWithExplicitlyNamedProcedure() {
 
 		StoredProcedureAttributes attr = creator
@@ -128,10 +113,7 @@ public class StoredProcedureAttributeSourceUnitTests {
 		assertThat(attr.getOutputParameterName(), is("res"));
 	}
 
-	/**
-	 * @see DATAJPA-455
-	 */
-	@Test
+	@Test // DATAJPA-455
 	public void shouldCreateStoredProcedureAttributesFromProcedureMethodBackedWithImplicitlyNamedProcedure() {
 
 		StoredProcedureAttributes attr = creator.createFrom(method("plus1", Integer.class), entityMetadata);
@@ -141,10 +123,7 @@ public class StoredProcedureAttributeSourceUnitTests {
 		assertThat(attr.getOutputParameterName(), is("res"));
 	}
 
-	/**
-	 * @see DATAJPA-871
-	 */
-	@Test
+	@Test // DATAJPA-871
 	public void aliasedStoredProcedure() {
 
 		StoredProcedureAttributes attr = creator
@@ -155,10 +134,7 @@ public class StoredProcedureAttributeSourceUnitTests {
 		assertThat(attr.getOutputParameterName(), is(StoredProcedureAttributes.SYNTHETIC_OUTPUT_PARAMETER_NAME));
 	}
 
-	/**
-	 * @see DATAJPA-871
-	 */
-	@Test
+	@Test // DATAJPA-871
 	public void aliasedStoredProcedure2() {
 
 		StoredProcedureAttributes attr = creator
@@ -180,42 +156,32 @@ public class StoredProcedureAttributeSourceUnitTests {
 
 		/**
 		 * Explicitly mapped to a procedure with name "plus1inout" in database.
-		 * 
-		 * @see DATAJPA-455
 		 */
-		@Procedure("plus1inout")
+		@Procedure("plus1inout") // DATAJPA-455
 		Integer explicitlyNamedPlus1inout(Integer arg);
 
 		/**
 		 * Explicitly mapped to a procedure with name "plus1inout" in database via alias.
-		 * 
-		 * @see DATAJPA-455
 		 */
-		@Procedure(procedureName = "plus1inout")
+		@Procedure(procedureName = "plus1inout") // DATAJPA-455
 		Integer explicitPlus1inoutViaProcedureNameAlias(Integer arg);
 
 		/**
 		 * Implicitly mapped to a procedure with name "plus1inout" in database via alias.
-		 * 
-		 * @see DATAJPA-455
 		 */
-		@Procedure
+		@Procedure // DATAJPA-455
 		Integer plus1inout(Integer arg);
 
 		/**
 		 * Explicitly mapped to named stored procedure "User.plus1IO" in {@link EntityManager}.
-		 * 
-		 * @see DATAJPA-455
 		 */
-		@Procedure(name = "User.plus1IO")
+		@Procedure(name = "User.plus1IO") // DATAJPA-455
 		Integer entityAnnotatedCustomNamedProcedurePlus1IO(@Param("arg") Integer arg);
 
 		/**
 		 * Implicitly mapped to named stored procedure "User.plus1" in {@link EntityManager}.
-		 * 
-		 * @see DATAJPA-455
 		 */
-		@Procedure
+		@Procedure // DATAJPA-455
 		Integer plus1(@Param("arg") Integer arg);
 
 		@ComposedProcedureUsingAliasFor(explicitProcedureName = "plus1inout")

--- a/src/test/java/org/springframework/data/jpa/repository/query/StoredProcedureAttributesUnitTests.java
+++ b/src/test/java/org/springframework/data/jpa/repository/query/StoredProcedureAttributesUnitTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 the original author or authors.
+ * Copyright 2015-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,10 +28,7 @@ import org.junit.Test;
  */
 public class StoredProcedureAttributesUnitTests {
 
-	/**
-	 * @see DATAJPA-681
-	 */
-	@Test
+	@Test // DATAJPA-681
 	public void usesSyntheticOutputParameterNameForAdhocProcedureWithoutOutputName() {
 
 		StoredProcedureAttributes attributes = new StoredProcedureAttributes("procedure", null, Long.class, false);

--- a/src/test/java/org/springframework/data/jpa/repository/query/StringQueryUnitTests.java
+++ b/src/test/java/org/springframework/data/jpa/repository/query/StringQueryUnitTests.java
@@ -292,7 +292,7 @@ public class StringQueryUnitTests {
 	}
 
 	/**
-	 * @see JPA 2.1 specification, section 4.8
+	 * @see <a href="download.oracle.com/otn-pub/jcp/persistence-2_1-fr-eval-spec/JavaPersistence.pdf">JPA 2.1 specification, section 4.8</a>
 	 */
 	@Test // DATAJPA-886
 	public void detectsConstructorExpressionForDefaultConstructor() {

--- a/src/test/java/org/springframework/data/jpa/repository/query/StringQueryUnitTests.java
+++ b/src/test/java/org/springframework/data/jpa/repository/query/StringQueryUnitTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2016 the original author or authors.
+ * Copyright 2013-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -39,10 +39,7 @@ public class StringQueryUnitTests {
 
 	public @Rule ExpectedException exception = ExpectedException.none();
 
-	/**
-	 * @see DATAJPA-341
-	 */
-	@Test
+	@Test // DATAJPA-341
 	public void doesNotConsiderPlainLikeABinding() {
 
 		String source = "select from User u where u.firstname like :firstname";
@@ -98,10 +95,7 @@ public class StringQueryUnitTests {
 		assertThat(binding.getType(), is(Type.ENDING_WITH));
 	}
 
-	/**
-	 * @see DATAJPA-461
-	 */
-	@Test
+	@Test // DATAJPA-461
 	public void detectsNamedInParameterBindings() {
 
 		String queryString = "select u from User u where u.id in :ids";
@@ -116,10 +110,7 @@ public class StringQueryUnitTests {
 		assertNamedBinding(InParameterBinding.class, "ids", bindings.get(0));
 	}
 
-	/**
-	 * @see DATAJPA-461
-	 */
-	@Test
+	@Test // DATAJPA-461
 	public void detectsMultipleNamedInParameterBindings() {
 
 		String queryString = "select u from User u where u.id in :ids and u.name in :names and foo = :bar";
@@ -136,10 +127,7 @@ public class StringQueryUnitTests {
 		assertNamedBinding(ParameterBinding.class, "bar", bindings.get(2));
 	}
 
-	/**
-	 * @see DATAJPA-461
-	 */
-	@Test
+	@Test // DATAJPA-461
 	public void detectsPositionalInParameterBindings() {
 
 		String queryString = "select u from User u where u.id in ?1";
@@ -154,10 +142,7 @@ public class StringQueryUnitTests {
 		assertPositionalBinding(InParameterBinding.class, 1, bindings.get(0));
 	}
 
-	/**
-	 * @see DATAJPA-461
-	 */
-	@Test
+	@Test // DATAJPA-461
 	public void detectsMultiplePositionalInParameterBindings() {
 
 		String queryString = "select u from User u where u.id in ?1 and u.names in ?2 and foo = ?3";
@@ -174,26 +159,17 @@ public class StringQueryUnitTests {
 		assertPositionalBinding(ParameterBinding.class, 3, bindings.get(2));
 	}
 
-	/**
-	 * @see DATAJPA-373
-	 */
-	@Test
+	@Test // DATAJPA-373
 	public void handlesMultipleNamedLikeBindingsCorrectly() {
 		new StringQuery("select u from User u where u.firstname like %:firstname or foo like :bar");
 	}
 
-	/**
-	 * @see DATAJPA-292, DATAJPA-362
-	 */
-	@Test(expected = IllegalArgumentException.class)
+	@Test(expected = IllegalArgumentException.class) // DATAJPA-292, DATAJPA-362
 	public void rejectsDifferentBindingsForRepeatedParameter() {
 		new StringQuery("select u from User u where u.firstname like %?1 and u.lastname like ?1%");
 	}
 
-	/**
-	 * @see DATAJPA-461
-	 */
-	@Test
+	@Test // DATAJPA-461
 	public void treatsGreaterThanBindingAsSimpleBinding() {
 
 		StringQuery query = new StringQuery("select u from User u where u.createdDate > ?1");
@@ -203,10 +179,7 @@ public class StringQueryUnitTests {
 		assertPositionalBinding(ParameterBinding.class, 1, bindings.get(0));
 	}
 
-	/**
-	 * @see DATAJPA-473
-	 */
-	@Test
+	@Test // DATAJPA-473
 	public void removesLikeBindingsFromQueryIfQueryContainsSimpleBinding() {
 
 		StringQuery query = new StringQuery("SELECT a FROM Article a WHERE a.overview LIKE %:escapedWord% ESCAPE '~'"
@@ -221,10 +194,7 @@ public class StringQueryUnitTests {
 				+ " OR a.content LIKE :escapedWord ESCAPE '~' OR a.title = :word ORDER BY a.articleId DESC"));
 	}
 
-	/**
-	 * @see DATAJPA-483
-	 */
-	@Test
+	@Test // DATAJPA-483
 	public void detectsInBindingWithParentheses() {
 
 		StringQuery query = new StringQuery("select count(we) from MyEntity we where we.status in (:statuses)");
@@ -235,10 +205,7 @@ public class StringQueryUnitTests {
 		assertNamedBinding(InParameterBinding.class, "statuses", bindings.get(0));
 	}
 
-	/**
-	 * @see DATAJPA-513
-	 */
-	@Test
+	@Test // DATAJPA-513
 	public void rejectsNullParameterNameHintingTowardsAtParamForNullParameterName() {
 
 		StringQuery query = new StringQuery("select x from X");
@@ -249,10 +216,7 @@ public class StringQueryUnitTests {
 		query.getBindingFor(null);
 	}
 
-	/**
-	 * @see DATAJPA-545
-	 */
-	@Test
+	@Test // DATAJPA-545
 	public void detectsInBindingWithSpecialFrenchCharactersInParentheses() {
 
 		StringQuery query = new StringQuery("select * from MyEntity where abonnés in (:abonnés)");
@@ -263,10 +227,7 @@ public class StringQueryUnitTests {
 		assertNamedBinding(InParameterBinding.class, "abonnés", bindings.get(0));
 	}
 
-	/**
-	 * @see DATAJPA-545
-	 */
-	@Test
+	@Test // DATAJPA-545
 	public void detectsInBindingWithSpecialCharactersInParentheses() {
 
 		StringQuery query = new StringQuery("select * from MyEntity where øre in (:øre)");
@@ -277,10 +238,7 @@ public class StringQueryUnitTests {
 		assertNamedBinding(InParameterBinding.class, "øre", bindings.get(0));
 	}
 
-	/**
-	 * @see DATAJPA-545
-	 */
-	@Test
+	@Test // DATAJPA-545
 	public void detectsInBindingWithSpecialAsianCharactersInParentheses() {
 
 		StringQuery query = new StringQuery("select * from MyEntity where 생일 in (:생일)");
@@ -291,10 +249,7 @@ public class StringQueryUnitTests {
 		assertNamedBinding(InParameterBinding.class, "생일", bindings.get(0));
 	}
 
-	/**
-	 * @see DATAJPA-545
-	 */
-	@Test
+	@Test // DATAJPA-545
 	public void detectsInBindingWithSpecialCharactersAndWordCharactersMixedInParentheses() {
 
 		StringQuery query = new StringQuery("select * from MyEntity where foo in (:ab1babc생일233)");
@@ -305,18 +260,12 @@ public class StringQueryUnitTests {
 		assertNamedBinding(InParameterBinding.class, "ab1babc생일233", bindings.get(0));
 	}
 
-	/**
-	 * @see DATAJPA-362
-	 */
-	@Test(expected = IllegalArgumentException.class)
+	@Test(expected = IllegalArgumentException.class) // DATAJPA-362
 	public void rejectsDifferentBindingsForRepeatedParameter2() {
 		new StringQuery("select u from User u where u.firstname like ?1 and u.lastname like %?1");
 	}
 
-	/**
-	 * @see @DATAJPA-712
-	 */
-	@Test
+	@Test // DATAJPA-712
 	public void shouldReplaceAllNamedExpressionParametersWithInClause() {
 
 		StringQuery query = new StringQuery("select a from A a where a.b in :#{#bs} and a.c in :#{#cs}");
@@ -325,10 +274,7 @@ public class StringQueryUnitTests {
 		assertThat(queryString, is("select a from A a where a.b in :__$synthetic$__1 and a.c in :__$synthetic$__2"));
 	}
 
-	/**
-	 * @see @DATAJPA-712
-	 */
-	@Test
+	@Test // DATAJPA-712
 	public void shouldReplaceAllPositionExpressionParametersWithInClause() {
 
 		StringQuery query = new StringQuery("select a from A a where a.b in ?#{#bs} and a.c in ?#{#cs}");
@@ -337,10 +283,7 @@ public class StringQueryUnitTests {
 		assertThat(queryString, is("select a from A a where a.b in ?1 and a.c in ?2"));
 	}
 
-	/**
-	 * @see DATAJPA-864
-	 */
-	@Test
+	@Test // DATAJPA-864
 	public void detectsConstructorExpressions() {
 
 		assertThat(new StringQuery("select  new  Dto(a.foo, a.bar)  from A a").hasConstructorExpression(), is(true));
@@ -349,10 +292,9 @@ public class StringQueryUnitTests {
 	}
 
 	/**
-	 * @see DATAJPA-886
 	 * @see JPA 2.1 specification, section 4.8
 	 */
-	@Test
+	@Test // DATAJPA-886
 	public void detectsConstructorExpressionForDefaultConstructor() {
 
 		// Parentheses required

--- a/src/test/java/org/springframework/data/jpa/repository/query/TupleConverterUnitTests.java
+++ b/src/test/java/org/springframework/data/jpa/repository/query/TupleConverterUnitTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 the original author or authors.
+ * Copyright 2016-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -61,10 +61,7 @@ public class TupleConverterUnitTests {
 		this.type = method.getResultProcessor().getReturnedType();
 	}
 
-	/**
-	 * @see DATAJPA-984
-	 */
-	@Test
+	@Test // DATAJPA-984
 	@SuppressWarnings("unchecked")
 	public void returnsSingleTupleElementIfItMatchesExpectedType() throws Exception {
 
@@ -76,10 +73,7 @@ public class TupleConverterUnitTests {
 		assertThat(converter.convert(tuple), is((Object) "Foo"));
 	}
 
-	/**
-	 * @see DATAJPA-1024
-	 */
-	@Test
+	@Test // DATAJPA-1024
 	@SuppressWarnings("unchecked")
 	public void returnsNullForSingleElementTupleWithNullValue() throws Exception {
 

--- a/src/test/java/org/springframework/data/jpa/repository/sample/ClassWithNestedRepository.java
+++ b/src/test/java/org/springframework/data/jpa/repository/sample/ClassWithNestedRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 the original author or authors.
+ * Copyright 2013-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,7 +19,6 @@ import org.springframework.data.jpa.domain.sample.User;
 import org.springframework.data.repository.Repository;
 
 /**
- * @see DATAJPA-416
  * @author Thomas Darimont
  * @author Oliver Gierke
  */

--- a/src/test/java/org/springframework/data/jpa/repository/sample/CustomAbstractPersistableRepository.java
+++ b/src/test/java/org/springframework/data/jpa/repository/sample/CustomAbstractPersistableRepository.java
@@ -15,8 +15,6 @@
  */
 package org.springframework.data.jpa.repository.sample;
 
-import java.util.UUID;
-
 import org.springframework.data.jpa.domain.sample.CustomAbstractPersistable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -24,4 +22,4 @@ import org.springframework.data.jpa.repository.JpaRepository;
  * @author Thomas Darimont
  * @author Oliver Gierke
  */
-public interface CustomAbstractPersistableRepository extends JpaRepository<CustomAbstractPersistable, UUID> {}
+public interface CustomAbstractPersistableRepository extends JpaRepository<CustomAbstractPersistable, Long> {}

--- a/src/test/java/org/springframework/data/jpa/repository/sample/EmployeeRepositoryWithEmbeddedId.java
+++ b/src/test/java/org/springframework/data/jpa/repository/sample/EmployeeRepositoryWithEmbeddedId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2015 the original author or authors.
+ * Copyright 2013-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,6 +30,7 @@ import com.querydsl.core.types.Predicate;
  * Demonstrates the support for composite primary keys with {@code @EmbeddedId}.
  * 
  * @author Thomas Darimont
+ * @author Mark Paluch
  */
 @Lazy
 public interface EmployeeRepositoryWithEmbeddedId
@@ -37,4 +38,9 @@ public interface EmployeeRepositoryWithEmbeddedId
 		QueryDslPredicateExecutor<EmbeddedIdExampleEmployee> {
 
 	List<EmbeddedIdExampleEmployee> findAll(Predicate predicate, OrderSpecifier<?>... orders);
+
+	/**
+	 * @see DATAJPA-920
+	 */
+	boolean existsByName(String name);
 }

--- a/src/test/java/org/springframework/data/jpa/repository/sample/EmployeeRepositoryWithEmbeddedId.java
+++ b/src/test/java/org/springframework/data/jpa/repository/sample/EmployeeRepositoryWithEmbeddedId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2016 the original author or authors.
+ * Copyright 2013-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -39,8 +39,6 @@ public interface EmployeeRepositoryWithEmbeddedId
 
 	List<EmbeddedIdExampleEmployee> findAll(Predicate predicate, OrderSpecifier<?>... orders);
 
-	/**
-	 * @see DATAJPA-920
-	 */
+	// DATAJPA-920
 	boolean existsByName(String name);
 }

--- a/src/test/java/org/springframework/data/jpa/repository/sample/EmployeeRepositoryWithIdClass.java
+++ b/src/test/java/org/springframework/data/jpa/repository/sample/EmployeeRepositoryWithIdClass.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2016 the original author or authors.
+ * Copyright 2013-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -38,8 +38,6 @@ public interface EmployeeRepositoryWithIdClass extends JpaRepository<IdClassExam
 
 	List<IdClassExampleEmployee> findAll(Predicate predicate, OrderSpecifier<?>... orders);
 
-	/**
-	 * @see DATAJPA-920
-	 */
+	// DATAJPA-920
 	boolean existsByName(String name);
 }

--- a/src/test/java/org/springframework/data/jpa/repository/sample/EmployeeRepositoryWithIdClass.java
+++ b/src/test/java/org/springframework/data/jpa/repository/sample/EmployeeRepositoryWithIdClass.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2015 the original author or authors.
+ * Copyright 2013-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,10 +30,16 @@ import com.querydsl.core.types.Predicate;
  * Demonstrates the support for composite primary keys with {@code @IdClass}.
  * 
  * @author Thomas Darimont
+ * @author Mark Paluch
  */
 @Lazy
 public interface EmployeeRepositoryWithIdClass extends JpaRepository<IdClassExampleEmployee, IdClassExampleEmployeePK>,
 		QueryDslPredicateExecutor<IdClassExampleEmployee> {
 
 	List<IdClassExampleEmployee> findAll(Predicate predicate, OrderSpecifier<?>... orders);
+
+	/**
+	 * @see DATAJPA-920
+	 */
+	boolean existsByName(String name);
 }

--- a/src/test/java/org/springframework/data/jpa/repository/sample/ItemRepository.java
+++ b/src/test/java/org/springframework/data/jpa/repository/sample/ItemRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 the original author or authors.
+ * Copyright 2016-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,7 +21,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 /**
  * @author Mark Paluch
- * @see DATAJPA-413
  * @see Final JPA 2.1 Specification 2.4.1.3 Derived Identities Example 2
  */
 public interface ItemRepository extends JpaRepository<Item, ItemId> {}

--- a/src/test/java/org/springframework/data/jpa/repository/sample/ItemRepository.java
+++ b/src/test/java/org/springframework/data/jpa/repository/sample/ItemRepository.java
@@ -21,6 +21,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 /**
  * @author Mark Paluch
- * @see Final JPA 2.1 Specification 2.4.1.3 Derived Identities Example 2
+ * @see <a href="download.oracle.com/otn-pub/jcp/persistence-2_1-fr-eval-spec/JavaPersistence.pdf">Final JPA 2.1
+ *      Specification 2.4.1.3 Derived Identities Example 2</a>
  */
 public interface ItemRepository extends JpaRepository<Item, ItemId> {}

--- a/src/test/java/org/springframework/data/jpa/repository/sample/ItemSiteRepository.java
+++ b/src/test/java/org/springframework/data/jpa/repository/sample/ItemSiteRepository.java
@@ -21,6 +21,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 /**
  * @author Mark Paluch
- * @see Final JPA 2.1 Specification 2.4.1.3 Derived Identities Example 2
+ * @see <a href="download.oracle.com/otn-pub/jcp/persistence-2_1-fr-eval-spec/JavaPersistence.pdf">Final JPA 2.1
+ *      Specification 2.4.1.3 Derived Identities Example 2</a>
  */
 public interface ItemSiteRepository extends JpaRepository<ItemSite, ItemSiteId> {}

--- a/src/test/java/org/springframework/data/jpa/repository/sample/ItemSiteRepository.java
+++ b/src/test/java/org/springframework/data/jpa/repository/sample/ItemSiteRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 the original author or authors.
+ * Copyright 2016-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,7 +21,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 /**
  * @author Mark Paluch
- * @see DATAJPA-413
  * @see Final JPA 2.1 Specification 2.4.1.3 Derived Identities Example 2
  */
 public interface ItemSiteRepository extends JpaRepository<ItemSite, ItemSiteId> {}

--- a/src/test/java/org/springframework/data/jpa/repository/sample/RepositoryMethodsWithEntityGraphConfigRepository.java
+++ b/src/test/java/org/springframework/data/jpa/repository/sample/RepositoryMethodsWithEntityGraphConfigRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2016 the original author or authors.
+ * Copyright 2014-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -49,21 +49,15 @@ public interface RepositoryMethodsWithEntityGraphConfigRepository
 	@EntityGraph(type = EntityGraphType.FETCH, value = "User.detail")
 	User findOne(Integer id);
 
-	/**
-	 * @see DATAJPA-696
-	 */
+	// DATAJPA-696
 	@EntityGraph
 	User getOneWithDefinedEntityGraphById(Integer id);
 
-	/**
-	 * @see DATAJPA-696
-	 */
+	// DATAJPA-696
 	@EntityGraph(attributePaths = { "roles", "colleagues.roles" })
 	User getOneWithAttributeNamesById(Integer id);
 
-	/**
-	 * @see DATAJPA-790
-	 */
+	// DATAJPA-790
 	@EntityGraph("User.detail")
 	Page<User> findAll(Predicate predicate, Pageable pageable);
 }

--- a/src/test/java/org/springframework/data/jpa/repository/sample/RepositoryMethodsWithEntityGraphConfigRepository.java
+++ b/src/test/java/org/springframework/data/jpa/repository/sample/RepositoryMethodsWithEntityGraphConfigRepository.java
@@ -69,5 +69,4 @@ public interface RepositoryMethodsWithEntityGraphConfigRepository
 	// DATAJPA-1041
 	@EntityGraph(attributePaths = { "colleagues", "colleagues.roles", "colleagues.colleagues" })
 	User findOneWithMultipleSubGraphsById(Integer id);
-
 }

--- a/src/test/java/org/springframework/data/jpa/repository/sample/RepositoryMethodsWithEntityGraphConfigRepository.java
+++ b/src/test/java/org/springframework/data/jpa/repository/sample/RepositoryMethodsWithEntityGraphConfigRepository.java
@@ -33,6 +33,7 @@ import com.querydsl.core.types.Predicate;
  * 
  * @author Thomas Darimont
  * @author Jocelyn Ntakpe
+ * @author Christoph Strobl
  */
 public interface RepositoryMethodsWithEntityGraphConfigRepository
 		extends CrudRepository<User, Integer>, QueryDslPredicateExecutor<User> {
@@ -60,4 +61,13 @@ public interface RepositoryMethodsWithEntityGraphConfigRepository
 	// DATAJPA-790
 	@EntityGraph("User.detail")
 	Page<User> findAll(Predicate predicate, Pageable pageable);
+
+	// DATAJPA-1041
+	@EntityGraph(type = EntityGraphType.FETCH, value = "User.withSubGraph")
+	User findOneWithMultipleSubGraphsUsingNamedEntityGraphById(Integer id);
+
+	// DATAJPA-1041
+	@EntityGraph(attributePaths = { "colleagues", "colleagues.roles", "colleagues.colleagues" })
+	User findOneWithMultipleSubGraphsById(Integer id);
+
 }

--- a/src/test/java/org/springframework/data/jpa/repository/sample/RoleRepository.java
+++ b/src/test/java/org/springframework/data/jpa/repository/sample/RoleRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2008-2015 the original author or authors.
+ * Copyright 2008-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -59,8 +59,6 @@ public interface RoleRepository extends CrudRepository<Role, Integer>, QueryDslP
 	@QueryHints(@QueryHint(name = "foo", value = "bar"))
 	Role findOne(Predicate predicate);
 
-	/**
-	 * @see DATAJPA-509
-	 */
+	// DATAJPA-509
 	long countByName(String name);
 }

--- a/src/test/java/org/springframework/data/jpa/repository/sample/SiteRepository.java
+++ b/src/test/java/org/springframework/data/jpa/repository/sample/SiteRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 the original author or authors.
+ * Copyright 2016-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,7 +20,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 /**
  * @author Mark Paluch
- * @see DATAJPA-413
  * @see Final JPA 2.1 Specification 2.4.1.3 Derived Identities Example 2
  */
 public interface SiteRepository extends JpaRepository<Site, Integer> {}

--- a/src/test/java/org/springframework/data/jpa/repository/sample/SiteRepository.java
+++ b/src/test/java/org/springframework/data/jpa/repository/sample/SiteRepository.java
@@ -20,6 +20,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 /**
  * @author Mark Paluch
- * @see Final JPA 2.1 Specification 2.4.1.3 Derived Identities Example 2
+ * @see <a href="download.oracle.com/otn-pub/jcp/persistence-2_1-fr-eval-spec/JavaPersistence.pdf">Final JPA 2.1
+ *      Specification 2.4.1.3 Derived Identities Example 2</a>
  */
 public interface SiteRepository extends JpaRepository<Site, Integer> {}

--- a/src/test/java/org/springframework/data/jpa/repository/sample/UserRepository.java
+++ b/src/test/java/org/springframework/data/jpa/repository/sample/UserRepository.java
@@ -283,6 +283,11 @@ public interface UserRepository
 	int countUsersByFirstname(String firstname);
 
 	/**
+	 * @see DATAJPA-920
+	 */
+	boolean existsByLastname(String lastname);
+
+	/**
 	 * @see DATAJPA-391
 	 */
 	@Query("select u.firstname from User u where u.lastname = ?1")

--- a/src/test/java/org/springframework/data/jpa/repository/sample/UserRepository.java
+++ b/src/test/java/org/springframework/data/jpa/repository/sample/UserRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2008-2014 the original author or authors.
+ * Copyright 2008-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -71,10 +71,8 @@ public interface UserRepository
 	/**
 	 * Redeclaration of {@link CrudRepository#delete(java.io.Serializable)}. to make sure the transaction configuration of
 	 * the original method is considered if the redeclaration does not carry a {@link Transactional} annotation.
-	 * 
-	 * @see DATACMNS-649
 	 */
-	void delete(Integer id);
+	void delete(Integer id); // DATACMNS-649
 
 	/**
 	 * Retrieve users by their email address. The finder {@literal User.findByEmailAddress} is declared as annotation at
@@ -141,15 +139,11 @@ public interface UserRepository
 
 	List<User> findByFirstnameNotIn(Collection<String> firstnames);
 
-	/**
-	 * @see DATAJPA-292
-	 */
+	// DATAJPA-292
 	@Query("select u from User u where u.firstname like ?1%")
 	List<User> findByFirstnameLike(String firstname);
 
-	/**
-	 * @see DATAJPA-292
-	 */
+	// DATAJPA-292
 	@Query("select u from User u where u.firstname like :firstname%")
 	List<User> findByFirstnameLikeNamed(@Param("firstname") String firstname);
 
@@ -222,20 +216,14 @@ public interface UserRepository
 	@Query("select u.lastname from User u group by u.lastname")
 	Page<String> findByLastnameGrouped(Pageable pageable);
 
-	/**
-	 * @see DATAJPA-117
-	 */
+	// DATAJPA-117
 	@Query(value = "SELECT * FROM SD_User WHERE lastname = ?1", nativeQuery = true)
 	List<User> findNativeByLastname(String lastname);
 
-	/**
-	 * @see DATAJPA-132
-	 */
+	// DATAJPA-132
 	List<User> findByActiveTrue();
 
-	/**
-	 * @see DATAJPA-132
-	 */
+	// DATAJPA-132
 	List<User> findByActiveFalse();
 
 	/**
@@ -244,362 +232,238 @@ public interface UserRepository
 	// @Query("select u.colleagues from User u where u = ?1")
 	// List<User> findColleaguesFor(User user);
 
-	/**
-	 * @see DATAJPA-188
-	 */
+	// DATAJPA-188
 	List<User> findByCreatedAtBefore(Date date);
 
-	/**
-	 * @see DATAJPA-188
-	 */
+	// DATAJPA-188
 	List<User> findByCreatedAtAfter(Date date);
 
-	/**
-	 * @see DATAJPA-180
-	 */
+	// DATAJPA-180
 	List<User> findByFirstnameStartingWith(String firstname);
 
-	/**
-	 * @see DATAJPA-180
-	 */
+	// DATAJPA-180
 	List<User> findByFirstnameEndingWith(String firstname);
 
-	/**
-	 * @see DATAJPA-180
-	 */
+	// DATAJPA-180
 	List<User> findByFirstnameContaining(String firstname);
 
 	@Query(value = "SELECT 1 FROM SD_User", nativeQuery = true)
 	List<Integer> findOnesByNativeQuery();
 
-	/**
-	 * @see DATAJPA-231
-	 */
+	// DATAJPA-231
 	long countByLastname(String lastname);
 
-	/**
-	 * @see DATAJPA-231
-	 */
+	// DATAJPA-231
 	int countUsersByFirstname(String firstname);
 
-	/**
-	 * @see DATAJPA-920
-	 */
+	// DATAJPA-920
 	boolean existsByLastname(String lastname);
 
-	/**
-	 * @see DATAJPA-391
-	 */
+	// DATAJPA-391
 	@Query("select u.firstname from User u where u.lastname = ?1")
 	List<String> findFirstnamesByLastname(String lastname);
 
-	/**
-	 * @see DATAJPA-415
-	 */
+	// DATAJPA-415
 	Collection<User> findByIdIn(@Param("ids") Integer... ids);
 
-	/**
-	 * @see DATAJPA-461
-	 */
+	// DATAJPA-461
 	@Query("select u from User u where u.id in ?1")
 	Collection<User> findByIdsCustomWithPositionalVarArgs(Integer... ids);
 
-	/**
-	 * @see DATAJPA-461
-	 */
+	// DATAJPA-461
 	@Query("select u from User u where u.id in :ids")
 	Collection<User> findByIdsCustomWithNamedVarArgs(@Param("ids") Integer... ids);
 
-	/**
-	 * @see DATAJPA-415
-	 */
+	// DATAJPA-415
 	@Modifying
 	@Query("update #{#entityName} u set u.active = :activeState where u.id in :ids")
 	void updateUserActiveState(@Param("activeState") boolean activeState, @Param("ids") Integer... ids);
 
-	/**
-	 * @see DATAJPA-405
-	 */
+	// DATAJPA-405
 	List<User> findAllByOrderByLastnameAsc();
 
-	/**
-	 * @see DATAJPA-454
-	 */
+	// DATAJPA-454
 	List<User> findByBinaryData(byte[] data);
 
-	/**
-	 * @see DATAJPA-486
-	 */
+	// DATAJPA-486
 	Slice<User> findSliceByLastname(String lastname, Pageable pageable);
 
-	/**
-	 * @see DATAJPA-496
-	 */
+	// DATAJPA-496
 	List<User> findByAttributesIn(Set<String> attributes);
 
-	/**
-	 * @see DATAJPA-460
-	 */
+	// DATAJPA-460
 	Long removeByLastname(String lastname);
 
-	/**
-	 * @see DATAJPA-460
-	 */
+	// DATAJPA-460
 	List<User> deleteByLastname(String lastname);
 
 	/**
-	 * @see DATAJPA-505
 	 * @see https://issues.apache.org/jira/browse/OPENJPA-2484
 	 */
+	// DATAJPA-505
 	// @Query(value = "select u.binaryData from User u where u.id = :id")
 	// byte[] findBinaryDataByIdJpaQl(@Param("id") Integer id);
 
 	/**
 	 * Explicitly mapped to a procedure with name "plus1inout" in database.
-	 * 
-	 * @see DATAJPA-455
 	 */
-	@Procedure("plus1inout")
+	@Procedure("plus1inout") // DATAJPA-455
 	Integer explicitlyNamedPlus1inout(Integer arg);
 
 	/**
 	 * Implicitly mapped to a procedure with name "plus1inout" in database via alias.
-	 * 
-	 * @see DATAJPA-455
 	 */
-	@Procedure(procedureName = "plus1inout")
+	@Procedure(procedureName = "plus1inout") // DATAJPA-455
 	Integer plus1inout(Integer arg);
 
 	/**
 	 * Explicitly mapped to named stored procedure "User.plus1IO" in {@link EntityManager}.
-	 * 
-	 * @see DATAJPA-455
 	 */
-	@Procedure(name = "User.plus1IO")
+	@Procedure(name = "User.plus1IO") // DATAJPA-455
 	Integer entityAnnotatedCustomNamedProcedurePlus1IO(@Param("arg") Integer arg);
 
 	/**
 	 * Implicitly mapped to named stored procedure "User.plus1" in {@link EntityManager}.
-	 * 
-	 * @see DATAJPA-455
 	 */
-	@Procedure
+	@Procedure // DATAJPA-455
 	Integer plus1(@Param("arg") Integer arg);
 
-	/**
-	 * @see DATAJPA-456
-	 */
+	// DATAJPA-456
 	@Query(value = "select u from User u where u.firstname like ?1%", countProjection = "u.firstname")
 	Page<User> findAllByFirstnameLike(String firstname, Pageable page);
 
-	/**
-	 * @see DATAJPA-456
-	 */
+	// DATAJPA-456
 	@Query(name = "User.findBySpringDataNamedQuery", countProjection = "u.firstname")
 	Page<User> findByNamedQueryAndCountProjection(String firstname, Pageable page);
 
-	/**
-	 * @see DATAJPA-551
-	 */
+	// DATAJPA-551
 	User findFirstByOrderByAgeDesc();
 
-	/**
-	 * @see DATAJPA-551
-	 */
+	// DATAJPA-551
 	User findFirst1ByOrderByAgeDesc();
 
-	/**
-	 * @see DATAJPA-551
-	 */
+	// DATAJPA-551
 	User findTopByOrderByAgeDesc();
 
-	/**
-	 * @see DATAJPA-551
-	 */
+	// DATAJPA-551
 	User findTopByOrderByAgeAsc();
 
-	/**
-	 * @see DATAJPA-551
-	 */
+	// DATAJPA-551
 	User findTop1ByOrderByAgeAsc();
 
-	/**
-	 * @see DATAJPA-551
-	 */
+	// DATAJPA-551
 	List<User> findTop2ByOrderByAgeDesc();
 
-	/**
-	 * @see DATAJPA-551
-	 */
+	// DATAJPA-551
 	List<User> findFirst2ByOrderByAgeDesc();
 
-	/**
-	 * @see DATAJPA-551
-	 */
+	// DATAJPA-551
 	List<User> findFirst2UsersBy(Sort sort);
 
-	/**
-	 * @see DATAJPA-551
-	 */
+	// DATAJPA-551
 	List<User> findTop2UsersBy(Sort sort);
 
-	/**
-	 * @see DATAJPA-551
-	 */
+	// DATAJPA-551
 	Page<User> findFirst3UsersBy(Pageable page);
 
-	/**
-	 * @see DATAJPA-551
-	 */
+	// DATAJPA-551
 	Page<User> findFirst2UsersBy(Pageable page);
 
-	/**
-	 * @see DATAJPA-551
-	 */
+	// DATAJPA-551
 	Slice<User> findTop3UsersBy(Pageable page);
 
-	/**
-	 * @see DATAJPA-551
-	 */
+	// DATAJPA-551
 	Slice<User> findTop2UsersBy(Pageable page);
 
-	/**
-	 * @see DATAJPA-506
-	 */
+	// DATAJPA-506
 	@Query(value = "select u.binaryData from SD_User u where u.id = ?1", nativeQuery = true)
 	byte[] findBinaryDataByIdNative(Integer id);
 
-	/**
-	 * @see DATAJPA-506
-	 */
+	// DATAJPA-506
 	@Query("select u from User u where u.emailAddress = ?1")
 	Optional<User> findOptionalByEmailAddress(String emailAddress);
 
-	/**
-	 * @see DATAJPA-564
-	 */
+	// DATAJPA-564
 	@Query("select u from User u where u.firstname = ?#{[0]} and u.firstname = ?1 and u.lastname like %?#{[1]}% and u.lastname like %?2%")
 	List<User> findByFirstnameAndLastnameWithSpelExpression(String firstname, String lastname);
 
-	/**
-	 * @see DATAJPA-564
-	 */
+	// DATAJPA-564
 	@Query("select u from User u where u.lastname like %:#{[0]}% and u.lastname like %:lastname%")
 	List<User> findByLastnameWithSpelExpression(@Param("lastname") String lastname);
 
-	/**
-	 * @see DATAJPA-564
-	 */
+	// DATAJPA-564
 	@Query("select u from User u where u.firstname = ?#{'Oliver'}")
 	List<User> findOliverBySpELExpressionWithoutArgumentsWithQuestionmark();
 
-	/**
-	 * @see DATAJPA-564
-	 */
+	// DATAJPA-564
 	@Query("select u from User u where u.firstname = :#{'Oliver'}")
 	List<User> findOliverBySpELExpressionWithoutArgumentsWithColon();
 
-	/**
-	 * @see DATAJPA-564
-	 */
+	// DATAJPA-564
 	@Query("select u from User u where u.age = ?#{[0]}")
 	List<User> findUsersByAgeForSpELExpressionByIndexedParameter(int age);
 
-	/**
-	 * @see DATAJPA-564
-	 */
+	// DATAJPA-564
 	@Query("select u from User u where u.firstname = :firstname and u.firstname = :#{#firstname}")
 	List<User> findUsersByFirstnameForSpELExpression(@Param("firstname") String firstname);
 
-	/**
-	 * @see DATAJPA-564
-	 */
+	// DATAJPA-564
 	@Query("select u from User u where u.emailAddress = ?#{principal.emailAddress}")
 	List<User> findCurrentUserWithCustomQuery();
 
-	/**
-	 * @see DATAJPA-564
-	 */
+	// DATAJPA-564
 	@Query("select u from User u where u.firstname = ?1 and u.firstname=?#{[0]} and u.emailAddress = ?#{principal.emailAddress}")
 	List<User> findByFirstnameAndCurrentUserWithCustomQuery(String firstname);
 
-	/**
-	 * @see DATAJPA-564
-	 */
+	// DATAJPA-564
 	@Query("select u from User u where u.firstname = :#{#firstname}")
 	List<User> findUsersByFirstnameForSpELExpressionWithParameterVariableOnly(@Param("firstname") String firstname);
 
-	/**
-	 * @see DATAJPA-564
-	 */
+	// DATAJPA-564
 	@Query("select u from User u where u.firstname = ?#{[0]}")
 	List<User> findUsersByFirstnameForSpELExpressionWithParameterIndexOnly(String firstname);
 
-	/**
-	 * @see DATAJPA-564
-	 */
+	// DATAJPA-564
 	@Query(
 			value = "select * from (select rownum() as RN, u.* from SD_User u) where RN between ?#{ #pageable.offset -1} and ?#{#pageable.offset + #pageable.pageSize}",
 			countQuery = "select count(u.id) from SD_User u", nativeQuery = true)
 	Page<User> findUsersInNativeQueryWithPagination(Pageable pageable);
 
-	/**
-	 * @see DATAJPA-629
-	 */
+	// DATAJPA-629
 	@Query("select u from #{#entityName} u where u.firstname = ?#{[0]} and u.lastname = ?#{[1]}")
 	List<User> findUsersByFirstnameForSpELExpressionWithParameterIndexOnlyWithEntityExpression(String firstname,
 			String lastname);
 
-	/**
-	 * @see DATAJPA-606
-	 */
+	// DATAJPA-606
 	List<User> findByAgeIn(Collection<Integer> ages);
 
-	/**
-	 * @see DATAJPA-606
-	 */
+	// DATAJPA-606
 	List<User> queryByAgeIn(Integer[] ages);
 
-	/**
-	 * @see DATAJPA-606
-	 */
+	// DATAJPA-606
 	List<User> queryByAgeInOrFirstname(Integer[] ages, String firstname);
 
-	/**
-	 * @see DATAJPA-677
-	 */
+	// DATAJPA-677
 	@Query("select u from User u")
 	Stream<User> findAllByCustomQueryAndStream();
 
-	/**
-	 * @see DATAJPA-677
-	 */
+	// DATAJPA-677
 	Stream<User> readAllByFirstnameNotNull();
 
-	/**
-	 * @see DATAJPA-677
-	 */
+	// DATAJPA-677
 	@Query("select u from User u")
 	Stream<User> streamAllPaged(Pageable pageable);
 
-	/**
-	 * @see DATAJPA-830
-	 */
+	// DATAJPA-830
 	List<User> findByLastnameNotContaining(String part);
 
-	/**
-	 * @see DATAJPA-829
-	 */
+	// DATAJPA-829
 	List<User> findByRolesContaining(Role role);
 
-	/**
-	 * @see DATAJPA-829
-	 */
+	// DATAJPA-829
 	List<User> findByRolesNotContaining(Role role);
 
-	/**
-	 * @see DATAJPA-858
-	 */
+	// DATAJPA-858
 	List<User> findByRolesNameContaining(String name);
 
 	List<RolesAndFirstname> findRolesAndFirstnameBy();

--- a/src/test/java/org/springframework/data/jpa/repository/sample/UserRepository.java
+++ b/src/test/java/org/springframework/data/jpa/repository/sample/UserRepository.java
@@ -109,7 +109,7 @@ public interface UserRepository
 	/**
 	 * Retrieves a user by its username using the query annotated to the method.
 	 * 
-	 * @param username
+	 * @param emailAddress
 	 * @return
 	 */
 	@Query("select u from User u where u.emailAddress = ?1")
@@ -162,8 +162,8 @@ public interface UserRepository
 	/**
 	 * Method where parameters will be applied by name. Note that the order of the parameters is then not crucial anymore.
 	 * 
-	 * @param firstname
-	 * @param lastname
+	 * @param foo
+	 * @param bar
 	 * @return
 	 */
 	@Query("select u from User u where u.lastname = :lastname or u.firstname = :firstname")
@@ -298,7 +298,7 @@ public interface UserRepository
 	List<User> deleteByLastname(String lastname);
 
 	/**
-	 * @see https://issues.apache.org/jira/browse/OPENJPA-2484
+	 * @see <a href="https://issues.apache.org/jira/browse/OPENJPA-2484">OPENJPA-2484</a>
 	 */
 	// DATAJPA-505
 	// @Query(value = "select u.binaryData from User u where u.id = :id")

--- a/src/test/java/org/springframework/data/jpa/repository/support/CrudMethodMetadataPopulatingMethodInterceptorUnitTests.java
+++ b/src/test/java/org/springframework/data/jpa/repository/support/CrudMethodMetadataPopulatingMethodInterceptorUnitTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2014 the original author or authors.
+ * Copyright 2012-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -45,10 +45,7 @@ public class CrudMethodMetadataPopulatingMethodInterceptorUnitTests {
 
 	@Mock MethodInvocation invocation;
 
-	/**
-	 * @see DATAJPA-268
-	 */
-	@Test
+	@Test // DATAJPA-268
 	public void cleansUpBoundResources() throws Throwable {
 
 		Method method = prepareMethodInvocation("someMethod");
@@ -59,10 +56,7 @@ public class CrudMethodMetadataPopulatingMethodInterceptorUnitTests {
 		assertThat(TransactionSynchronizationManager.getResource(method), is(nullValue()));
 	}
 
-	/**
-	 * @see DATAJPA-839
-	 */
-	@Test
+	@Test // DATAJPA-839
 	public void looksUpCrudMethodMetadataForEveryInvocation() throws Throwable {
 
 		CrudMethodMetadata metadata = new CrudMethodMetadataPostProcessor().getCrudMethodMetadata();

--- a/src/test/java/org/springframework/data/jpa/repository/support/DefaultJpaContextIntegrationTests.java
+++ b/src/test/java/org/springframework/data/jpa/repository/support/DefaultJpaContextIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2016 the original author or authors.
+ * Copyright 2015-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -84,10 +84,7 @@ public class DefaultJpaContextIntegrationTests {
 		this.jpaContext = new DefaultJpaContext(new HashSet<EntityManager>(Arrays.asList(firstEm, secondEm)));
 	}
 
-	/**
-	 * @see DATAJPA-669
-	 */
-	@Test
+	@Test // DATAJPA-669
 	public void rejectsUnmanagedType() {
 
 		exception.expect(IllegalArgumentException.class);
@@ -96,18 +93,12 @@ public class DefaultJpaContextIntegrationTests {
 		jpaContext.getEntityManagerByManagedType(Object.class);
 	}
 
-	/**
-	 * @see DATAJPA-669
-	 */
-	@Test
+	@Test // DATAJPA-669
 	public void returnsEntitymanagerForUniqueType() {
 		assertThat(jpaContext.getEntityManagerByManagedType(Category.class), is(firstEm));
 	}
 
-	/**
-	 * @see DATAJPA-669
-	 */
-	@Test
+	@Test // DATAJPA-669
 	public void rejectsRequestForTypeManagedByMultipleEntityManagers() {
 
 		exception.expect(IllegalArgumentException.class);
@@ -116,11 +107,7 @@ public class DefaultJpaContextIntegrationTests {
 		jpaContext.getEntityManagerByManagedType(User.class);
 	}
 
-	/**
-	 * @see DATAJPA-813
-	 * @see DATAJPA-956
-	 */
-	@Test
+	@Test // DATAJPA-813, DATAJPA-956
 	public void bootstrapsDefaultJpaContextInSpringContainer() {
 
 		ConfigurableApplicationContext context = new AnnotationConfigApplicationContext(Config.class);
@@ -131,10 +118,7 @@ public class DefaultJpaContextIntegrationTests {
 		context.close();
 	}
 
-	/**
-	 * @see DATAJPA-813
-	 */
-	@Test
+	@Test // DATAJPA-813
 	public void bootstrapsDefaultJpaContextInSpringContainerWithEntityManagerFromJndi() throws Exception {
 
 		SimpleNamingContextBuilder builder = SimpleNamingContextBuilder.emptyActivatedContextBuilder();
@@ -179,8 +163,7 @@ public class DefaultJpaContextIntegrationTests {
 		}
 
 		// A non-EntityManagerFactory JNDI object to make sure the detection doesn't include it
-		// @see DATAJPA-956
-
+		// see DATAJPA-956
 		@Bean
 		public JndiObjectFactoryBean jndiObject() throws NamingException {
 

--- a/src/test/java/org/springframework/data/jpa/repository/support/DefaultJpaContextUnitTests.java
+++ b/src/test/java/org/springframework/data/jpa/repository/support/DefaultJpaContextUnitTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 the original author or authors.
+ * Copyright 2015-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,18 +30,12 @@ import org.junit.Test;
  */
 public class DefaultJpaContextUnitTests {
 
-	/**
-	 * @see DATAJPA-669
-	 */
-	@Test(expected = IllegalArgumentException.class)
+	@Test(expected = IllegalArgumentException.class) // DATAJPA-669
 	public void rejectsNullEntityManagers() {
 		new DefaultJpaContext(null);
 	}
 
-	/**
-	 * @see DATAJPA-669
-	 */
-	@Test(expected = IllegalArgumentException.class)
+	@Test(expected = IllegalArgumentException.class) // DATAJPA-669
 	public void rejectsEmptyEntityManagers() {
 		new DefaultJpaContext(Collections.<EntityManager> emptySet());
 	}

--- a/src/test/java/org/springframework/data/jpa/repository/support/DefaultJpaEntityMetadataUnitTest.java
+++ b/src/test/java/org/springframework/data/jpa/repository/support/DefaultJpaEntityMetadataUnitTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2016 the original author or authors.
+ * Copyright 2013-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -62,10 +62,7 @@ public class DefaultJpaEntityMetadataUnitTest {
 		assertThat(metadata.getEntityName(), is("Entity"));
 	}
 
-	/**
-	 * @see DATAJPA-871
-	 */
-	@Test
+	@Test // DATAJPA-871
 	public void returnsCustomizedEntityNameIfConfiguredViaComposedAnnotation() {
 
 		DefaultJpaEntityMetadata<BarWithComposedAnnotation> metadata = new DefaultJpaEntityMetadata<BarWithComposedAnnotation>(

--- a/src/test/java/org/springframework/data/jpa/repository/support/DefaultTransactionDisablingIntegrationTests.java
+++ b/src/test/java/org/springframework/data/jpa/repository/support/DefaultTransactionDisablingIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 the original author or authors.
+ * Copyright 2015-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -47,10 +47,7 @@ public abstract class DefaultTransactionDisablingIntegrationTests {
 	@Autowired UserRepository repository;
 	@Autowired DelegatingTransactionManager txManager;
 
-	/**
-	 * @see DATAJPA-685
-	 */
-	@Test
+	@Test // DATAJPA-685
 	public void considersExplicitConfigurationOnRepositoryInterface() {
 
 		repository.findOne(1);
@@ -58,10 +55,7 @@ public abstract class DefaultTransactionDisablingIntegrationTests {
 		assertThat(txManager.getDefinition().isReadOnly(), is(false));
 	}
 
-	/**
-	 * @see DATAJPA-685
-	 */
-	@Test
+	@Test // DATAJPA-685
 	public void doesNotUseDefaultTransactionsOnNonRedeclaredMethod() {
 
 		repository.findAll(new PageRequest(0, 10));
@@ -69,10 +63,7 @@ public abstract class DefaultTransactionDisablingIntegrationTests {
 		assertThat(txManager.getDefinition(), is(nullValue()));
 	}
 
-	/**
-	 * @see DATAJPA-685
-	 */
-	@Test
+	@Test // DATAJPA-685
 	public void persistingAnEntityShouldThrowExceptionDueToMissingTransaction() {
 
 		exception.expect(InvalidDataAccessApiUsageException.class);

--- a/src/test/java/org/springframework/data/jpa/repository/support/EntityManagerBeanDefinitionRegistrarPostProcessorIntegrationTests.java
+++ b/src/test/java/org/springframework/data/jpa/repository/support/EntityManagerBeanDefinitionRegistrarPostProcessorIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Copyright 2014-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -86,10 +86,7 @@ public class EntityManagerBeanDefinitionRegistrarPostProcessorIntegrationTests {
 
 	@Autowired EntityManagerInjectionTarget target;
 
-	/**
-	 * @see DATAJPA-445
-	 */
-	@Test
+	@Test // DATAJPA-445
 	public void injectsEntityManagerIntoConstructors() {
 
 		assertThat(target, is(notNullValue()));

--- a/src/test/java/org/springframework/data/jpa/repository/support/EntityManagerBeanDefinitionRegistratPostProcessorUnitTests.java
+++ b/src/test/java/org/springframework/data/jpa/repository/support/EntityManagerBeanDefinitionRegistratPostProcessorUnitTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Copyright 2014-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,10 +32,7 @@ import org.springframework.orm.jpa.LocalContainerEntityManagerFactoryBean;
  */
 public class EntityManagerBeanDefinitionRegistratPostProcessorUnitTests {
 
-	/**
-	 * @see DATAJPA-453
-	 */
-	@Test
+	@Test // DATAJPA-453
 	public void findsBeanDefinitionInParentBeanFactory() {
 
 		DefaultListableBeanFactory beanFactory = new DefaultListableBeanFactory();

--- a/src/test/java/org/springframework/data/jpa/repository/support/EntityManagerBeanDefinitionRegistratPostProcessorUnitTests.java
+++ b/src/test/java/org/springframework/data/jpa/repository/support/EntityManagerBeanDefinitionRegistratPostProcessorUnitTests.java
@@ -17,10 +17,14 @@ package org.springframework.data.jpa.repository.support;
 
 import static org.hamcrest.CoreMatchers.*;
 import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+import javax.persistence.EntityManagerFactory;
 
 import org.junit.Test;
 import org.springframework.beans.factory.config.BeanFactoryPostProcessor;
 import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
+import org.springframework.beans.factory.support.BeanDefinitionBuilder;
 import org.springframework.beans.factory.support.DefaultListableBeanFactory;
 import org.springframework.beans.factory.support.RootBeanDefinition;
 import org.springframework.orm.jpa.LocalContainerEntityManagerFactoryBean;
@@ -44,5 +48,41 @@ public class EntityManagerBeanDefinitionRegistratPostProcessorUnitTests {
 		processor.postProcessBeanFactory(childFactory);
 
 		assertThat(beanFactory.getBeanDefinitionCount(), is(2));
+	}
+
+	@Test // DATAJPA-1005, DATAJPA-1045
+	public void discoversFactoryBeanReturningConcreteEntityManagerFactoryType() {
+
+		BeanDefinitionBuilder builder = BeanDefinitionBuilder.rootBeanDefinition(StubEntityManagerFactoryBean.class);
+		builder.addConstructorArgValue(SpecialEntityManagerFactory.class);
+
+		DefaultListableBeanFactory beanFactory = new DefaultListableBeanFactory();
+		beanFactory.registerBeanDefinition("factory", builder.getBeanDefinition());
+
+		BeanFactoryPostProcessor processor = new EntityManagerBeanDefinitionRegistrarPostProcessor();
+		processor.postProcessBeanFactory(beanFactory);
+
+		assertThat(beanFactory.getBeanDefinitionCount(), is(2));
+	}
+
+	interface SpecialEntityManagerFactory extends EntityManagerFactory {}
+
+	static class StubEntityManagerFactoryBean extends LocalContainerEntityManagerFactoryBean {
+
+		private final Class<? extends EntityManagerFactory> emfType;
+
+		public StubEntityManagerFactoryBean(Class<? extends EntityManagerFactory> emfType) {
+			this.emfType = emfType;
+		}
+
+		@Override
+		public Class<? extends EntityManagerFactory> getObjectType() {
+			return emfType;
+		}
+
+		@Override
+		protected EntityManagerFactory createEntityManagerFactoryProxy(EntityManagerFactory emf) {
+			return mock(emfType);
+		}
 	}
 }

--- a/src/test/java/org/springframework/data/jpa/repository/support/JpaEntityInformationSupportUnitTests.java
+++ b/src/test/java/org/springframework/data/jpa/repository/support/JpaEntityInformationSupportUnitTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011 the original author or authors.
+ * Copyright 2011-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -54,10 +54,7 @@ public class JpaEntityInformationSupportUnitTests {
 		assertEquals("AnotherNamedUser", second.getEntityName());
 	}
 
-	/**
-	 * @see DATAJPA-93
-	 */
-	@Test(expected = IllegalArgumentException.class)
+	@Test(expected = IllegalArgumentException.class) // DATAJPA-93
 	public void rejectsClassNotBeingFoundInMetamodel() {
 
 		when(em.getMetamodel()).thenReturn(metaModel);

--- a/src/test/java/org/springframework/data/jpa/repository/support/JpaMetamodelEntityInformationIntegrationTests.java
+++ b/src/test/java/org/springframework/data/jpa/repository/support/JpaMetamodelEntityInformationIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2015 the original author or authors.
+ * Copyright 2011-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -39,6 +39,7 @@ import org.hibernate.Version;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+
 import org.springframework.data.jpa.domain.AbstractPersistable;
 import org.springframework.data.jpa.domain.sample.ConcreteType1;
 import org.springframework.data.jpa.domain.sample.Item;
@@ -85,9 +86,8 @@ public class JpaMetamodelEntityInformationIntegrationTests {
 	 * {@link MappedSuperclass}es correctly).
 	 * 
 	 * @see https://hibernate.onjira.com/browse/HHH-6896
-	 * @see DATAJPA-141
 	 */
-	@Test
+	@Test // DATAJPA-141
 	@Ignore
 	public void detectsIdTypeForMappedSuperclass() {
 
@@ -95,20 +95,14 @@ public class JpaMetamodelEntityInformationIntegrationTests {
 		assertEquals(Serializable.class, information.getIdType());
 	}
 
-	/**
-	 * @see DATAJPA-50
-	 */
-	@Test
+	@Test // DATAJPA-50
 	public void detectsIdClass() {
 
 		EntityInformation<PersistableWithIdClass, ?> information = getEntityInformation(PersistableWithIdClass.class, em);
 		assertThat(information.getIdType(), is(typeCompatibleWith(PersistableWithIdClassPK.class)));
 	}
 
-	/**
-	 * @see DATAJPA-50
-	 */
-	@Test
+	@Test // DATAJPA-50
 	public void returnsIdOfPersistableInstanceCorrectly() {
 
 		PersistableWithIdClass entity = new PersistableWithIdClass(2L, 4L);
@@ -121,10 +115,7 @@ public class JpaMetamodelEntityInformationIntegrationTests {
 		assertThat(id, is((Object) new PersistableWithIdClassPK(2L, 4L)));
 	}
 
-	/**
-	 * @see DATAJPA-413
-	 */
-	@Test
+	@Test // DATAJPA-413
 	public void returnsIdOfEntityWithIdClassCorrectly() {
 
 		Item item = new Item(2, 1);
@@ -136,10 +127,7 @@ public class JpaMetamodelEntityInformationIntegrationTests {
 		assertThat(id, is((Object) new ItemId(2, 1)));
 	}
 
-	/**
-	 * @see DATAJPA-413
-	 */
-	@Test
+	@Test // DATAJPA-413
 	public void returnsDerivedIdOfEntityWithIdClassCorrectly() {
 
 		Item item = new Item(1, 2);
@@ -154,10 +142,7 @@ public class JpaMetamodelEntityInformationIntegrationTests {
 		assertThat(id, is((Object) new ItemSiteId(new ItemId(1, 2), 3)));
 	}
 
-	/**
-	 * @see DATAJPA-413
-	 */
-	@Test
+	@Test // DATAJPA-413
 	public void returnsPartialEmptyDerivedIdOfEntityWithIdClassCorrectly() {
 
 		Item item = new Item(1, null);
@@ -172,10 +157,7 @@ public class JpaMetamodelEntityInformationIntegrationTests {
 		assertThat(id, is((Object) new ItemSiteId(new ItemId(1, null), 3)));
 	}
 
-	/**
-	 * @see DATAJPA-119
-	 */
-	@Test
+	@Test // DATAJPA-119
 	public void favoursVersionAnnotationIfPresent() {
 
 		EntityInformation<VersionedUser, Long> information = new JpaMetamodelEntityInformation<VersionedUser, Long>(
@@ -191,10 +173,7 @@ public class JpaMetamodelEntityInformationIntegrationTests {
 		assertThat(information.isNew(entity), is(false));
 	}
 
-	/**
-	 * @see DATAJPA-348
-	 */
-	@Test
+	@Test // DATAJPA-348
 	public void findsIdClassOnMappedSuperclass() {
 
 		EntityManagerFactory emf = Persistence.createEntityManagerFactory(getMetadadataPersitenceUnitName());
@@ -206,10 +185,7 @@ public class JpaMetamodelEntityInformationIntegrationTests {
 		assertThat(information.getIdType(), is((Object) BaseIdClass.class));
 	}
 
-	/**
-	 * @see DATACMNS-357
-	 */
-	@Test
+	@Test // DATACMNS-357
 	public void detectsNewStateForEntityWithPrimitiveId() {
 
 		EntityInformation<SampleWithPrimitiveId, Long> information = new JpaMetamodelEntityInformation<SampleWithPrimitiveId, Long>(
@@ -222,10 +198,7 @@ public class JpaMetamodelEntityInformationIntegrationTests {
 		assertThat(information.isNew(sample), is(false));
 	}
 
-	/**
-	 * @see DATAJPA-509
-	 */
-	@Test
+	@Test // DATAJPA-509
 	public void jpaMetamodelEntityInformationShouldRespectExplicitlyConfiguredEntityNameFromOrmXml() {
 
 		JpaEntityInformation<Role, Integer> info = new JpaMetamodelEntityInformation<Role, Integer>(Role.class,
@@ -234,10 +207,7 @@ public class JpaMetamodelEntityInformationIntegrationTests {
 		assertThat(info.getEntityName(), is("ROLE"));
 	}
 
-	/**
-	 * @see DATAJPA-561
-	 */
-	@Test
+	@Test // DATAJPA-561
 	public void considersEntityWithPrimitiveVersionPropertySetToDefaultNew() {
 
 		EntityInformation<PrimitiveVersionProperty, Serializable> information = new JpaMetamodelEntityInformation<PrimitiveVersionProperty, Serializable>(
@@ -246,10 +216,7 @@ public class JpaMetamodelEntityInformationIntegrationTests {
 		assertThat(information.isNew(new PrimitiveVersionProperty()), is(true));
 	}
 
-	/**
-	 * @see DATAJPA-568
-	 */
-	@Test
+	@Test // DATAJPA-568
 	public void considersEntityAsNotNewWhenHavingIdSetAndUsingPrimitiveTypeForVersionProperty() {
 
 		EntityInformation<PrimitiveVersionProperty, Serializable> information = new JpaMetamodelEntityInformation<PrimitiveVersionProperty, Serializable>(
@@ -261,10 +228,7 @@ public class JpaMetamodelEntityInformationIntegrationTests {
 		assertThat(information.isNew(pvp), is(false));
 	}
 
-	/**
-	 * @see DATAJPA-568
-	 */
-	@Test
+	@Test // DATAJPA-568
 	public void fallsBackToIdInspectionForAPrimitiveVersionProperty() {
 
 		EntityInformation<PrimitiveVersionProperty, Serializable> information = new JpaMetamodelEntityInformation<PrimitiveVersionProperty, Serializable>(
@@ -279,10 +243,7 @@ public class JpaMetamodelEntityInformationIntegrationTests {
 		assertThat(information.isNew(pvp), is(false));
 	}
 
-	/**
-	 * @see DATAJPA-582
-	 */
-	@Test
+	@Test // DATAJPA-582
 	public void considersEntityWithUnsetCompundIdNew() {
 
 		EntityInformation<SampleWithIdClass, ?> information = getEntityInformation(SampleWithIdClass.class, em);
@@ -290,10 +251,7 @@ public class JpaMetamodelEntityInformationIntegrationTests {
 		assertThat(information.isNew(new SampleWithIdClass()), is(true));
 	}
 
-	/**
-	 * @see DATAJPA-582
-	 */
-	@Test
+	@Test // DATAJPA-582
 	public void considersEntityWithSetTimestampVersionNotNew() {
 
 		EntityInformation<SampleWithTimestampVersion, ?> information = getEntityInformation(
@@ -305,10 +263,7 @@ public class JpaMetamodelEntityInformationIntegrationTests {
 		assertThat(information.isNew(entity), is(false));
 	}
 
-	/**
-	 * @see DATAJPA-582, DATAJPA-581
-	 */
-	@Test
+	@Test // DATAJPA-582, DATAJPA-581
 	public void considersEntityWithNonPrimitiveNonNullIdTypeNotNew() {
 
 		EntityInformation<User, ?> information = getEntityInformation(User.class, em);
@@ -321,10 +276,9 @@ public class JpaMetamodelEntityInformationIntegrationTests {
 	}
 
 	/**
-	 * @see DATAJPA-820 - Ignored as Hibernate < 4.3 doesn't expose the version property properly if it's declared on the
-	 *      superclass.
+	 * Ignored as Hibernate < 4.3 doesn't expose the version property properly if it's declared on the superclass.
 	 */
-	@Test
+	@Test // DATAJPA-820
 	@Ignore
 	public void detectsVersionPropertyOnMappedSuperClass() {
 

--- a/src/test/java/org/springframework/data/jpa/repository/support/JpaMetamodelEntityInformationIntegrationTests.java
+++ b/src/test/java/org/springframework/data/jpa/repository/support/JpaMetamodelEntityInformationIntegrationTests.java
@@ -35,6 +35,7 @@ import javax.persistence.Persistence;
 import javax.persistence.PersistenceContext;
 import javax.persistence.metamodel.Metamodel;
 
+import org.hibernate.Version;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -333,7 +334,7 @@ public class JpaMetamodelEntityInformationIntegrationTests {
 	}
 
 	protected String getMetadadataPersitenceUnitName() {
-		return "metadata";
+		return Version.getVersionString().startsWith("5.2") ? "metadata-52" : "metadata";
 	}
 
 	@SuppressWarnings("serial")

--- a/src/test/java/org/springframework/data/jpa/repository/support/JpaMetamodelEntityInformationIntegrationTests.java
+++ b/src/test/java/org/springframework/data/jpa/repository/support/JpaMetamodelEntityInformationIntegrationTests.java
@@ -85,7 +85,7 @@ public class JpaMetamodelEntityInformationIntegrationTests {
 	 * Ignored for Hibernate as it does not implement {@link Metamodel#managedType(Class)} correctly (does not consider
 	 * {@link MappedSuperclass}es correctly).
 	 * 
-	 * @see https://hibernate.onjira.com/browse/HHH-6896
+	 * @see <a href="https://hibernate.atlassian.net/browse/HHH-6896">HHH-6896</a>
 	 */
 	@Test // DATAJPA-141
 	@Ignore

--- a/src/test/java/org/springframework/data/jpa/repository/support/JpaMetamodelEntityInformationUnitTests.java
+++ b/src/test/java/org/springframework/data/jpa/repository/support/JpaMetamodelEntityInformationUnitTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012 the original author or authors.
+ * Copyright 2012-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -70,10 +70,7 @@ public class JpaMetamodelEntityInformationUnitTests {
 		when(idType.getJavaType()).thenReturn(PersistableWithIdClassPK.class);
 	}
 
-	/**
-	 * @see DATAJPA-50
-	 */
-	@Test
+	@Test // DATAJPA-50
 	public void doesNotCreateIdIfAllPartialAttributesAreNull() {
 
 		JpaMetamodelEntityInformation<PersistableWithIdClass, Serializable> information = new JpaMetamodelEntityInformation<PersistableWithIdClass, Serializable>(

--- a/src/test/java/org/springframework/data/jpa/repository/support/JpaRepositoryFactoryBeanUnitTests.java
+++ b/src/test/java/org/springframework/data/jpa/repository/support/JpaRepositoryFactoryBeanUnitTests.java
@@ -51,18 +51,12 @@ public class JpaRepositoryFactoryBeanUnitTests {
 
 	JpaRepositoryFactoryBean<SimpleSampleRepository, User, Integer> factoryBean;
 
-	@Mock
-	EntityManager entityManager;
-	@Mock
-	RepositoryFactorySupport factory;
-	@Mock
-	ListableBeanFactory beanFactory;
-	@Mock
-	PersistenceExceptionTranslator translator;
-	@Mock
-	Repository<?, ?> repository;
-	@Mock
-	Metamodel metamodel;
+	@Mock EntityManager entityManager;
+	@Mock RepositoryFactorySupport factory;
+	@Mock ListableBeanFactory beanFactory;
+	@Mock PersistenceExceptionTranslator translator;
+	@Mock Repository<?, ?> repository;
+	@Mock Metamodel metamodel;
 
 	@Before
 	@SuppressWarnings("unchecked")
@@ -70,14 +64,14 @@ public class JpaRepositoryFactoryBeanUnitTests {
 
 		Map<String, PersistenceExceptionTranslator> beans = new HashMap<String, PersistenceExceptionTranslator>();
 		beans.put("foo", translator);
-		when(beanFactory.getBeansOfType(eq(PersistenceExceptionTranslator.class), anyBoolean(), anyBoolean())).thenReturn(
-				beans);
+		when(beanFactory.getBeansOfType(eq(PersistenceExceptionTranslator.class), anyBoolean(), anyBoolean()))
+				.thenReturn(beans);
 		when(factory.getRepository(any(Class.class), any(Object.class))).thenReturn(repository);
 		when(entityManager.getMetamodel()).thenReturn(metamodel);
 
 		// Setup standard factory configuration
-		factoryBean = new DummyJpaRepositoryFactoryBean<SimpleSampleRepository, User, Integer>();
-		factoryBean.setRepositoryInterface(SimpleSampleRepository.class);
+		factoryBean = new DummyJpaRepositoryFactoryBean<SimpleSampleRepository, User, Integer>(
+				SimpleSampleRepository.class);
 		factoryBean.setEntityManager(entityManager);
 	}
 
@@ -107,34 +101,22 @@ public class JpaRepositoryFactoryBeanUnitTests {
 	 */
 	@Test(expected = IllegalArgumentException.class)
 	public void preventsNullRepositoryInterface() {
-
-		factoryBean.setRepositoryInterface(null);
+		new JpaRepositoryFactoryBean<Repository<Object, Long>, Object, Long>(null);
 	}
 
-	/**
-	 * Assert that the factory detects unset repository class and interface in
-	 * {@code JpaRepositoryFactoryBean#afterPropertiesSet()}.
-	 */
-	@Test(expected = IllegalArgumentException.class)
-	public void preventsUnsetRepositoryInterface() throws Exception {
+	private class DummyJpaRepositoryFactoryBean<T extends JpaRepository<S, ID>, S, ID extends Serializable>
+			extends JpaRepositoryFactoryBean<T, S, ID> {
 
-		factoryBean = new JpaRepositoryFactoryBean<SimpleSampleRepository, User, Integer>();
-		factoryBean.afterPropertiesSet();
-	}
-
-	private class DummyJpaRepositoryFactoryBean<T extends JpaRepository<S, ID>, S, ID extends Serializable> extends
-			JpaRepositoryFactoryBean<T, S, ID> {
+		public DummyJpaRepositoryFactoryBean(Class<? extends T> repositoryInterface) {
+			super(repositoryInterface);
+		}
 
 		/*
 		 * (non-Javadoc)
-		 * 
-		 * @see
-		 * org.springframework.data.jpa.repository.support.JpaRepositoryFactoryBean
-		 * #createRepositoryFactory()
+		 * @see org.springframework.data.jpa.repository.support.JpaRepositoryFactoryBean#doCreateRepositoryFactory()
 		 */
 		@Override
 		protected RepositoryFactorySupport doCreateRepositoryFactory() {
-
 			return factory;
 		}
 	}

--- a/src/test/java/org/springframework/data/jpa/repository/support/JpaRepositoryFactoryUnitTests.java
+++ b/src/test/java/org/springframework/data/jpa/repository/support/JpaRepositoryFactoryUnitTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2008-2015 the original author or authors.
+ * Copyright 2008-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -158,10 +158,7 @@ public class JpaRepositoryFactoryUnitTests {
 		}
 	}
 
-	/**
-	 * @see DATAJPA-710, DATACMNS-542
-	 */
-	@Test
+	@Test // DATAJPA-710, DATACMNS-542
 	public void usesConfiguredRepositoryBaseClass() {
 
 		factory.setRepositoryBaseClass(CustomJpaRepository.class);
@@ -170,10 +167,7 @@ public class JpaRepositoryFactoryUnitTests {
 		assertEquals(CustomJpaRepository.class, ((Advised) repository).getTargetClass());
 	}
 
-	/**
-	 * @see DATAJPA-819
-	 */
-	@Test
+	@Test // DATAJPA-819
 	public void crudMethodMetadataPostProcessorUsesBeanClassLoader() {
 
 		ClassLoader classLoader = new OverridingClassLoader(ClassUtils.getDefaultClassLoader());

--- a/src/test/java/org/springframework/data/jpa/repository/support/JpaRepositoryTests.java
+++ b/src/test/java/org/springframework/data/jpa/repository/support/JpaRepositoryTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2008-2014 the original author or authors.
+ * Copyright 2008-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -73,10 +73,7 @@ public class JpaRepositoryTests {
 		assertThat(repository.count(), is(0L));
 	}
 
-	/**
-	 * @see DATAJPA-50
-	 */
-	@Test
+	@Test // DATAJPA-50
 	public void executesCrudOperationsForEntityWithIdClass() {
 
 		PersistableWithIdClass entity = new PersistableWithIdClass(1L, 1L);
@@ -90,10 +87,7 @@ public class JpaRepositoryTests {
 		assertThat(idClassRepository.findOne(id), is(entity));
 	}
 
-	/**
-	 * @see DATAJPA-266
-	 */
-	@Test
+	@Test // DATAJPA-266
 	public void testExistsForDomainObjectsWithCompositeKeys() throws Exception {
 
 		PersistableWithIdClass s1 = idClassRepository.save(new PersistableWithIdClass(1L, 1L));
@@ -104,10 +98,7 @@ public class JpaRepositoryTests {
 		assertThat(idClassRepository.exists(new PersistableWithIdClassPK(1L, 2L)), is(false));
 	}
 
-	/**
-	 * @see DATAJPA-527
-	 */
-	@Test
+	@Test // DATAJPA-527
 	public void executesExistsForEntityWithIdClass() {
 
 		PersistableWithIdClass entity = new PersistableWithIdClass(1L, 1L);

--- a/src/test/java/org/springframework/data/jpa/repository/support/MailMessageRepositoryIntegrationTests.java
+++ b/src/test/java/org/springframework/data/jpa/repository/support/MailMessageRepositoryIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 the original author or authors.
+ * Copyright 2013-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -63,10 +63,7 @@ public class MailMessageRepositoryIntegrationTests {
 
 	@Autowired MailMessageRepository mailMessageRepository;
 
-	/**
-	 * @see DATAJPA-12
-	 */
-	@Test
+	@Test // DATAJPA-12
 	public void shouldSortMailWithPageRequestAndJpaSortCriteriaNullsFirst() {
 
 		MailMessage message1 = new MailMessage();
@@ -89,10 +86,7 @@ public class MailMessageRepositoryIntegrationTests {
 		assertThat(messages.get(1).getMailSender(), is(sender1));
 	}
 
-	/**
-	 * @see DATAJPA-12
-	 */
-	@Test
+	@Test // DATAJPA-12
 	public void shouldSortMailWithQueryDslRepositoryAndDslSortCriteriaNullsFirst() {
 
 		MailMessage message1 = new MailMessage();
@@ -114,10 +108,7 @@ public class MailMessageRepositoryIntegrationTests {
 		assertThat(messages.get(1).getMailSender(), is(sender1));
 	}
 
-	/**
-	 * @see DATAJPA-491
-	 */
-	@Test
+	@Test // DATAJPA-491
 	public void shouldSortMailWithNestedQueryDslSortCriteriaNullsFirst() {
 
 		MailUser fooMailUser = new MailUser("foo");
@@ -143,10 +134,7 @@ public class MailMessageRepositoryIntegrationTests {
 		assertThat(messages.get(1).getMailSender(), is(sender1));
 	}
 
-	/**
-	 * @see DATAJPA-491
-	 */
-	@Test
+	@Test // DATAJPA-491
 	public void shouldSortMailWithNestedStringBasedSortCriteriaNullsFirst() {
 
 		MailUser fooMailUser = new MailUser("foo");

--- a/src/test/java/org/springframework/data/jpa/repository/support/QueryDslJpaRepositoryTests.java
+++ b/src/test/java/org/springframework/data/jpa/repository/support/QueryDslJpaRepositoryTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2008-2016 the original author or authors.
+ * Copyright 2008-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -106,10 +106,7 @@ public class QueryDslJpaRepositoryTests {
 		assertThat(result, hasItems(carter, dave));
 	}
 
-	/**
-	 * @see DATAJPA-243
-	 */
-	@Test
+	@Test // DATAJPA-243
 	public void considersSortingProvidedThroughPageable() {
 
 		Predicate lastnameContainsE = user.lastname.contains("e");
@@ -126,10 +123,7 @@ public class QueryDslJpaRepositoryTests {
 		assertThat(result.getContent().get(1), is(dave));
 	}
 
-	/**
-	 * @see DATAJPA-296
-	 */
-	@Test
+	@Test // DATAJPA-296
 	public void appliesIgnoreCaseOrdering() {
 
 		Sort sort = new Sort(new Order(Direction.DESC, "lastname").ignoreCase(), new Order(Direction.ASC, "firstname"));
@@ -141,10 +135,7 @@ public class QueryDslJpaRepositoryTests {
 		assertThat(result.getContent().get(1), is(oliver));
 	}
 
-	/**
-	 * @see DATAJPA-427
-	 */
-	@Test
+	@Test // DATAJPA-427
 	public void findBySpecificationWithSortByPluralAssociationPropertyInPageableShouldUseSortNullValuesLast() {
 
 		oliver.getColleagues().add(dave);
@@ -159,10 +150,7 @@ public class QueryDslJpaRepositoryTests {
 		assertThat(page.getContent(), hasItems(oliver, dave, carter));
 	}
 
-	/**
-	 * @see DATAJPA-427
-	 */
-	@Test
+	@Test // DATAJPA-427
 	public void findBySpecificationWithSortBySingularAssociationPropertyInPageableShouldUseSortNullValuesLast() {
 
 		oliver.setManager(dave);
@@ -177,10 +165,7 @@ public class QueryDslJpaRepositoryTests {
 		assertThat(page.getContent(), hasItems(dave, oliver, carter));
 	}
 
-	/**
-	 * @see DATAJPA-427
-	 */
-	@Test
+	@Test // DATAJPA-427
 	public void findBySpecificationWithSortBySingularPropertyInPageableShouldUseSortNullValuesFirst() {
 
 		QUser user = QUser.user;
@@ -192,10 +177,7 @@ public class QueryDslJpaRepositoryTests {
 		assertThat(page.getContent(), hasItems(carter, dave, oliver));
 	}
 
-	/**
-	 * @see DATAJPA-427
-	 */
-	@Test
+	@Test // DATAJPA-427
 	public void findBySpecificationWithSortByOrderIgnoreCaseBySingularPropertyInPageableShouldUseSortNullValuesFirst() {
 
 		QUser user = QUser.user;
@@ -207,10 +189,7 @@ public class QueryDslJpaRepositoryTests {
 		assertThat(page.getContent(), hasItems(carter, dave, oliver));
 	}
 
-	/**
-	 * @see DATAJPA-427
-	 */
-	@Test
+	@Test // DATAJPA-427
 	public void findBySpecificationWithSortByNestedEmbeddedPropertyInPageableShouldUseSortNullValuesFirst() {
 
 		oliver.setAddress(new Address("Germany", "Saarbrücken", "HaveItYourWay", "123"));
@@ -225,10 +204,7 @@ public class QueryDslJpaRepositoryTests {
 		assertThat(page.getContent().get(2), is(oliver));
 	}
 
-	/**
-	 * @see DATAJPA-12
-	 */
-	@Test
+	@Test // DATAJPA-12
 	public void findBySpecificationWithSortByQueryDslOrderSpecifierWithQPageRequestAndQSort() {
 
 		QUser user = QUser.user;
@@ -243,10 +219,7 @@ public class QueryDslJpaRepositoryTests {
 		assertThat(page.getContent().get(2), is(oliver));
 	}
 
-	/**
-	 * @see DATAJPA-12
-	 */
-	@Test
+	@Test // DATAJPA-12
 	public void findBySpecificationWithSortByQueryDslOrderSpecifierWithQPageRequest() {
 
 		QUser user = QUser.user;
@@ -260,10 +233,7 @@ public class QueryDslJpaRepositoryTests {
 		assertThat(page.getContent().get(2), is(oliver));
 	}
 
-	/**
-	 * @see DATAJPA-12
-	 */
-	@Test
+	@Test // DATAJPA-12
 	public void findBySpecificationWithSortByQueryDslOrderSpecifierForAssociationShouldGenerateLeftJoinWithQPageRequest() {
 
 		oliver.setManager(dave);
@@ -281,10 +251,7 @@ public class QueryDslJpaRepositoryTests {
 		assertThat(page.getContent().get(2), is(oliver));
 	}
 
-	/**
-	 * @see DATAJPA-491
-	 */
-	@Test
+	@Test // DATAJPA-491
 	public void sortByNestedAssociationPropertyWithSpecificationAndSortInPageable() {
 
 		oliver.setManager(dave);
@@ -296,10 +263,7 @@ public class QueryDslJpaRepositoryTests {
 		assertThat(page.getContent().get(0), is(dave));
 	}
 
-	/**
-	 * @see DATAJPA-500, DATAJPA-635
-	 */
-	@Test
+	@Test // DATAJPA-500, DATAJPA-635
 	public void sortByNestedEmbeddedAttribite() {
 
 		carter.setAddress(new Address("U", "Z", "Y", "41"));
@@ -312,10 +276,7 @@ public class QueryDslJpaRepositoryTests {
 		assertThat(users, hasItems(dave, oliver, carter));
 	}
 
-	/**
-	 * @see DATAJPA-566, DATAJPA-635
-	 */
-	@Test
+	@Test // DATAJPA-566, DATAJPA-635
 	public void shouldSupportSortByOperatorWithDateExpressions() {
 
 		carter.setDateOfBirth(new LocalDate(2000, 2, 1).toDate());
@@ -328,10 +289,7 @@ public class QueryDslJpaRepositoryTests {
 		assertThat(users, hasItems(dave, carter, oliver));
 	}
 
-	/**
-	 * @see DATAJPA-665
-	 */
-	@Test
+	@Test // DATAJPA-665
 	public void shouldSupportExistsWithPredicate() throws Exception {
 
 		assertThat(repository.exists(user.firstname.eq("Dave")), is(true));
@@ -339,10 +297,7 @@ public class QueryDslJpaRepositoryTests {
 		assertThat(repository.exists((Predicate) null), is(true));
 	}
 
-	/**
-	 * @see DATAJPA-679
-	 */
-	@Test
+	@Test // DATAJPA-679
 	public void shouldSupportFindAllWithPredicateAndSort() {
 
 		List<User> users = repository.findAll(user.dateOfBirth.isNull(), new Sort(Direction.ASC, "firstname"));
@@ -353,18 +308,12 @@ public class QueryDslJpaRepositoryTests {
 		assertThat(users, hasItems(carter, dave, oliver));
 	}
 
-	/**
-	 * @see DATAJPA-585
-	 */
-	@Test
+	@Test // DATAJPA-585
 	public void worksWithNullPageable() {
 		assertThat(repository.findAll(user.dateOfBirth.isNull(), (Pageable) null).getContent(), hasSize(3));
 	}
 
-	/**
-	 * @see DATAJPA-912
-	 */
-	@Test
+	@Test // DATAJPA-912
 	public void pageableQueryReportsTotalFromResult() {
 
 		Page<User> firstPage = repository.findAll(user.dateOfBirth.isNull(), new PageRequest(0, 10));
@@ -376,10 +325,7 @@ public class QueryDslJpaRepositoryTests {
 		assertThat(secondPage.getTotalElements(), is(3L));
 	}
 
-	/**
-	 * @see DATAJPA-912
-	 */
-	@Test
+	@Test // DATAJPA-912
 	public void pageableQueryReportsTotalFromCount() {
 
 		Page<User> firstPage = repository.findAll(user.dateOfBirth.isNull(), new PageRequest(0, 3));

--- a/src/test/java/org/springframework/data/jpa/repository/support/QueryDslRepositorySupportIntegrationTests.java
+++ b/src/test/java/org/springframework/data/jpa/repository/support/QueryDslRepositorySupportIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2013 the original author or authors.
+ * Copyright 2011-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -91,10 +91,7 @@ public class QueryDslRepositorySupportIntegrationTests {
 		assertThat(repository, is(notNullValue()));
 	}
 
-	/**
-	 * @see DATAJPA-135
-	 */
-	@Test
+	@Test // DATAJPA-135
 	public void createsReconfiguredRepoAccordingly() {
 
 		assertThat(reconfiguredRepo, is(notNullValue()));

--- a/src/test/java/org/springframework/data/jpa/repository/support/QuerydslIntegrationTests.java
+++ b/src/test/java/org/springframework/data/jpa/repository/support/QuerydslIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Copyright 2014-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -57,10 +57,7 @@ public class QuerydslIntegrationTests {
 		userQuery = querydsl.createQuery().select(userPath);
 	}
 
-	/**
-	 * @see DATAJPA-499
-	 */
-	@Test
+	@Test // DATAJPA-499
 	public void defaultOrderingShouldNotGenerateAnNullOrderingHint() {
 
 		JPQLQuery<User> result = querydsl.applySorting(new Sort(new Sort.Order("firstname")), userQuery);

--- a/src/test/java/org/springframework/data/jpa/repository/support/SimpleJpaRepositoryUnitTests.java
+++ b/src/test/java/org/springframework/data/jpa/repository/support/SimpleJpaRepositoryUnitTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2016 the original author or authors.
+ * Copyright 2011-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -79,11 +79,7 @@ public class SimpleJpaRepositoryUnitTests {
 		repo.setRepositoryMethodMetadata(metadata);
 	}
 
-	/**
-	 * @see DATAJPA-124
-	 * @see DATAJPA-912
-	 */
-	@Test
+	@Test // DATAJPA-124, DATAJPA-912
 	public void retrieveObjectsForPageableOutOfRange() {
 
 		when(countQuery.getSingleResult()).thenReturn(20L);
@@ -92,10 +88,7 @@ public class SimpleJpaRepositoryUnitTests {
 		verify(query).getResultList();
 	}
 
-	/**
-	 * @see DATAJPA-912
-	 */
-	@Test
+	@Test // DATAJPA-912
 	public void doesNotRetrieveCountWithoutOffsetAndResultsWithinPageSize() {
 
 		when(query.getResultList()).thenReturn(Arrays.asList(new User(), new User()));
@@ -105,10 +98,7 @@ public class SimpleJpaRepositoryUnitTests {
 		verify(countQuery, never()).getSingleResult();
 	}
 
-	/**
-	 * @see DATAJPA-912
-	 */
-	@Test
+	@Test // DATAJPA-912
 	public void doesNotRetrieveCountWithOffsetAndResultsWithinPageSize() {
 
 		when(query.getResultList()).thenReturn(Arrays.asList(new User(), new User()));
@@ -118,20 +108,13 @@ public class SimpleJpaRepositoryUnitTests {
 		verify(countQuery, never()).getSingleResult();
 	}
 
-	/**
-	 * @see DATAJPA-177
-	 */
-	@Test(expected = EmptyResultDataAccessException.class)
+	@Test(expected = EmptyResultDataAccessException.class) // DATAJPA-177
 	public void throwsExceptionIfEntityToDeleteDoesNotExist() {
 
 		repo.delete(4711);
 	}
 
-	/**
-	 * @see DATAJPA-689
-	 * @see DATAJPA-696
-	 */
-	@Test
+	@Test // DATAJPA-689, DATAJPA-696
 	@SuppressWarnings({ "rawtypes", "unchecked" })
 	public void shouldPropagateConfiguredEntityGraphToFindOne() throws Exception {
 

--- a/src/test/java/org/springframework/data/jpa/repository/support/TransactionalRepositoryTests.java
+++ b/src/test/java/org/springframework/data/jpa/repository/support/TransactionalRepositoryTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2008-2015 the original author or authors.
+ * Copyright 2008-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -82,10 +82,7 @@ public class TransactionalRepositoryTests extends AbstractJUnit4SpringContextTes
 		assertFalse(transactionManager.getDefinition().isReadOnly());
 	}
 
-	/**
-	 * @see DATACMNS-649
-	 */
-	@Test
+	@Test // DATACMNS-649
 	public void invokeRedeclaredDeleteMethodWithoutTransactionDeclaration() throws Exception {
 
 		User user = repository.saveAndFlush(new User("foo", "bar", "foo@bar.de"));

--- a/src/test/java/org/springframework/data/jpa/support/ClasspathScanningPersistenceUnitPostProcessorUnitTests.java
+++ b/src/test/java/org/springframework/data/jpa/support/ClasspathScanningPersistenceUnitPostProcessorUnitTests.java
@@ -18,6 +18,7 @@ package org.springframework.data.jpa.support;
 import static org.mockito.Mockito.*;
 
 import java.io.IOException;
+import java.net.URL;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Set;
@@ -138,15 +139,19 @@ public class ClasspathScanningPersistenceUnitPostProcessorUnitTests {
 				return resources;
 			}
 
+			/* 
+			 * (non-Javadoc)
+			 * @see org.springframework.core.io.support.PathMatchingResourcePatternResolver#doFindPathMatchingJarResources(org.springframework.core.io.Resource, java.net.URL, java.lang.String)
+			 */
 			@Override
-			protected Set<Resource> doFindPathMatchingJarResources(Resource rootDirResource, String subPattern)
-					throws IOException {
+			protected Set<Resource> doFindPathMatchingJarResources(Resource rootDirResource, URL rootDirURL,
+					String subPattern) throws IOException {
 
-				if (fileInJarUrl.equals(rootDirResource.getURI().toString())) {
+				if (fileInJarUrl.equals(rootDirURL.toString())) {
 					return Collections.singleton(rootDirResource);
 				}
 
-				return super.doFindPathMatchingJarResources(rootDirResource, subPattern);
+				return super.doFindPathMatchingJarResources(rootDirResource, rootDirURL, subPattern);
 			}
 		};
 

--- a/src/test/java/org/springframework/data/jpa/support/ClasspathScanningPersistenceUnitPostProcessorUnitTests.java
+++ b/src/test/java/org/springframework/data/jpa/support/ClasspathScanningPersistenceUnitPostProcessorUnitTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2014 the original author or authors.
+ * Copyright 2011-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -83,10 +83,7 @@ public class ClasspathScanningPersistenceUnitPostProcessorUnitTests {
 		verify(pui).addManagedClassName(SampleEntity.class.getName());
 	}
 
-	/**
-	 * @see DATAJPA-407
-	 */
-	@Test
+	@Test // DATAJPA-407
 	public void findsMappingFile() {
 
 		ClasspathScanningPersistenceUnitPostProcessor processor = new ClasspathScanningPersistenceUnitPostProcessor(
@@ -101,11 +98,7 @@ public class ClasspathScanningPersistenceUnitPostProcessorUnitTests {
 		verify(pui).addMappingFileName(expected);
 	}
 
-	/**
-	 * @see DATAJPA-353
-	 * @see DATAJPA-407
-	 */
-	@Test
+	@Test // DATAJPA-353, DATAJPA-407
 	public void shouldFindJpaMappingFilesFromMultipleLocationsOnClasspath() {
 
 		ClasspathScanningPersistenceUnitPostProcessor processor = new ClasspathScanningPersistenceUnitPostProcessor(
@@ -119,10 +112,7 @@ public class ClasspathScanningPersistenceUnitPostProcessorUnitTests {
 		verify(pui).addMappingFileName("org/springframework/data/jpa/support/module2/module2-orm.xml");
 	}
 
-	/**
-	 * @see DATAJPA-519
-	 */
-	@Test
+	@Test // DATAJPA-519
 	public void shouldFindJpaMappingFilesFromNestedJarLocationsOnClasspath() {
 
 		String nestedModule3Path = "org/springframework/data/jpa/support/module3/module3-orm.xml";

--- a/src/test/resources/META-INF/persistence.xml
+++ b/src/test/resources/META-INF/persistence.xml
@@ -71,7 +71,26 @@
 			<property name="hibernate.hbm2ddl.auto" value="update" />
 		</properties>
 	</persistence-unit>
-	
+
+	<persistence-unit name="cdi-52">
+		<provider>org.hibernate.jpa.HibernatePersistenceProvider</provider>
+		<class>org.springframework.data.jpa.domain.sample.MailMessage</class>
+		<class>org.springframework.data.jpa.domain.sample.MailSender</class>
+		<class>org.springframework.data.jpa.domain.sample.MailUser</class>
+		<class>org.springframework.data.jpa.domain.sample.User</class>
+		<class>org.springframework.data.jpa.repository.cdi.Person</class>
+		<class>org.springframework.data.jpa.domain.sample.Dummy</class>
+		<exclude-unlisted-classes>true</exclude-unlisted-classes>
+		<properties>
+			<property name="hibernate.connection.username" value="sa" />
+			<property name="hibernate.connection.driver_class" value="org.hsqldb.jdbcDriver" />
+			<property name="hibernate.connection.password" value="" />
+			<property name="hibernate.connection.url" value="jdbc:hsqldb:mem:cdi" />
+			<property name="hibernate.dialect" value="org.hibernate.dialect.HSQLDialect" />
+			<property name="hibernate.hbm2ddl.auto" value="update" />
+		</properties>
+	</persistence-unit>
+
 	<!-- DATAJPA-476 -->
 	<persistence-unit name="merchant">
 		<class>org.springframework.data.jpa.domain.sample.User</class>
@@ -88,6 +107,19 @@
 	
 	<persistence-unit name="metadata">
 		<provider>org.hibernate.ejb.HibernatePersistence</provider>
+		<class>org.springframework.data.jpa.domain.sample.CustomAbstractPersistable</class>
+		<class>org.springframework.data.jpa.domain.sample.MailMessage</class>
+		<class>org.springframework.data.jpa.domain.sample.MailSender</class>
+		<class>org.springframework.data.jpa.domain.sample.MailUser</class>
+		<class>org.springframework.data.jpa.domain.sample.User</class>
+		<class>org.springframework.data.jpa.repository.support.JpaMetamodelEntityInformationIntegrationTests$Sample</class>
+		<exclude-unlisted-classes>true</exclude-unlisted-classes>
+		<properties>
+			<property name="hibernate.dialect" value="org.hibernate.dialect.HSQLDialect" />
+		</properties>
+	</persistence-unit>
+	<persistence-unit name="metadata-52">
+		<provider>org.hibernate.jpa.HibernatePersistenceProvider</provider>
 		<class>org.springframework.data.jpa.domain.sample.CustomAbstractPersistable</class>
 		<class>org.springframework.data.jpa.domain.sample.MailMessage</class>
 		<class>org.springframework.data.jpa.domain.sample.MailSender</class>

--- a/src/test/resources/application-context.xml
+++ b/src/test/resources/application-context.xml
@@ -10,7 +10,7 @@
 
 	<!-- Configure a DAO for User class -->
 	<bean id="userDao" class="org.springframework.data.jpa.repository.support.JpaRepositoryFactoryBean">
-		<property name="repositoryInterface" value="org.springframework.data.jpa.repository.sample.UserRepository" />
+		<constructor-arg value="org.springframework.data.jpa.repository.sample.UserRepository" />
 		<property name="customImplementation">
 			<bean class="org.springframework.data.jpa.repository.sample.UserRepositoryImpl">
 				<constructor-arg>
@@ -25,12 +25,11 @@
 				</constructor-arg>
 			</bean>
 		</property>
-		
 		<property name="evaluationContextProvider" ref="expressionEvaluationContextProvider"/>
 	</bean>
 	
 	<bean id="roleDao" class="org.springframework.data.jpa.repository.support.JpaRepositoryFactoryBean">
-		<property name="repositoryInterface" value="org.springframework.data.jpa.repository.sample.RoleRepository" />
+		<constructor-arg value="org.springframework.data.jpa.repository.sample.RoleRepository" />
 		<property name="evaluationContextProvider" ref="expressionEvaluationContextProvider"/>
 	</bean>
 


### PR DESCRIPTION
Renamed collection arguments name of example code in the reference documentation.
One was plural but another was singular.

<!--

Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
Make sure that:

-->

- [ v ] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [ v ] There is a ticket in the bug tracker for the project in our [JIRA](https://jira.spring.io/browse/DATAJPA).
- [ v ] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [ v ] You submit test cases (unit or integration tests) that back your changes.
- [ v ] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).

