### PR TITLE
DATAJPA-1116 - Return Optional for JpaSpecificationExecutor.findOne(Specification)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-jpa</artifactId>
-	<version>2.0.0.BUILD-SNAPSHOT</version>
+	<version>2.0.0.DATAJPA-1116-SNAPSHOT</version>
 
 	<name>Spring Data JPA</name>
 	<description>Spring Data module for JPA repositories.</description>

--- a/src/main/java/org/springframework/data/jpa/repository/JpaSpecificationExecutor.java
+++ b/src/main/java/org/springframework/data/jpa/repository/JpaSpecificationExecutor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2008-2011 the original author or authors.
+ * Copyright 2008-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 package org.springframework.data.jpa.repository;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -26,16 +27,18 @@ import org.springframework.data.jpa.domain.Specification;
  * Interface to allow execution of {@link Specification}s based on the JPA criteria API.
  * 
  * @author Oliver Gierke
+ * @author Christoph Strobl
  */
 public interface JpaSpecificationExecutor<T> {
 
 	/**
-	 * Returns a single entity matching the given {@link Specification}.
+	 * Returns a single entity matching the given {@link Specification} or {@link Optional#empty()} if none found.
 	 * 
-	 * @param spec
+	 * @param spec can be @literal {@null}.
 	 * @return
+	 * @throws org.springframework.dao.IncorrectResultSizeDataAccessException if more than one entity found.
 	 */
-	T findOne(Specification<T> spec);
+	Optional<T> findOne(Specification<T> spec);
 
 	/**
 	 * Returns all entities matching the given {@link Specification}.

--- a/src/main/java/org/springframework/data/jpa/repository/JpaSpecificationExecutor.java
+++ b/src/main/java/org/springframework/data/jpa/repository/JpaSpecificationExecutor.java
@@ -25,7 +25,7 @@ import org.springframework.data.jpa.domain.Specification;
 
 /**
  * Interface to allow execution of {@link Specification}s based on the JPA criteria API.
- * 
+ *
  * @author Oliver Gierke
  * @author Christoph Strobl
  */
@@ -33,7 +33,7 @@ public interface JpaSpecificationExecutor<T> {
 
 	/**
 	 * Returns a single entity matching the given {@link Specification} or {@link Optional#empty()} if none found.
-	 * 
+	 *
 	 * @param spec can be @literal {@null}.
 	 * @return
 	 * @throws org.springframework.dao.IncorrectResultSizeDataAccessException if more than one entity found.
@@ -42,35 +42,35 @@ public interface JpaSpecificationExecutor<T> {
 
 	/**
 	 * Returns all entities matching the given {@link Specification}.
-	 * 
-	 * @param spec
-	 * @return
+	 *
+	 * @param spec can be {@literal null}.
+	 * @return never {@literal null}.
 	 */
 	List<T> findAll(Specification<T> spec);
 
 	/**
 	 * Returns a {@link Page} of entities matching the given {@link Specification}.
-	 * 
-	 * @param spec
-	 * @param pageable
-	 * @return
+	 *
+	 * @param spec can be {@literal null}.
+	 * @param pageable can be {@literal null}.
+	 * @return never {@literal null}.
 	 */
 	Page<T> findAll(Specification<T> spec, Pageable pageable);
 
 	/**
 	 * Returns all entities matching the given {@link Specification} and {@link Sort}.
-	 * 
-	 * @param spec
-	 * @param sort
-	 * @return
+	 *
+	 * @param spec can be {@literal null}.
+	 * @param sort can be {@literal null}.
+	 * @return never {@literal null}.
 	 */
 	List<T> findAll(Specification<T> spec, Sort sort);
 
 	/**
 	 * Returns the number of instances that the given {@link Specification} will return.
-	 * 
-	 * @param spec the {@link Specification} to count instances for
-	 * @return the number of instances
+	 *
+	 * @param spec the {@link Specification} to count instances for. Can be {@literal null}.
+	 * @return the number of instances.
 	 */
 	long count(Specification<T> spec);
 }

--- a/src/main/java/org/springframework/data/jpa/repository/support/SimpleJpaRepository.java
+++ b/src/main/java/org/springframework/data/jpa/repository/support/SimpleJpaRepository.java
@@ -357,12 +357,12 @@ public class SimpleJpaRepository<T, ID> implements JpaRepository<T, ID>, JpaSpec
 	 * (non-Javadoc)
 	 * @see org.springframework.data.jpa.repository.JpaSpecificationExecutor#findOne(org.springframework.data.jpa.domain.Specification)
 	 */
-	public T findOne(Specification<T> spec) {
+	public Optional<T> findOne(Specification<T> spec) {
 
 		try {
-			return getQuery(spec, (Sort) null).getSingleResult();
+			return Optional.of(getQuery(spec, (Sort) null).getSingleResult());
 		} catch (NoResultException e) {
-			return null;
+			return Optional.empty();
 		}
 	}
 

--- a/src/main/java/org/springframework/data/jpa/repository/support/SimpleJpaRepository.java
+++ b/src/main/java/org/springframework/data/jpa/repository/support/SimpleJpaRepository.java
@@ -381,7 +381,7 @@ public class SimpleJpaRepository<T, ID> implements JpaRepository<T, ID>, JpaSpec
 	public Page<T> findAll(Specification<T> spec, Pageable pageable) {
 
 		TypedQuery<T> query = getQuery(spec, pageable);
-		return pageable == null ? new PageImpl<T>(query.getResultList())
+		return (pageable == null || pageable.isUnpaged()) ? new PageImpl<T>(query.getResultList())
 				: readPage(query, getDomainClass(), pageable, spec);
 	}
 
@@ -452,11 +452,11 @@ public class SimpleJpaRepository<T, ID> implements JpaRepository<T, ID>, JpaSpec
 	@Override
 	public <S extends T> Page<S> findAll(Example<S> example, Pageable pageable) {
 
-		ExampleSpecification<S> spec = new ExampleSpecification<S>(example);
+		ExampleSpecification<S> spec = new ExampleSpecification<>(example);
 		Class<S> probeType = example.getProbeType();
-		TypedQuery<S> query = getQuery(new ExampleSpecification<S>(example), probeType, pageable);
+		TypedQuery<S> query = getQuery(new ExampleSpecification<>(example), probeType, pageable);
 
-		return pageable == null ? new PageImpl<S>(query.getResultList()) : readPage(query, probeType, pageable, spec);
+		return pageable == null ? new PageImpl<>(query.getResultList()) : readPage(query, probeType, pageable, spec);
 	}
 
 	/*
@@ -624,7 +624,7 @@ public class SimpleJpaRepository<T, ID> implements JpaRepository<T, ID>, JpaSpec
 		Root<S> root = applySpecificationToCriteria(spec, domainClass, query);
 		query.select(root);
 
-		if (sort != null && !ObjectUtils.nullSafeEquals(sort, Sort.unsorted())) {
+		if (sort != null && !sort.isUnsorted()) {
 			query.orderBy(toOrders(sort, root, builder));
 		}
 

--- a/src/test/java/org/springframework/data/jpa/repository/UserRepositoryTests.java
+++ b/src/test/java/org/springframework/data/jpa/repository/UserRepositoryTests.java
@@ -443,14 +443,14 @@ public class UserRepositoryTests {
 	public void executesSingleEntitySpecificationCorrectly() throws Exception {
 
 		flushTestUsers();
-		assertThat(repository.findOne(userHasFirstname("Oliver"))).isEqualTo(firstUser);
+		assertThat(repository.findOne(userHasFirstname("Oliver"))).contains(firstUser);
 	}
 
 	@Test
 	public void returnsNullIfNoEntityFoundForSingleEntitySpecification() throws Exception {
 
 		flushTestUsers();
-		assertThat(repository.findOne(userHasLastname("Beauford"))).isNull();
+		assertThat(repository.findOne(userHasLastname("Beauford"))).isNotPresent();
 	}
 
 	@Test(expected = IncorrectResultSizeDataAccessException.class)


### PR DESCRIPTION
We now return `Optional<T>` instead of just `T` for `findOne(Specification)` to align the return type to the ones used in `Repository`.