### PR TITLE
DATAJPA-1115 - Adapt to QuerydslPredicateExecutor API changes.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-jpa</artifactId>
-	<version>2.0.0.BUILD-SNAPSHOT</version>
+	<version>2.0.0.DATAJPA-1115-SNAPSHOT</version>
 
 	<name>Spring Data JPA</name>
 	<description>Spring Data module for JPA repositories.</description>
@@ -26,7 +26,7 @@
 		<hsqldb1>1.8.0.10</hsqldb1>
 		<jpa>2.0.0</jpa>
 		<openjpa>2.4.1</openjpa>
-		<springdata.commons>2.0.0.BUILD-SNAPSHOT</springdata.commons>
+		<springdata.commons>2.0.0.DATACMNS-1059-SNAPSHOT</springdata.commons>
 
 		<sonar.dynamicAnalysis>reuseReports</sonar.dynamicAnalysis>
 

--- a/src/main/java/org/springframework/data/jpa/repository/support/QuerydslJpaRepository.java
+++ b/src/main/java/org/springframework/data/jpa/repository/support/QuerydslJpaRepository.java
@@ -23,7 +23,6 @@ import java.util.Optional;
 import javax.persistence.EntityManager;
 import javax.persistence.LockModeType;
 
-import com.querydsl.core.NonUniqueResultException;
 import org.springframework.dao.IncorrectResultSizeDataAccessException;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -35,6 +34,7 @@ import org.springframework.data.querydsl.SimpleEntityPathResolver;
 import org.springframework.data.repository.support.PageableExecutionUtils;
 import org.springframework.util.Assert;
 
+import com.querydsl.core.NonUniqueResultException;
 import com.querydsl.core.types.EntityPath;
 import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.Predicate;
@@ -45,7 +45,7 @@ import com.querydsl.jpa.impl.AbstractJPAQuery;
 /**
  * QueryDsl specific extension of {@link SimpleJpaRepository} which adds implementation for
  * {@link QuerydslPredicateExecutor}.
- * 
+ *
  * @author Oliver Gierke
  * @author Thomas Darimont
  * @author Mark Paluch
@@ -65,7 +65,7 @@ public class QuerydslJpaRepository<T, ID extends Serializable> extends SimpleJpa
 	/**
 	 * Creates a new {@link QuerydslJpaRepository} from the given domain class and {@link EntityManager}. This will use
 	 * the {@link SimpleEntityPathResolver} to translate the given domain class into an {@link EntityPath}.
-	 * 
+	 *
 	 * @param entityInformation must not be {@literal null}.
 	 * @param entityManager must not be {@literal null}.
 	 */
@@ -76,7 +76,7 @@ public class QuerydslJpaRepository<T, ID extends Serializable> extends SimpleJpa
 	/**
 	 * Creates a new {@link QuerydslJpaRepository} from the given domain class and {@link EntityManager} and uses the
 	 * given {@link EntityPathResolver} to translate the domain class into an {@link EntityPath}.
-	 * 
+	 *
 	 * @param entityInformation must not be {@literal null}.
 	 * @param entityManager must not be {@literal null}.
 	 * @param resolver must not be {@literal null}.
@@ -183,7 +183,7 @@ public class QuerydslJpaRepository<T, ID extends Serializable> extends SimpleJpa
 
 	/**
 	 * Creates a new {@link JPQLQuery} for the given {@link Predicate}.
-	 * 
+	 *
 	 * @param predicate
 	 * @return the Querydsl {@link JPQLQuery}.
 	 */
