### PR TITLE
DATAJPA-1058 - Better exception when named method parameter is required but missing.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-jpa</artifactId>
-	<version>2.0.0.BUILD-SNAPSHOT</version>
+	<version>2.0.0.DATAJPA-1058-SNAPSHOT</version>
 
 	<name>Spring Data JPA</name>
 	<description>Spring Data module for JPA repositories.</description>

--- a/src/main/java/org/springframework/data/jpa/repository/query/ParameterBinder.java
+++ b/src/main/java/org/springframework/data/jpa/repository/query/ParameterBinder.java
@@ -32,6 +32,8 @@ import org.springframework.util.Assert;
  */
 public class ParameterBinder {
 
+	static final String PARAMETER_NEEDS_TO_BE_NAMED = "For queries with named parameters you need to use provide names for method parameters. Use @Param for query method parameters, or when on Java 8+ use the javac flag -parameters.";
+
 	private final JpaParameters parameters;
 	private final Iterable<QueryParameterSetter> parameterSetters;
 

--- a/src/main/java/org/springframework/data/jpa/repository/query/QueryParameterSetterFactory.java
+++ b/src/main/java/org/springframework/data/jpa/repository/query/QueryParameterSetterFactory.java
@@ -49,9 +49,9 @@ abstract class QueryParameterSetterFactory {
 	 * Creates a new {@link QueryParameterSetterFactory} for the given {@link JpaParameters}.
 	 * 
 	 * @param parameters must not be {@literal null}.
-	 * @return
+	 * @return A basic {@link QueryParameterSetterFactory} that can handle named and index parameters.
 	 */
-	public static QueryParameterSetterFactory basic(JpaParameters parameters) {
+	static QueryParameterSetterFactory basic(JpaParameters parameters) {
 
 		Assert.notNull(parameters, "JpaParameters must not be null!");
 
@@ -64,10 +64,10 @@ abstract class QueryParameterSetterFactory {
 	 * 
 	 * @param parameters must not be {@literal null}.
 	 * @param metadata must not be {@literal null}.
-	 * @return
+	 * @return A {@link QueryParameterSetterFactory} for criteria Queries.
 	 */
-	public static QueryParameterSetterFactory forCriteriaQuery(JpaParameters parameters,
-			List<ParameterMetadata<?>> metadata) {
+	static QueryParameterSetterFactory forCriteriaQuery(JpaParameters parameters,
+														List<ParameterMetadata<?>> metadata) {
 
 		Assert.notNull(parameters, "JpaParameters must not be null!");
 		Assert.notNull(metadata, "ParameterMetadata must not be null!");
@@ -82,10 +82,10 @@ abstract class QueryParameterSetterFactory {
 	 * @param parser must not be {@literal null}.
 	 * @param evaluationContextProvider must not be {@literal null}.
 	 * @param parameters must not be {@literal null}.
-	 * @return
+	 * @return A {@link QueryParameterSetterFactory} that can handle {@link org.springframework.expression.spel.standard.SpelExpression}s.
 	 */
-	public static QueryParameterSetterFactory parsing(SpelExpressionParser parser,
-			EvaluationContextProvider evaluationContextProvider, Parameters<?, ?> parameters) {
+	static QueryParameterSetterFactory parsing(SpelExpressionParser parser,
+											   EvaluationContextProvider evaluationContextProvider, Parameters<?, ?> parameters) {
 
 		Assert.notNull(parser, "SpelExpressionParser must not be null!");
 		Assert.notNull(evaluationContextProvider, "EvaluationContextProvider must not be null!");
@@ -165,7 +165,7 @@ abstract class QueryParameterSetterFactory {
 		 * 
 		 * @param expression must not be {@literal null}.
 		 * @param values must not be {@literal null}.
-		 * @return
+		 * @return the result of the evaluation.
 		 */
 		private Object evaluateExpression(Expression expression, Object[] values) {
 
@@ -295,7 +295,7 @@ abstract class QueryParameterSetterFactory {
 		 * 
 		 * @param parameter can be {@literal null}.
 		 * @param binding must not be {@literal null}.
-		 * @return
+		 * @return a {@link javax.persistence.Parameter} object based on the information from the arguments.
 		 */
 		static javax.persistence.Parameter<?> of(JpaParameter parameter, ParameterBinding binding) {
 

--- a/src/main/java/org/springframework/data/jpa/repository/query/QueryParameterSetterFactory.java
+++ b/src/main/java/org/springframework/data/jpa/repository/query/QueryParameterSetterFactory.java
@@ -202,6 +202,8 @@ abstract class QueryParameterSetterFactory {
 		@Override
 		public QueryParameterSetter create(ParameterBinding binding, String queryString) {
 
+			Assert.notNull(binding, "Binding must not be null.");
+
 			JpaParameter parameter = QueryUtils.hasNamedParameter(queryString) //
 					? findParameterForBinding(binding) //
 					: parameters.getBindableParameter(binding.getPosition() - 1);
@@ -223,7 +225,7 @@ abstract class QueryParameterSetterFactory {
 		}
 
 		private static String getName(JpaParameter p) {
-			return p.getName().orElseThrow(() -> new IllegalArgumentException("Parameter needs to be named!"));
+			return p.getName().orElseThrow(() -> new IllegalStateException(ParameterBinder.PARAMETER_NEEDS_TO_BE_NAMED));
 		}
 	}
 

--- a/src/main/java/org/springframework/data/jpa/repository/query/StoredProcedureJpaQuery.java
+++ b/src/main/java/org/springframework/data/jpa/repository/query/StoredProcedureJpaQuery.java
@@ -153,7 +153,7 @@ class StoredProcedureJpaQuery extends AbstractJpaQuery {
 
 			if (useNamedParameters) {
 				procedureQuery.registerStoredProcedureParameter(
-						param.getName().orElseThrow(() -> new IllegalArgumentException("Parameter needs to be named!")),
+						param.getName().orElseThrow(() -> new IllegalArgumentException(ParameterBinder.PARAMETER_NEEDS_TO_BE_NAMED)),
 						param.getType(), ParameterMode.IN);
 			} else {
 				procedureQuery.registerStoredProcedureParameter(param.getIndex() + 1, param.getType(), ParameterMode.IN);

--- a/src/test/java/org/springframework/data/jpa/repository/query/QueryParameterSetterFactoryTest.java
+++ b/src/test/java/org/springframework/data/jpa/repository/query/QueryParameterSetterFactoryTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.jpa.repository.query;
+
+import static org.mockito.Mockito.*;
+
+import java.util.stream.Stream;
+
+import org.assertj.core.api.Assertions;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+import org.springframework.data.jpa.repository.query.JpaParameters.JpaParameter;
+import org.springframework.data.jpa.repository.query.StringQuery.ParameterBinding;
+
+/**
+ * @author Jens Schauder
+ */
+public class QueryParameterSetterFactoryTest {
+
+	JpaParameters parameters = mock(JpaParameters.class, Mockito.RETURNS_DEEP_STUBS);
+	ParameterBinding binding = mock(ParameterBinding.class);
+
+	QueryParameterSetterFactory setterFactory;
+
+	@Before
+	public void before() {
+
+		// we have one bindable parameter
+		when(parameters.getBindableParameters().stream()).thenReturn(Stream.of(mock(JpaParameter.class)));
+
+		setterFactory = QueryParameterSetterFactory.basic(parameters);
+	}
+
+	@Test // DATAJPA-1058
+	public void noExceptionWhenQueryDoesNotContainNamedParameters() {
+
+		setterFactory.create(binding, "QueryStringWithOutNamedParameter");
+	}
+
+	@Test // DATAJPA-1058
+	public void exceptionWhenQueryContainNamedParametersAndMethodParametersAreNotNamed() {
+
+		Assertions.assertThatExceptionOfType(IllegalStateException.class) //
+				.isThrownBy(() -> setterFactory.create(binding, "QueryStringWith :NamedParameter")) //
+				.withMessageContaining("Java 8") //
+				.withMessageContaining("@Param") //
+				.withMessageContaining("-parameters");
+	}
+
+}


### PR DESCRIPTION
The exception now is a `IllegalStateException`, and mentions @Param as well as the -parameters compiler flag.

Original issue: https://jira.spring.io/browse/DATAJPA-1058