### PR TITLE
DATAJPA-1145 - Update StoredProcedureJpaQuery.java

### DIFF
--- a/src/main/java/org/springframework/data/jpa/repository/query/StoredProcedureJpaQuery.java
+++ b/src/main/java/org/springframework/data/jpa/repository/query/StoredProcedureJpaQuery.java
@@ -116,9 +116,13 @@ class StoredProcedureJpaQuery extends AbstractJpaQuery {
 		String outputParameterName = procedureAttributes.getOutputParameterName();
 		JpaParameters parameters = getQueryMethod().getParameters();
 
-		return useNamedParameters && StringUtils.hasText(outputParameterName) ? //
+		try{
+			return useNamedParameters && StringUtils.hasText(outputParameterName) ? //
 				storedProcedureQuery.getOutputParameterValue(outputParameterName)
 				: storedProcedureQuery.getOutputParameterValue(parameters.getNumberOfParameters() + 1);
+		}catch(PersistenceException pe){
+			return storedProcedureQuery.getResultList();
+		}
 	}
 
 	/**


### PR DESCRIPTION
storedProcedureQuery.getOutputParameterValue(i) for RefCursor is not supported by Hibernate. 
we have to use storedProcedureQuery.getResultList();

Change to call getResultList() instead of getOutputParameterValue() when hibernate
throw new ParameterMisuseException( "REF_CURSOR parameters should be accessed via results" );

Fix for the issue https://jira.spring.io/browse/DATAJPA-1145

<!--

Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
Make sure that:

-->

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] There is a ticket in the bug tracker for the project in our [JIRA](https://jira.spring.io/browse/DATAJPA).
- [ ] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [ ] You submit test cases (unit or integration tests) that back your changes.
- [ ] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).