@@ -224,7 +224,7 @@ public class QuerydslJpaRepository<T, ID extends Serializable> extends SimpleJpa
 
 	/**
 	 * Executes the given {@link JPQLQuery} after applying the given {@link OrderSpecifier}s.
-	 * 
+	 *
 	 * @param query must not be {@literal null}.
 	 * @param orders must not be {@literal null}.
 	 * @return
@@ -235,7 +235,7 @@ public class QuerydslJpaRepository<T, ID extends Serializable> extends SimpleJpa
 
 	/**
 	 * Executes the given {@link JPQLQuery} after applying the given {@link Sort}.
-	 * 
+	 *
 	 * @param query must not be {@literal null}.
 	 * @param sort must not be {@literal null}.
 	 * @return

--- a/src/main/java/org/springframework/data/jpa/repository/support/QuerydslJpaRepository.java
+++ b/src/main/java/org/springframework/data/jpa/repository/support/QuerydslJpaRepository.java
@@ -18,10 +18,13 @@ package org.springframework.data.jpa.repository.support;
 import java.io.Serializable;
 import java.util.List;
 import java.util.Map.Entry;
+import java.util.Optional;
 
 import javax.persistence.EntityManager;
 import javax.persistence.LockModeType;
 
+import com.querydsl.core.NonUniqueResultException;
+import org.springframework.dao.IncorrectResultSizeDataAccessException;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
@@ -94,8 +97,13 @@ public class QuerydslJpaRepository<T, ID extends Serializable> extends SimpleJpa
 	 * @see org.springframework.data.querydsl.QuerydslPredicateExecutor#findOne(com.mysema.query.types.Predicate)
 	 */
 	@Override
