### PR TITLE
DATAJPA-1087 (1.x) - Apply query hints to count queries for Querydsl but leave out fetch graphs.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-jpa</artifactId>
-	<version>1.10.9.BUILD-SNAPSHOT</version>
+	<version>1.10.9.DATAJPA-1087-SNAPSHOT</version>
 
 	<name>Spring Data JPA</name>
 	<description>Spring Data module for JPA repositories.</description>

--- a/src/main/java/org/springframework/data/jpa/repository/support/QueryDslJpaRepository.java
+++ b/src/main/java/org/springframework/data/jpa/repository/support/QueryDslJpaRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2008-2015 the original author or authors.
+ * Copyright 2008-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -46,6 +46,7 @@ import com.querydsl.jpa.impl.AbstractJPAQuery;
  * @author Oliver Gierke
  * @author Thomas Darimont
  * @author Jocelyn Ntakpe
+ * @author Christoph Strobl
  */
 public class QueryDslJpaRepository<T, ID extends Serializable> extends SimpleJpaRepository<T, ID>
 		implements QueryDslPredicateExecutor<T> {
@@ -196,7 +197,18 @@ public class QueryDslJpaRepository<T, ID extends Serializable> extends SimpleJpa
 	 * @return the Querydsl count {@link JPQLQuery}.
 	 */
 	protected JPQLQuery<?> createCountQuery(Predicate predicate) {
-		return querydsl.createQuery(path).where(predicate);
+		AbstractJPAQuery<?, ?> query = querydsl.createQuery(path).where(predicate);
+
+		CrudMethodMetadata metadata = getRepositoryMethodMetadata();
+		if (metadata == null) {
+			return query;
+		}
+
+		for (Entry<String, Object> hint : metadata.getQueryHints().entrySet()) {
+			query.setHint(hint.getKey(), hint.getValue());
+		}
+
+		return query;
 	}
 
 	/**

--- a/src/test/java/org/springframework/data/jpa/repository/EntityGraphRepositoryMethodsIntegrationTests.java
+++ b/src/test/java/org/springframework/data/jpa/repository/EntityGraphRepositoryMethodsIntegrationTests.java
@@ -154,7 +154,7 @@ public class EntityGraphRepositoryMethodsIntegrationTests {
 	}
 
 	/**
-	 * @see DATAJPA-790
+	 * @see DATAJPA-790, DATAJPA-1087
 	 */
 	@Test
 	public void shouldRespectConfiguredJpaEntityGraphWithPaginationAndQueryDslPredicates() {


### PR DESCRIPTION
We now make sure to apply query hints also to count queries created via Querydsl ``Predicate``s but avoid applying potential fetch graphs. 

Please note that for the `1.x` line we’ll preserve binary comparability while for `2.x` we’ll change the signature of `SimpleJpaRepository.getQueryHints` (see #196).

---
Should be forward ported to `1.11.x` and `1.12.x`.