### PR TITLE
DATAJPA-1178 Failure to resolve named queries on Entity using Hiberna…

### DIFF
--- a/src/main/java/org/springframework/data/jpa/repository/query/NamedQuery.java
+++ b/src/main/java/org/springframework/data/jpa/repository/query/NamedQuery.java
@@ -100,7 +100,7 @@ final class NamedQuery extends AbstractJpaQuery {
 		try {
 			lookupEm.createNamedQuery(queryName);
 			return true;
-		} catch (IllegalArgumentException e) {
+		} catch (IllegalArgumentException | IllegalStateException e) {
 			LOG.debug("Did not find named query {}", queryName);
 			return false;
 		} finally {


### PR DESCRIPTION
…te 5.2.11 with JTA transaction manager.

Changed the exception handling in NamedQuery.hasNamedQuery to handle IllegalStateException thrown when running in a JTA environment

<!--

Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
Make sure that:

-->

- [ ] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [ ] There is a ticket in the bug tracker for the project in our [JIRA](https://jira.spring.io/browse/DATAJPA).
- [ ] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [ ] You submit test cases (unit or integration tests) that back your changes.
- [ ] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).

