### PR TITLE
DATAJPA-1175 - Remove EntityManager injection in QuerydslRepositorySupport.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-jpa</artifactId>
-	<version>1.11.7.BUILD-SNAPSHOT</version>
+	<version>1.11.7.DATAJPA-1175-SNAPSHOT</version>
 
 	<name>Spring Data JPA</name>
 	<description>Spring Data module for JPA repositories.</description>

--- a/src/main/java/org/springframework/data/jpa/repository/support/QueryDslRepositorySupport.java
+++ b/src/main/java/org/springframework/data/jpa/repository/support/QueryDslRepositorySupport.java
@@ -17,7 +17,6 @@ package org.springframework.data.jpa.repository.support;
 
 import javax.annotation.PostConstruct;
 import javax.persistence.EntityManager;
-import javax.persistence.PersistenceContext;
 
 import org.springframework.stereotype.Repository;
 import org.springframework.util.Assert;
@@ -32,8 +31,8 @@ import com.querydsl.jpa.impl.JPADeleteClause;
 import com.querydsl.jpa.impl.JPAUpdateClause;
 
 /**
- * Base class for implementing repositories using QueryDsl library.
- * 
+ * Base class for implementing repositories using Querydsl library.
+ *
  * @author Oliver Gierke
  * @author Mark Paluch
  */
@@ -59,9 +58,8 @@ public abstract class QueryDslRepositorySupport {
 	/**
 	 * Setter to inject {@link EntityManager}.
 	 * 
-	 * @param entityManager must not be {@literal null}
+	 * @param entityManager must not be {@literal null}.
 	 */
-	@PersistenceContext
 	public void setEntityManager(EntityManager entityManager) {
 
 		Assert.notNull(entityManager, "EntityManager must not be null!");


### PR DESCRIPTION
We no longer declare entity manager injection in `QuerydslRepositorySupport` to prevent annotation-triggered class path scanning from touching this class. Class path scans can fail because Querydsl is an optional dependency and `@PersistenceContext` is a marker for environments like CDI to initiate a class path scan. Depending on the scan implementation, reflection-based scanners are known to fail because the class cannot be linked without Querydsl on the class path.  

---

Related ticket: [DATAJPA-1175](https://jira.spring.io/browse/DATAJPA-1175).