### PR TITLE
DATAJPA-1099 Fix Travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,9 @@ cache:
   directories:
     - $HOME/.m2
 
+before_install:
+  - rm ~/.m2/settings.xml
+
 install: true
 
 script: "mvn clean dependency:list test -P${PROFILE} -Dsort -Dbundlor.enabled=false -B"

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ cache:
     - $HOME/.m2
 
 before_install:
-  - rm ~/.m2/settings.xml
+  - test ! -f ~/.m2/settings.xml || rm ~/.m2/settings.xml
 
 install: true
 

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 
 		<dist.key>DATAJPA</dist.key>
 
-		<eclipselink>2.6.2</eclipselink>
+		<eclipselink>2.6.4</eclipselink>
 		<hibernate>5.2.9.Final</hibernate>
 		<hsqldb1>1.8.0.10</hsqldb1>
 		<jpa>2.0.0</jpa>
@@ -48,7 +48,7 @@
 		<profile>
 			<id>eclipselink-next</id>
 			<properties>
-				<eclipselink>2.6.3-SNAPSHOT</eclipselink>
+				<eclipselink>2.6.5-SNAPSHOT</eclipselink>
 			</properties>
 			<repositories>
 				<repository>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-jpa</artifactId>
-	<version>2.0.0.BUILD-SNAPSHOT</version>
+	<version>2.0.0.DATAJPA-1099-SNAPSHOT</version>
 
 	<name>Spring Data JPA</name>
 	<description>Spring Data module for JPA repositories.</description>


### PR DESCRIPTION
Travis builds seemed to be failing due to a broken reference to codehaus.org but the actual reason was a missing snapshot dependency.

Fixed both issues by deleting Travis' settings.xml and upgrading the snapshot dependency. 