-	public T findOne(Predicate predicate) {
-		return createQuery(predicate).select(path).fetchOne();
+	public Optional<T> findOne(Predicate predicate) {
+
+		try {
+			return Optional.ofNullable(createQuery(predicate).select(path).fetchOne());
+		} catch (NonUniqueResultException ex) {
+			throw new IncorrectResultSizeDataAccessException(ex.getMessage(), 1, ex);
+		}
 	}
 
 	/*

--- a/src/test/java/org/springframework/data/jpa/repository/sample/RoleRepository.java
+++ b/src/test/java/org/springframework/data/jpa/repository/sample/RoleRepository.java
@@ -59,7 +59,7 @@ public interface RoleRepository extends CrudRepository<Role, Integer>, QuerydslP
 	@Override
 	@Lock(LockModeType.READ)
 	@QueryHints(@QueryHint(name = "foo", value = "bar"))
-	Role findOne(Predicate predicate);
+	Optional<Role> findOne(Predicate predicate);
 
 	// DATAJPA-509
 	long countByName(String name);

--- a/src/test/java/org/springframework/data/jpa/repository/support/QuerydslJpaRepositoryTests.java
+++ b/src/test/java/org/springframework/data/jpa/repository/support/QuerydslJpaRepositoryTests.java
@@ -15,15 +15,13 @@
  */
 package org.springframework.data.jpa.repository.support;
 
-import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.*;
+import static org.assertj.core.api.Assertions.*;
 
 import java.util.List;
 
 import javax.persistence.EntityManager;
 import javax.persistence.PersistenceContext;
 
-import org.assertj.core.api.Assertions;
 import org.joda.time.LocalDate;
 import org.junit.Before;
 import org.junit.Test;
@@ -52,7 +50,7 @@ import com.querydsl.core.types.dsl.PathBuilderFactory;
 
 /**
  * Integration test for {@link QuerydslJpaRepository}.
- * 
+ *
  * @author Oliver Gierke
  * @author Thomas Darimont
  * @author Mark Paluch
@@ -91,8 +89,7 @@ public class QuerydslJpaRepositoryTests {
 
 		List<User> result = repository.findAll(isCalledDave.or(isBeauford));
 
-		assertThat(result.size(), is(2));
-		assertThat(result, hasItems(carter, dave));
+		assertThat(result).containsExactlyInAnyOrder(carter, dave);
 	}
 
 	@Test
@@ -105,8 +102,7 @@ public class QuerydslJpaRepositoryTests {
 
 		List<User> result = repository.findAll(isCalledDave.or(isBeauford));
 
-		assertThat(result.size(), is(2));
-		assertThat(result, hasItems(carter, dave));
+		assertThat(result).containsExactlyInAnyOrder(carter, dave);
 	}
 
 	@Test // DATAJPA-243
@@ -116,14 +112,11 @@ public class QuerydslJpaRepositoryTests {
 
 		Page<User> result = repository.findAll(lastnameContainsE, PageRequest.of(0, 1, Direction.ASC, "lastname"));
 
-		assertThat(result.getContent(), hasSize(1));
-		assertThat(result.getContent().get(0), is(carter));
+		assertThat(result).containsExactly(carter);
 
 		result = repository.findAll(lastnameContainsE, PageRequest.of(0, 2, Direction.DESC, "lastname"));
 
-		assertThat(result.getContent(), hasSize(2));
-		assertThat(result.getContent().get(0), is(oliver));
-		assertThat(result.getContent().get(1), is(dave));
+		assertThat(result).containsExactly(oliver, dave);
 	}
 
 	@Test // DATAJPA-296
@@ -133,9 +126,7 @@ public class QuerydslJpaRepositoryTests {
 
 		Page<User> result = repository.findAll(user.lastname.contains("e"), PageRequest.of(0, 2, sort));
 
-		assertThat(result.getContent(), hasSize(2));
-		assertThat(result.getContent().get(0), is(dave));
-		assertThat(result.getContent().get(1), is(oliver));
+		assertThat(result.getContent()).containsExactly(dave, oliver);
 	}
 
 	@Test // DATAJPA-427
@@ -149,8 +140,7 @@ public class QuerydslJpaRepositoryTests {
 		Page<User> page = repository.findAll(user.firstname.isNotNull(),
 				PageRequest.of(0, 10, Sort.by(Sort.Direction.ASC, "colleagues.firstname")));
 
-		assertThat(page.getContent(), hasSize(3));
-		assertThat(page.getContent(), hasItems(oliver, dave, carter));
+		assertThat(page.getContent()).hasSize(3).contains(oliver, dave, carter);
 	}
 
 	@Test // DATAJPA-427
@@ -164,8 +154,7 @@ public class QuerydslJpaRepositoryTests {
 		Page<User> page = repository.findAll(user.firstname.isNotNull(),
 				PageRequest.of(0, 10, Sort.by(Sort.Direction.ASC, "manager.firstname")));
 
-		assertThat(page.getContent(), hasSize(3));
-		assertThat(page.getContent(), hasItems(dave, oliver, carter));
+		assertThat(page.getContent()).hasSize(3).contains(dave, oliver, carter);
 	}
 
 	@Test // DATAJPA-427
@@ -176,8 +165,7 @@ public class QuerydslJpaRepositoryTests {
 		Page<User> page = repository.findAll(user.firstname.isNotNull(),
 				PageRequest.of(0, 10, Sort.by(Sort.Direction.ASC, "firstname")));
 
-		assertThat(page.getContent(), hasSize(3));
-		assertThat(page.getContent(), hasItems(carter, dave, oliver));
+		assertThat(page.getContent()).containsExactly(carter, dave, oliver);
 	}
 
 	@Test // DATAJPA-427
@@ -188,8 +176,7 @@ public class QuerydslJpaRepositoryTests {
 		Page<User> page = repository.findAll(user.firstname.isNotNull(),
 				PageRequest.of(0, 10, Sort.by(new Order(Sort.Direction.ASC, "firstname").ignoreCase())));
 
-		assertThat(page.getContent(), hasSize(3));
-		assertThat(page.getContent(), hasItems(carter, dave, oliver));
+		assertThat(page.getContent()).containsExactly(carter, dave, oliver);
 	}
 
 	@Test // DATAJPA-427
@@ -202,9 +189,7 @@ public class QuerydslJpaRepositoryTests {
 		Page<User> page = repository.findAll(user.firstname.isNotNull(),
 				PageRequest.of(0, 10, Sort.by(Sort.Direction.ASC, "address.streetName")));
 
-		assertThat(page.getContent(), hasSize(3));
-		assertThat(page.getContent(), hasItems(dave, carter, oliver));
-		assertThat(page.getContent().get(2), is(oliver));
+		assertThat(page.getContent()).containsExactly(dave, carter, oliver);
 	}
 
 	@Test // DATAJPA-12
@@ -215,11 +200,7 @@ public class QuerydslJpaRepositoryTests {
 		Page<User> page = repository.findAll(user.firstname.isNotNull(),
 				new QPageRequest(0, 10, new QSort(user.firstname.asc())));
 
-		assertThat(page.getContent(), hasSize(3));
-		assertThat(page.getContent(), hasItems(carter, dave, oliver));
-		assertThat(page.getContent().get(0), is(carter));
-		assertThat(page.getContent().get(1), is(dave));
-		assertThat(page.getContent().get(2), is(oliver));
+		assertThat(page.getContent()).containsExactly(carter, dave, oliver);
 	}
 
 	@Test // DATAJPA-12
@@ -229,11 +210,7 @@ public class QuerydslJpaRepositoryTests {
 
 		Page<User> page = repository.findAll(user.firstname.isNotNull(), new QPageRequest(0, 10, user.firstname.asc()));
 
-		assertThat(page.getContent(), hasSize(3));
-		assertThat(page.getContent(), hasItems(carter, dave, oliver));
-		assertThat(page.getContent().get(0), is(carter));
-		assertThat(page.getContent().get(1), is(dave));
-		assertThat(page.getContent().get(2), is(oliver));
+		assertThat(page.getContent()).containsExactly(carter, dave, oliver);
 	}
 
 	@Test // DATAJPA-12
@@ -247,11 +224,7 @@ public class QuerydslJpaRepositoryTests {
 		Page<User> page = repository.findAll(user.firstname.isNotNull(),
 				new QPageRequest(0, 10, user.manager.firstname.asc()));
 
-		assertThat(page.getContent(), hasSize(3));
-		assertThat(page.getContent(), hasItems(carter, dave, oliver));
-		assertThat(page.getContent().get(0), is(carter));
-		assertThat(page.getContent().get(1), is(dave));
-		assertThat(page.getContent().get(2), is(oliver));
+		assertThat(page.getContent()).containsExactly(carter, dave, oliver);
 	}
 
 	@Test // DATAJPA-491
@@ -262,12 +235,12 @@ public class QuerydslJpaRepositoryTests {
 
 		Page<User> page = repository.findAll(PageRequest.of(0, 10, Sort.by(Direction.ASC, "manager.roles.name")));
 
-		assertThat(page.getContent(), hasSize(3));
-		assertThat(page.getContent().get(0), is(dave));
+		assertThat(page.getContent()).hasSize(3);
+		assertThat(page.getContent().get(0)).isEqualTo(dave);
 	}
 
 	@Test // DATAJPA-500, DATAJPA-635
-	public void sortByNestedEmbeddedAttribite() {
+	public void sortByNestedEmbeddedAttribute() {
 
 		carter.setAddress(new Address("U", "Z", "Y", "41"));
 		dave.setAddress(new Address("U", "A", "Y", "41"));
@@ -275,8 +248,7 @@ public class QuerydslJpaRepositoryTests {
 
 		List<User> users = repository.findAll(QUser.user.address.streetName.asc());
 
-		assertThat(users, hasSize(3));
-		assertThat(users, hasItems(dave, oliver, carter));
+		assertThat(users).hasSize(3).contains(dave, oliver, carter);
 	}
 
 	@Test // DATAJPA-566, DATAJPA-635
@@ -288,16 +260,15 @@ public class QuerydslJpaRepositoryTests {
 
 		List<User> users = repository.findAll(QUser.user.dateOfBirth.yearMonth().asc());
 
-		assertThat(users, hasSize(3));
-		assertThat(users, hasItems(dave, carter, oliver));
+		assertThat(users).containsExactly(dave, carter, oliver);
 	}
 
 	@Test // DATAJPA-665
 	public void shouldSupportExistsWithPredicate() throws Exception {
 
-		assertThat(repository.exists(user.firstname.eq("Dave")), is(true));
-		assertThat(repository.exists(user.firstname.eq("Unknown")), is(false));
-		assertThat(repository.exists((Predicate) null), is(true));
+		assertThat(repository.exists(user.firstname.eq("Dave"))).isEqualTo(true);
+		assertThat(repository.exists(user.firstname.eq("Unknown"))).isEqualTo(false);
+		assertThat(repository.exists((Predicate) null)).isEqualTo(true);
 	}
 
 	@Test // DATAJPA-679
@@ -305,49 +276,46 @@ public class QuerydslJpaRepositoryTests {
 
 		List<User> users = repository.findAll(user.dateOfBirth.isNull(), Sort.by(Direction.ASC, "firstname"));
 
-		assertThat(users, hasSize(3));
-		assertThat(users.get(0).getFirstname(), is(carter.getFirstname()));
-		assertThat(users.get(2).getFirstname(), is(oliver.getFirstname()));
-		assertThat(users, hasItems(carter, dave, oliver));
+		assertThat(users).contains(carter, dave, oliver);
 	}
 
 	@Test // DATAJPA-585
 	public void worksWithUnpagedPageable() {
-		assertThat(repository.findAll(user.dateOfBirth.isNull(), Pageable.unpaged()).getContent(), hasSize(3));
+		assertThat(repository.findAll(user.dateOfBirth.isNull(), Pageable.unpaged()).getContent()).hasSize(3);
 	}
 
 	@Test // DATAJPA-912
 	public void pageableQueryReportsTotalFromResult() {
 
 		Page<User> firstPage = repository.findAll(user.dateOfBirth.isNull(), PageRequest.of(0, 10));
-		assertThat(firstPage.getContent(), hasSize(3));
-		assertThat(firstPage.getTotalElements(), is(3L));
+		assertThat(firstPage.getContent()).hasSize(3);
+		assertThat(firstPage.getTotalElements()).isEqualTo(3L);
 
 		Page<User> secondPage = repository.findAll(user.dateOfBirth.isNull(), PageRequest.of(1, 2));
-		assertThat(secondPage.getContent(), hasSize(1));
-		assertThat(secondPage.getTotalElements(), is(3L));
+		assertThat(secondPage.getContent()).hasSize(1);
+		assertThat(secondPage.getTotalElements()).isEqualTo(3L);
 	}
 
 	@Test // DATAJPA-912
 	public void pageableQueryReportsTotalFromCount() {
 
 		Page<User> firstPage = repository.findAll(user.dateOfBirth.isNull(), PageRequest.of(0, 3));
-		assertThat(firstPage.getContent(), hasSize(3));
-		assertThat(firstPage.getTotalElements(), is(3L));
+		assertThat(firstPage.getContent()).hasSize(3);
+		assertThat(firstPage.getTotalElements()).isEqualTo(3L);
 
 		Page<User> secondPage = repository.findAll(user.dateOfBirth.isNull(), PageRequest.of(10, 10));
-		assertThat(secondPage.getContent(), hasSize(0));
-		assertThat(secondPage.getTotalElements(), is(3L));
+		assertThat(secondPage.getContent()).hasSize(0);
+		assertThat(secondPage.getTotalElements()).isEqualTo(3L);
 	}
 
 	@Test // DATAJPA-1115
 	public void findOneWithPredicateReturnsResultCorrectly() {
-		Assertions.assertThat(repository.findOne(user.eq(dave))).contains(dave);
+		assertThat(repository.findOne(user.eq(dave))).contains(dave);
 	}
 
 	@Test // DATAJPA-1115
 	public void findOneWithPredicateReturnsOptionalEmptyWhenNoDataFound() {
-		Assertions.assertThat(repository.findOne(user.firstname.eq("batman"))).isNotPresent();
+		assertThat(repository.findOne(user.firstname.eq("batman"))).isNotPresent();
 	}
 
 	@Test(expected = IncorrectResultSizeDataAccessException.class) // DATAJPA-1115


### PR DESCRIPTION
We now return `Optional<T>` for `findOne(Predicate)`.

See DATACMNS-1059 for details.

Depends on: spring-projects/spring-data-commons#215