### PR TITLE
DATAJPA-1093 - Java 8fying entity graph calculation.

### DIFF
--- a/src/main/java/org/springframework/data/jpa/repository/query/AbstractJpaQuery.java
+++ b/src/main/java/org/springframework/data/jpa/repository/query/AbstractJpaQuery.java
@@ -15,6 +15,7 @@
  */
 package org.springframework.data.jpa.repository.query;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -45,11 +46,12 @@ import org.springframework.util.Assert;
 
 /**
  * Abstract base class to implement {@link RepositoryQuery}s.
- * 
+ *
  * @author Oliver Gierke
  * @author Thomas Darimont
  * @author Mark Paluch
  * @author Christoph Strobl
+ * @author MD Sayem Ahmed
  */
 public abstract class AbstractJpaQuery implements RepositoryQuery {
 
@@ -59,7 +61,7 @@ public abstract class AbstractJpaQuery implements RepositoryQuery {
 
 	/**
 	 * Creates a new {@link AbstractJpaQuery} from the given {@link JpaQueryMethod}.
-	 * 
+	 *
 	 * @param method
 	 * @param em
 	 */
@@ -83,7 +85,7 @@ public abstract class AbstractJpaQuery implements RepositoryQuery {
 
 	/**
 	 * Returns the {@link EntityManager}.
-	 * 
+	 *
 	 * @return will never be {@literal null}.
 	 */
 	protected EntityManager getEntityManager() {
@@ -92,7 +94,7 @@ public abstract class AbstractJpaQuery implements RepositoryQuery {
 
 	/**
 	 * Returns the {@link JpaMetamodel}.
-	 * 
+	 *
 	 * @return
 	 */
 	protected JpaMetamodel getMetamodel() {
@@ -143,7 +145,7 @@ public abstract class AbstractJpaQuery implements RepositoryQuery {
 
 	/**
 	 * Applies the declared query hints to the given query.
-	 * 
+	 *
 	 * @param query
 	 * @return
 	 */
@@ -158,7 +160,7 @@ public abstract class AbstractJpaQuery implements RepositoryQuery {
 
 	/**
 	 * Protected to be able to customize in sub-classes.
-	 * 
+	 *
 	 * @param query must not be {@literal null}.
 	 * @param hint must not be {@literal null}.
 	 */
@@ -172,7 +174,7 @@ public abstract class AbstractJpaQuery implements RepositoryQuery {
 
 	/**
 	 * Applies the {@link LockModeType} provided by the {@link JpaQueryMethod} to the given {@link Query}.
-	 * 
+	 *
 	 * @param query must not be {@literal null}.
 	 * @param method must not be {@literal null}.
 	 * @return
@@ -194,22 +196,18 @@ public abstract class AbstractJpaQuery implements RepositoryQuery {
 	/**
 	 * Configures the {@link javax.persistence.EntityGraph} to use for the given {@link JpaQueryMethod} if the
 	 * {@link EntityGraph} annotation is present.
-	 * 
+	 *
 	 * @param query must not be {@literal null}.
 	 * @param method must not be {@literal null}.
 	 * @return
 	 */
 	private Query applyEntityGraphConfiguration(Query query, JpaQueryMethod method) {
-
 		Assert.notNull(query, "Query must not be null!");
 		Assert.notNull(method, "JpaQueryMethod must not be null!");
 
-		Map<String, Object> hints = Jpa21Utils.tryGetFetchGraphHints(em, method.getEntityGraph(),
-				getQueryMethod().getEntityInformation().getJavaType());
-
-		for (Map.Entry<String, Object> hint : hints.entrySet()) {
-			query.setHint(hint.getKey(), hint.getValue());
-		}
+		Class<?> entityType = getQueryMethod().getEntityInformation().getJavaType();
+		method.getEntityGraph().map(entityGraph -> Jpa21Utils.tryGetFetchGraphHints(em, entityGraph, entityType))
+				.orElse(Collections.emptyMap()).forEach(query::setHint);
 
 		return query;
 	}
@@ -221,7 +219,7 @@ public abstract class AbstractJpaQuery implements RepositoryQuery {
 
 	/**
 	 * Creates a {@link Query} instance for the given values.
-	 * 
+	 *
 	 * @param values must not be {@literal null}.
 	 * @return
 	 */
@@ -229,7 +227,7 @@ public abstract class AbstractJpaQuery implements RepositoryQuery {
 
 	/**
 	 * Creates a {@link TypedQuery} for counting using the given values.
-	 * 
+	 *
 	 * @param values must not be {@literal null}.
 	 * @return
 	 */
@@ -241,7 +239,7 @@ public abstract class AbstractJpaQuery implements RepositoryQuery {
 
 		/**
 		 * Creates a new {@link TupleConverter} for the given {@link ReturnedType}.
-		 * 
+		 *
 		 * @param type must not be {@literal null}.
 		 */
 		public TupleConverter(ReturnedType type) {

--- a/src/main/java/org/springframework/data/jpa/repository/query/JpaQueryMethod.java
+++ b/src/main/java/org/springframework/data/jpa/repository/query/JpaQueryMethod.java
@@ -22,6 +22,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 
 import javax.persistence.LockModeType;
@@ -49,6 +50,7 @@ import org.springframework.util.StringUtils;
  * @author Oliver Gierke
  * @author Thomas Darimont
  * @author Christoph Strobl
+ * @author MD Sayem Ahmed
  */
 public class JpaQueryMethod extends QueryMethod {
 
@@ -177,10 +179,9 @@ public class JpaQueryMethod extends QueryMethod {
 	 * @return
 	 * @since 1.6
 	 */
-	JpaEntityGraph getEntityGraph() {
-
-		EntityGraph annotation = AnnotatedElementUtils.findMergedAnnotation(method, EntityGraph.class);
-		return annotation == null ? null : new JpaEntityGraph(annotation, getNamedQueryName());
+	Optional<JpaEntityGraph> getEntityGraph() {
+		return Optional.ofNullable(AnnotatedElementUtils.findMergedAnnotation(method, EntityGraph.class))
+				.map(annotation -> new JpaEntityGraph(annotation, getNamedQueryName()));
 	}
 
 	/**

--- a/src/test/java/org/springframework/data/jpa/repository/query/JpaQueryMethodUnitTests.java
+++ b/src/test/java/org/springframework/data/jpa/repository/query/JpaQueryMethodUnitTests.java
@@ -62,6 +62,7 @@ import org.springframework.data.repository.query.QueryMethod;
  * @author Oliver Gierke
  * @author Thomas Darimont
  * @author Christoph Strobl
+ * @author MD Sayem Ahmed
  */
 @RunWith(MockitoJUnitRunner.class)
 public class JpaQueryMethodUnitTests {
@@ -305,9 +306,9 @@ public class JpaQueryMethodUnitTests {
 
 		JpaQueryMethod method = new JpaQueryMethod(queryMethodWithCustomEntityFetchGraph, metadata, factory, extractor);
 
-		assertThat(method.getEntityGraph(), is(notNullValue()));
-		assertThat(method.getEntityGraph().getName(), is("User.propertyLoadPath"));
-		assertThat(method.getEntityGraph().getType(), is(EntityGraphType.LOAD));
+		assertThat(method.getEntityGraph().isPresent(), is(true));
+		assertThat(method.getEntityGraph().get().getName(), is("User.propertyLoadPath"));
+		assertThat(method.getEntityGraph().get().getType(), is(EntityGraphType.LOAD));
 	}
 
 	@Test // DATAJPA-612
@@ -319,9 +320,9 @@ public class JpaQueryMethodUnitTests {
 		JpaQueryMethod method = new JpaQueryMethod(JpaRepositoryOverride.class.getMethod("findAll"), metadata, factory,
 				extractor);
 
-		assertThat(method.getEntityGraph(), is(notNullValue()));
-		assertThat(method.getEntityGraph().getName(), is("User.detail"));
-		assertThat(method.getEntityGraph().getType(), is(EntityGraphType.FETCH));
+		assertThat(method.getEntityGraph().isPresent(), is(true));
+		assertThat(method.getEntityGraph().get().getName(), is("User.detail"));
+		assertThat(method.getEntityGraph().get().getType(), is(EntityGraphType.FETCH));
 	}
 
 	@Test // DATAJPA-689
@@ -333,9 +334,9 @@ public class JpaQueryMethodUnitTests {
 		JpaQueryMethod method = new JpaQueryMethod(JpaRepositoryOverride.class.getMethod("findOne", Long.class), metadata,
 				factory, extractor);
 
-		assertThat(method.getEntityGraph(), is(notNullValue()));
-		assertThat(method.getEntityGraph().getName(), is("User.detail"));
-		assertThat(method.getEntityGraph().getType(), is(EntityGraphType.FETCH));
+		assertThat(method.getEntityGraph().isPresent(), is(true));
+		assertThat(method.getEntityGraph().get().getName(), is("User.detail"));
+		assertThat(method.getEntityGraph().get().getType(), is(EntityGraphType.FETCH));
 	}
 
 	/**
@@ -350,9 +351,9 @@ public class JpaQueryMethodUnitTests {
 		JpaQueryMethod method = new JpaQueryMethod(JpaRepositoryOverride.class.getMethod("getOneById", Long.class),
 				metadata, factory, extractor);
 
-		assertThat(method.getEntityGraph(), is(notNullValue()));
-		assertThat(method.getEntityGraph().getName(), is("User.getOneById"));
-		assertThat(method.getEntityGraph().getType(), is(EntityGraphType.FETCH));
+		assertThat(method.getEntityGraph().isPresent(), is(true));
+		assertThat(method.getEntityGraph().get().getName(), is("User.getOneById"));
+		assertThat(method.getEntityGraph().get().getType(), is(EntityGraphType.FETCH));
 	}
 
 	@Test // DATAJPA-758
@@ -461,9 +462,9 @@ public class JpaQueryMethodUnitTests {
 		JpaQueryMethod method = new JpaQueryMethod(
 				JpaRepositoryOverride.class.getMethod("getOneWithCustomEntityGraphAnnotation"), metadata, factory, extractor);
 
-		assertThat(method.getEntityGraph(), is(notNullValue()));
-		assertThat(method.getEntityGraph().getName(), is("User.detail"));
-		assertThat(method.getEntityGraph().getType(), is(EntityGraphType.LOAD));
+		assertThat(method.getEntityGraph().isPresent(), is(true));
+		assertThat(method.getEntityGraph().get().getName(), is("User.detail"));
+		assertThat(method.getEntityGraph().get().getType(), is(EntityGraphType.LOAD));
 	}
 
 	/**


### PR DESCRIPTION
1. AbstractJpaQuery.applyEntityGraphConfiguration now uses Java 8 streams.
2. Jpa21Utils.getSubgraph now returns Optional.
3. Both versions of Jpa21Utils.findAttributeNode now returns Optional.
4. Jpa21Utils.findAttributeNode uses Java 8 streams to search in a list.
5. Jpa21Utils.createGraph uses streams and optionals.
6. Jpa21Utils.configureFetchGraphFrom uses streams.
7. Jpa21Utils.tryGetFetchGraphHints uses streams and optionals.
8. JpaQueryMethod.getEntityGraph returns Optional.
9. Test modifications to support above changes.

If I am not mistaken, then `https://jira.spring.io/browse/DATAJPA-1093` is about these changes. If I am mistaken, then any suggestions/ideas/improvements are really really appreciated!