### PR TITLE
DATAJPA-1170 - Unify Specification and Specifications API.

### DIFF
--- a/src/main/java/org/springframework/data/jpa/domain/Specification.java
+++ b/src/main/java/org/springframework/data/jpa/domain/Specification.java
@@ -15,10 +15,16 @@
  */
 package org.springframework.data.jpa.domain;
 
+import org.springframework.util.Assert;
+
 import javax.persistence.criteria.CriteriaBuilder;
 import javax.persistence.criteria.CriteriaQuery;
 import javax.persistence.criteria.Predicate;
 import javax.persistence.criteria.Root;
+
+import java.io.Serializable;
+
+import static org.springframework.data.jpa.domain.Specification.CompositionType.*;
 
 /**
  * Specification in the sense of Domain Driven Design.
@@ -26,8 +32,43 @@ import javax.persistence.criteria.Root;
  * @author Oliver Gierke
  * @author Thomas Darimont
  * @author Krzysztof Rzymkowski
+ * @author Sebastian Staudt
  */
-public interface Specification<T> {
+public interface Specification<T> extends Serializable {
+
+	long serialVersionUID = 1L;
+
+	static <T> Specification<T> not(Specification<T> spec) {
+		return new NegatedSpecification<>(spec);
+	}
+
+	static <T> Specification<T> where(Specification<T> spec) {
+		if (spec == null) {
+			return new Specifications<>(null);
+		}
+
+		return spec;
+	}
+
+	/**
+	 * ANDs the given {@link Specification} to the current one.
+	 *
+	 * @param other can be {@literal null}.
+	 * @return The conjunction of the specifications
+	 */
+	default Specification<T> and(Specification<T> other) {
+		return new ComposedSpecification<>(this, other, AND);
+	}
+
+	/**
+	 * ORs the given specification to the current one.
+	 *
+	 * @param other can be {@literal null}.
+	 * @return The disjunction of the specifications
+	 */
+	default Specification<T> or(Specification<T> other) {
+		return new ComposedSpecification<>(this, other, OR);
+	}
 
 	/**
 	 * Creates a WHERE clause for a query of the referenced entity in form of a {@link Predicate} for the given
@@ -38,4 +79,100 @@ public interface Specification<T> {
 	 * @return a {@link Predicate}, may be {@literal null}.
 	 */
 	Predicate toPredicate(Root<T> root, CriteriaQuery<?> query, CriteriaBuilder cb);
+
+	/**
+	 * Enum for the composition types for {@link Predicate}s.
+	 *
+	 * @author Thomas Darimont
+	 */
+	enum CompositionType {
+
+		AND {
+			@Override
+			public Predicate combine(CriteriaBuilder builder, Predicate lhs, Predicate rhs) {
+				return builder.and(lhs, rhs);
+			}
+		},
+
+		OR {
+			@Override
+			public Predicate combine(CriteriaBuilder builder, Predicate lhs, Predicate rhs) {
+				return builder.or(lhs, rhs);
+			}
+		};
+
+		abstract Predicate combine(CriteriaBuilder builder, Predicate lhs, Predicate rhs);
+	}
+
+	/**
+	 * A {@link Specification} that negates a given {@code Specification}.
+	 *
+	 * @author Thomas Darimont
+	 * @since 1.6
+	 */
+	class NegatedSpecification<T> implements Specification<T>, Serializable {
+
+		private static final long serialVersionUID = 1L;
+
+		private final Specification<T> spec;
+
+		/**
+		 * Creates a new {@link NegatedSpecification} from the given {@link Specification}
+		 *
+		 * @param spec may be {@literal null}
+		 */
+		NegatedSpecification(Specification<T> spec) {
+			this.spec = spec;
+		}
+
+		public Predicate toPredicate(Root<T> root, CriteriaQuery<?> query, CriteriaBuilder builder) {
+			return spec == null ? null : builder.not(spec.toPredicate(root, query, builder));
+		}
+	}
+
+	/**
+	 * A {@link Specification} that combines two given {@code Specification}s via a given {@link CompositionType}.
+	 *
+	 * @author Thomas Darimont
+	 * @since 1.6
+	 */
+	class ComposedSpecification<T> implements Specification<T>, Serializable {
+
+		private static final long serialVersionUID = 1L;
+
+		private final Specification<T> lhs;
+		private final Specification<T> rhs;
+		private final CompositionType compositionType;
+
+		/**
+		 * Creates a new {@link ComposedSpecification} from the given {@link Specification} for the left-hand-side and the
+		 * right-hand-side with the given {@link CompositionType}.
+		 *
+		 * @param lhs may be {@literal null}
+		 * @param rhs may be {@literal null}
+		 * @param compositionType must not be {@literal null}
+		 */
+		ComposedSpecification(Specification<T> lhs, Specification<T> rhs, CompositionType compositionType) {
+
+			Assert.notNull(compositionType, "CompositionType must not be null!");
+
+			this.lhs = lhs;
+			this.rhs = rhs;
+			this.compositionType = compositionType;
+		}
+
+		/**
+		 * Returns {@link Predicate} for the given {@link Root} and {@link CriteriaQuery} that is constructed via the given
+		 * {@link CriteriaBuilder}.
+		 */
+		public Predicate toPredicate(Root<T> root, CriteriaQuery<?> query, CriteriaBuilder builder) {
+
+			Predicate otherPredicate = rhs == null ? null : rhs.toPredicate(root, query, builder);
+			Predicate thisPredicate = lhs == null ? null : lhs.toPredicate(root, query, builder);
+
+			return thisPredicate == null ? otherPredicate : otherPredicate == null ? thisPredicate : this.compositionType
+					.combine(builder, thisPredicate, otherPredicate);
+		}
+	}
+
 }

--- a/src/main/java/org/springframework/data/jpa/domain/Specifications.java
+++ b/src/main/java/org/springframework/data/jpa/domain/Specifications.java
@@ -15,8 +15,6 @@
  */
 package org.springframework.data.jpa.domain;
 
-import static org.springframework.data.jpa.domain.Specifications.CompositionType.*;
-
 import java.io.Serializable;
 
 import javax.persistence.criteria.CriteriaBuilder;
@@ -24,13 +22,14 @@ import javax.persistence.criteria.CriteriaQuery;
 import javax.persistence.criteria.Predicate;
 import javax.persistence.criteria.Root;
 
-import org.springframework.util.Assert;
+import static org.springframework.data.jpa.domain.Specification.CompositionType.*;
 
 /**
  * Helper class to easily combine {@link Specification} instances.
- * 
+ *
  * @author Oliver Gierke
  * @author Thomas Darimont
+ * @author Sebastian Staudt
  */
 public class Specifications<T> implements Specification<T>, Serializable {
 
@@ -40,16 +39,17 @@ public class Specifications<T> implements Specification<T>, Serializable {
 
 	/**
 	 * Creates a new {@link Specifications} wrapper for the given {@link Specification}.
-	 * 
+	 *
 	 * @param spec can be {@literal null}.
 	 */
-	private Specifications(Specification<T> spec) {
+	Specifications(Specification<T> spec) {
 		this.spec = spec;
 	}
 
 	/**
 	 * Simple static factory method to add some syntactic sugar around a {@link Specification}.
-	 * 
+	 *
+	 * @deprecated Use {@link Specification#where} instead
 	 * @param <T>
 	 * @param spec can be {@literal null}.
 	 * @return
@@ -60,7 +60,8 @@ public class Specifications<T> implements Specification<T>, Serializable {
 
 	/**
 	 * ANDs the given {@link Specification} to the current one.
-	 * 
+	 *
+	 * @deprecated Use {@link Specification#and} instead
 	 * @param <T>
 	 * @param other can be {@literal null}.
 	 * @return
@@ -71,7 +72,8 @@ public class Specifications<T> implements Specification<T>, Serializable {
 
 	/**
 	 * ORs the given specification to the current one.
-	 * 
+	 *
+	 * @deprecated Use {@link Specification#or} instead
 	 * @param <T>
 	 * @param other can be {@literal null}.
 	 * @return
@@ -82,7 +84,8 @@ public class Specifications<T> implements Specification<T>, Serializable {
 
 	/**
 	 * Negates the given {@link Specification}.
-	 * 
+	 *
+	 * @deprecated Use {@link Specification#not} instead
 	 * @param <T>
 	 * @param spec can be {@literal null}.
 	 * @return
@@ -99,98 +102,4 @@ public class Specifications<T> implements Specification<T>, Serializable {
 		return spec == null ? null : spec.toPredicate(root, query, builder);
 	}
 
-	/**
-	 * Enum for the composition types for {@link Predicate}s.
-	 * 
-	 * @author Thomas Darimont
-	 */
-	enum CompositionType {
-
-		AND {
-			@Override
-			public Predicate combine(CriteriaBuilder builder, Predicate lhs, Predicate rhs) {
-				return builder.and(lhs, rhs);
-			}
-		},
-
-		OR {
-			@Override
-			public Predicate combine(CriteriaBuilder builder, Predicate lhs, Predicate rhs) {
-				return builder.or(lhs, rhs);
-			}
-		};
-
-		abstract Predicate combine(CriteriaBuilder builder, Predicate lhs, Predicate rhs);
-	}
-
-	/**
-	 * A {@link Specification} that negates a given {@code Specification}.
-	 * 
-	 * @author Thomas Darimont
-	 * @since 1.6
-	 */
-	private static class NegatedSpecification<T> implements Specification<T>, Serializable {
-
-		private static final long serialVersionUID = 1L;
-
-		private final Specification<T> spec;
-
-		/**
-		 * Creates a new {@link NegatedSpecification} from the given {@link Specification}
-		 * 
-		 * @param spec may be {@iteral null}
-		 */
-		public NegatedSpecification(Specification<T> spec) {
-			this.spec = spec;
-		}
-
-		public Predicate toPredicate(Root<T> root, CriteriaQuery<?> query, CriteriaBuilder builder) {
-			return spec == null ? null : builder.not(spec.toPredicate(root, query, builder));
-		}
-	}
-
-	/**
-	 * A {@link Specification} that combines two given {@code Specification}s via a given {@link CompositionType}.
-	 * 
-	 * @author Thomas Darimont
-	 * @since 1.6
-	 */
-	private static class ComposedSpecification<T> implements Specification<T>, Serializable {
-
-		private static final long serialVersionUID = 1L;
-
-		private final Specification<T> lhs;
-		private final Specification<T> rhs;
-		private final CompositionType compositionType;
-
-		/**
-		 * Creates a new {@link ComposedSpecification} from the given {@link Specification} for the left-hand-side and the
-		 * right-hand-side with the given {@link CompositionType}.
-		 * 
-		 * @param lhs may be {@literal null}
-		 * @param rhs may be {@literal null}
-		 * @param compositionType must not be {@literal null}
-		 */
-		private ComposedSpecification(Specification<T> lhs, Specification<T> rhs, CompositionType compositionType) {
-
-			Assert.notNull(compositionType, "CompositionType must not be null!");
-
-			this.lhs = lhs;
-			this.rhs = rhs;
-			this.compositionType = compositionType;
-		}
-
-		/**
-		 * Returns {@link Predicate} for the given {@link Root} and {@link CriteriaQuery} that is constructed via the given
-		 * {@link CriteriaBuilder}.
-		 */
-		public Predicate toPredicate(Root<T> root, CriteriaQuery<?> query, CriteriaBuilder builder) {
-
-			Predicate otherPredicate = rhs == null ? null : rhs.toPredicate(root, query, builder);
-			Predicate thisPredicate = lhs == null ? null : lhs.toPredicate(root, query, builder);
-
-			return thisPredicate == null ? otherPredicate : otherPredicate == null ? thisPredicate : this.compositionType
-					.combine(builder, thisPredicate, otherPredicate);
-		}
-	}
 }

--- a/src/test/java/org/springframework/data/jpa/domain/SpecificationUnitTests.java
+++ b/src/test/java/org/springframework/data/jpa/domain/SpecificationUnitTests.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright 2013-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.jpa.domain;
+
+import static org.hamcrest.CoreMatchers.*;
+import static org.junit.Assert.*;
+import static org.springframework.data.jpa.domain.Specification.not;
+import static org.springframework.data.jpa.domain.Specification.where;
+import static org.springframework.util.SerializationUtils.*;
+
+import java.io.Serializable;
+
+import javax.persistence.criteria.CriteriaBuilder;
+import javax.persistence.criteria.CriteriaQuery;
+import javax.persistence.criteria.Predicate;
+import javax.persistence.criteria.Root;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+/**
+ * @author Oliver Gierke
+ * @author Thomas Darimont
+ * @author Sebastian Staudt
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class SpecificationUnitTests implements Serializable {
+
+	Specification<Object> spec;
+	@Mock(extraInterfaces = Serializable.class) Root<Object> root;
+	@Mock(extraInterfaces = Serializable.class) CriteriaQuery<?> query;
+	@Mock(extraInterfaces = Serializable.class) CriteriaBuilder builder;
+
+	@Mock(extraInterfaces = Serializable.class) Predicate predicate;
+
+	@Before
+	@SuppressWarnings("unchecked")
+	public void setUp() {
+
+		spec = (root, query, cb) -> predicate;
+	}
+
+	@Test // DATAJPA-300
+	public void createsSpecificationsFromNull() {
+
+		Specification<Object> specification = where(null);
+		assertThat(specification, is(notNullValue()));
+		assertThat(specification.toPredicate(root, query, builder), is(nullValue()));
+	}
+
+	@Test // DATAJPA-300
+	public void negatesNullSpecToNull() {
+
+		Specification<Object> specification = not(null);
+
+		assertThat(specification, is(notNullValue()));
+		assertThat(specification.toPredicate(root, query, builder), is(nullValue()));
+	}
+
+	@Test // DATAJPA-300
+	public void andConcatenatesSpecToNullSpec() {
+
+		Specification<Object> specification = where(null);
+		specification = specification.and(spec);
+
+		assertThat(specification, is(notNullValue()));
+		assertThat(specification.toPredicate(root, query, builder), is(predicate));
+	}
+
+	@Test // DATAJPA-300
+	public void andConcatenatesNullSpecToSpec() {
+
+		Specification<Object> specification = spec.and(null);
+
+		assertThat(specification, is(notNullValue()));
+		assertThat(specification.toPredicate(root, query, builder), is(predicate));
+	}
+
+	@Test // DATAJPA-300
+	public void orConcatenatesSpecToNullSpec() {
+
+		Specification<Object> specification = where(null);
+		specification = specification.or(spec);
+
+		assertThat(specification, is(notNullValue()));
+		assertThat(specification.toPredicate(root, query, builder), is(predicate));
+	}
+
+	@Test // DATAJPA-300
+	public void orConcatenatesNullSpecToSpec() {
+
+		Specification<Object> specification = spec.or(null);
+
+		assertThat(specification, is(notNullValue()));
+		assertThat(specification.toPredicate(root, query, builder), is(predicate));
+	}
+
+	@Test // DATAJPA-523
+	public void specificationsShouldBeSerializable() {
+
+		Specification<Object> serializableSpec = new SerializableSpecification();
+		Specification<Object> specification = serializableSpec.and(serializableSpec);
+
+		assertThat(specification, is(notNullValue()));
+
+		@SuppressWarnings("unchecked")
+		Specification<Object> transferredSpecification = (Specification<Object>) deserialize(serialize(specification));
+
+		assertThat(transferredSpecification, is(notNullValue()));
+	}
+
+	@Test // DATAJPA-523
+	public void complexSpecificationsShouldBeSerializable() {
+
+		SerializableSpecification serializableSpec = new SerializableSpecification();
+		Specification<Object> specification = Specification.not(serializableSpec.and(serializableSpec).or(serializableSpec));
+
+		assertThat(specification, is(notNullValue()));
+
+		@SuppressWarnings("unchecked")
+		Specification<Object> transferredSpecification = (Specification<Object>) deserialize(serialize(specification));
+
+		assertThat(transferredSpecification, is(notNullValue()));
+	}
+
+	public class SerializableSpecification implements Serializable, Specification<Object> {
+		@Override
+		public Predicate toPredicate(Root<Object> root, CriteriaQuery<?> query, CriteriaBuilder cb) {
+			return null;
+		}
+	}
+
+}

--- a/src/test/java/org/springframework/data/jpa/repository/UserRepositoryTests.java
+++ b/src/test/java/org/springframework/data/jpa/repository/UserRepositoryTests.java
@@ -19,8 +19,7 @@ import static org.assertj.core.api.Assertions.*;
 import static org.springframework.data.domain.Example.*;
 import static org.springframework.data.domain.ExampleMatcher.*;
 import static org.springframework.data.domain.Sort.Direction.*;
-import static org.springframework.data.jpa.domain.Specifications.*;
-import static org.springframework.data.jpa.domain.Specifications.not;
+import static org.springframework.data.jpa.domain.Specification.*;
 import static org.springframework.data.jpa.domain.sample.UserSpecifications.*;
 
 import java.util.ArrayList;
@@ -458,7 +457,7 @@ public class UserRepositoryTests {
 	public void executesCombinedSpecificationsCorrectly() {
 
 		flushTestUsers();
-		Specification<User> spec = where(userHasFirstname("Oliver")).or(userHasLastname("Arrasz"));
+		Specification<User> spec = userHasFirstname("Oliver").or(userHasLastname("Arrasz"));
 		assertThat(repository.findAll(spec)).hasSize(2);
 	}
 
@@ -475,7 +474,7 @@ public class UserRepositoryTests {
 	public void executesCombinedSpecificationsWithPageableCorrectly() {
 
 		flushTestUsers();
-		Specification<User> spec = where(userHasFirstname("Oliver")).or(userHasLastname("Arrasz"));
+		Specification<User> spec = userHasFirstname("Oliver").or(userHasLastname("Arrasz"));
 
 		Page<User> users = repository.findAll(spec, PageRequest.of(0, 1));
 		assertThat(users.getSize()).isEqualTo(1);
@@ -2047,7 +2046,7 @@ public class UserRepositoryTests {
 
 		flushTestUsers();
 
-		Page<User> result = repository.findAll(where(userHasLastnameLikeWithSort("e")), PageRequest.of(0, 1));
+		Page<User> result = repository.findAll(userHasLastnameLikeWithSort("e"), PageRequest.of(0, 1));
 
 		assertThat(result.getTotalElements()).isEqualTo(2L);
 		assertThat(result.getNumberOfElements()).isEqualTo(1);
@@ -2058,7 +2057,7 @@ public class UserRepositoryTests {
 
 		flushTestUsers();
 
-		Specification<User> spec = where(userHasFirstname("Oliver")).or(userHasLastname("Matthews"));
+		Specification<User> spec = userHasFirstname("Oliver").or(userHasLastname("Matthews"));
 
 		Page<User> result = repository.findAll(spec, PageRequest.of(0, 1, sort));
 		assertThat(result.getTotalElements()).isEqualTo(2L);


### PR DESCRIPTION
Using default methods in the `Specification` interface we’re able to effectively remove the `Specifications` class from the public API.

This allows to use `and`, `or` and `not` without wrapping `Specification` into `Specifications` using `where`. `where` is still available to wrap potentially nullable specifications.

