### PR TITLE
DATAJPA-1098 - javadoc update.

### DIFF
--- a/src/main/java/org/springframework/data/jpa/domain/Specification.java
+++ b/src/main/java/org/springframework/data/jpa/domain/Specification.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2008-2014 the original author or authors.
+ * Copyright 2008-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,6 +25,7 @@ import javax.persistence.criteria.Root;
  * 
  * @author Oliver Gierke
  * @author Thomas Darimont
+ * @author Krzysztof Rzymkowski
  */
 public interface Specification<T> {
 
@@ -34,7 +35,7 @@ public interface Specification<T> {
 	 * 
 	 * @param root
 	 * @param query
-	 * @return a {@link Predicate}, must not be {@literal null}.
+	 * @return a {@link Predicate}, may be {@literal null}.
 	 */
 	Predicate toPredicate(Root<T> root, CriteriaQuery<?> query, CriteriaBuilder cb);
 }


### PR DESCRIPTION
Change javadoc of `Specification.toPredicate()`.
The javadoc was misleading. The method may return null as described in https://jira.spring.io/browse/DATAJPA-300

<!--

Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
Make sure that:

-->

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] There is a ticket in the bug tracker for the project in our [JIRA](https://jira.spring.io/browse/DATAJPA).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [ ] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).

