### PR TITLE
DATAJPA-1087 (2.x) - Apply query hints to count queries for Querydsl but leave out fetch graphs.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-jpa</artifactId>
-	<version>2.0.0.BUILD-SNAPSHOT</version>
+	<version>2.0.0.DATAJPA-1087-SNAPSHOT</version>
 
 	<name>Spring Data JPA</name>
 	<description>Spring Data module for JPA repositories.</description>

--- a/src/main/java/org/springframework/data/jpa/repository/support/CrudMethodMetadata.java
+++ b/src/main/java/org/springframework/data/jpa/repository/support/CrudMethodMetadata.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2015 the original author or authors.
+ * Copyright 2011-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@ package org.springframework.data.jpa.repository.support;
 
 import java.lang.reflect.Method;
 import java.util.Map;
+import java.util.Optional;
 
 import javax.persistence.LockModeType;
 
@@ -28,6 +29,7 @@ import org.springframework.data.jpa.repository.EntityGraph;
  * 
  * @author Oliver Gierke
  * @author Thomas Darimont
+ * @author Christoph Strobl
  */
 public interface CrudMethodMetadata {
 
@@ -51,7 +53,7 @@ public interface CrudMethodMetadata {
 	 * @return
 	 * @since 1.9
 	 */
-	EntityGraph getEntityGraph();
+	Optional<EntityGraph> getEntityGraph();
 
 	/**
 	 * Returns the {@link Method} to be used.

--- a/src/main/java/org/springframework/data/jpa/repository/support/CrudMethodMetadataPostProcessor.java
+++ b/src/main/java/org/springframework/data/jpa/repository/support/CrudMethodMetadataPostProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2016 the original author or authors.
+ * Copyright 2011-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@ import java.lang.reflect.Method;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
@@ -147,7 +148,7 @@ class CrudMethodMetadataPostProcessor implements RepositoryProxyPostProcessor, B
 
 		private final LockModeType lockModeType;
 		private final Map<String, Object> queryHints;
-		private final EntityGraph entityGraph;
+		private final Optional<EntityGraph> entityGraph;
 		private final Method method;
 
 		/**
@@ -161,7 +162,7 @@ class CrudMethodMetadataPostProcessor implements RepositoryProxyPostProcessor, B
 
 			this.lockModeType = findLockModeType(method);
 			this.queryHints = findQueryHints(method);
-			this.entityGraph = findEntityGraph(method);
+			this.entityGraph = Optional.ofNullable(findEntityGraph(method));
 			this.method = method;
 		}
 
@@ -219,7 +220,7 @@ class CrudMethodMetadataPostProcessor implements RepositoryProxyPostProcessor, B
 		 * @see org.springframework.data.jpa.repository.support.CrudMethodMetadata#getEntityGraph()
 		 */
 		@Override
-		public EntityGraph getEntityGraph() {
+		public Optional<EntityGraph> getEntityGraph() {
 			return entityGraph;
 		}
 

--- a/src/main/java/org/springframework/data/jpa/repository/support/QuerydslJpaRepository.java
+++ b/src/main/java/org/springframework/data/jpa/repository/support/QuerydslJpaRepository.java
@@ -179,7 +179,8 @@ public class QuerydslJpaRepository<T, ID extends Serializable> extends SimpleJpa
 	 */
 	protected JPQLQuery<?> createQuery(Predicate... predicate) {
 
-		AbstractJPAQuery<?, ?> query = querydsl.createQuery(path).where(predicate);
+		AbstractJPAQuery<?, ?> query = doCreateQuery(getQueryHints().withFetchGraphs(), predicate);
+
 		CrudMethodMetadata metadata = getRepositoryMethodMetadata();
 
 		if (metadata == null) {
@@ -187,13 +188,7 @@ public class QuerydslJpaRepository<T, ID extends Serializable> extends SimpleJpa
 		}
 
 		LockModeType type = metadata.getLockModeType();
-		query = type == null ? query : query.setLockMode(type);
-
-		for (Entry<String, Object> hint : getQueryHints().entrySet()) {
-			query.setHint(hint.getKey(), hint.getValue());
-		}
-
-		return query;
+		return type == null ? query : query.setLockMode(type);
 	}
 
 	/**
@@ -202,8 +197,19 @@ public class QuerydslJpaRepository<T, ID extends Serializable> extends SimpleJpa
 	 * @param predicate, can be {@literal null}.
 	 * @return the Querydsl count {@link JPQLQuery}.
 	 */
-	protected JPQLQuery<?> createCountQuery(Predicate predicate) {
-		return querydsl.createQuery(path).where(predicate);
+	protected JPQLQuery<?> createCountQuery(Predicate... predicate) {
+		return doCreateQuery(getQueryHints(), predicate);
+	}
+
+	private AbstractJPAQuery<?, ?> doCreateQuery(QueryHints hints, Predicate... predicate) {
+
+		AbstractJPAQuery<?, ?> query = querydsl.createQuery(path).where(predicate);
+
+		for (Entry<String, Object> hint : hints) {
+			query.setHint(hint.getKey(), hint.getValue());
+		}
+
+		return query;
 	}
 
 	/**

--- a/src/test/java/org/springframework/data/jpa/repository/EntityGraphRepositoryMethodsIntegrationTests.java
+++ b/src/test/java/org/springframework/data/jpa/repository/EntityGraphRepositoryMethodsIntegrationTests.java
@@ -141,7 +141,7 @@ public class EntityGraphRepositoryMethodsIntegrationTests {
 		}
 	}
 
-	@Test // DATAJPA-790
+	@Test // DATAJPA-790, DATAJPA-1087
 	public void shouldRespectConfiguredJpaEntityGraphWithPaginationAndQueryDslPredicates() {
 
 		Assume.assumeTrue(currentEntityManagerIsAJpa21EntityManager(em));

--- a/src/test/java/org/springframework/data/jpa/repository/support/SimpleJpaRepositoryUnitTests.java
+++ b/src/test/java/org/springframework/data/jpa/repository/support/SimpleJpaRepositoryUnitTests.java
@@ -20,6 +20,7 @@ import static org.mockito.Mockito.*;
 
 import java.io.Serializable;
 import java.util.Arrays;
+import java.util.Optional;
 
 import javax.persistence.EntityGraph;
 import javax.persistence.EntityManager;
@@ -121,7 +122,7 @@ public class SimpleJpaRepositoryUnitTests {
 		String entityGraphName = "User.detail";
 		when(entityGraphAnnotation.value()).thenReturn(entityGraphName);
 		when(entityGraphAnnotation.type()).thenReturn(EntityGraphType.LOAD);
-		when(metadata.getEntityGraph()).thenReturn(entityGraphAnnotation);
+		when(metadata.getEntityGraph()).thenReturn(Optional.of(entityGraphAnnotation));
 		when(em.getEntityGraph(entityGraphName)).thenReturn((EntityGraph) entityGraph);
 		when(information.getEntityName()).thenReturn("User");
 		when(metadata.getMethod()).thenReturn(CrudRepository.class.getMethod("findOne", Serializable.class));


### PR DESCRIPTION
We now make sure to apply query hints also to count queries created via Querydsl Predicates but avoid applying potential fetch graphs.

This change alters return types of `CrudMethodMetadata#getEntityGraph()` and `SimpleJpaRepsoitory.getQueryHints()`.