### PR TITLE
DATAJPA-1179 - Create multiple placeholders for duplicate SpELs.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-jpa</artifactId>
-	<version>1.12.0.BUILD-SNAPSHOT</version>
+	<version>1.12.0.DATAJPA-1179-SNAPSHOT</version>
 
 	<name>Spring Data JPA</name>
 	<description>Spring Data module for JPA repositories.</description>

--- a/src/main/java/org/springframework/data/jpa/repository/query/StringQuery.java
+++ b/src/main/java/org/springframework/data/jpa/repository/query/StringQuery.java
@@ -38,6 +38,7 @@ import org.springframework.util.StringUtils;
  * @author Thomas Darimont
  * @author Oliver Wehrens
  * @author Mark Paluch
+ * @author Jens Schauder
  */
 class StringQuery {
 
@@ -287,12 +288,22 @@ class StringQuery {
 				}
 
 				if (replacement != null) {
-					result = StringUtils.replace(result, matcher.group(2), replacement);
+					result = replaceFirst(result, matcher.group(2), replacement);
 				}
 
 			}
 
 			return result;
+		}
+
+		private static String replaceFirst(String text, String substring, String replacement) {
+
+			int index = text.indexOf(substring);
+			if (index < 0) {
+				return text;
+			}
+
+			return text.substring(0, index) + replacement + text.substring(index + substring.length());
 		}
 
 		private int tryFindGreatestParameterIndexIn(String query) {

--- a/src/main/java/org/springframework/data/jpa/repository/query/StringQuery.java
+++ b/src/main/java/org/springframework/data/jpa/repository/query/StringQuery.java
@@ -54,7 +54,7 @@ class StringQuery {
 	 * 
 	 * @param query must not be {@literal null} or empty.
 	 */
-	public StringQuery(String query) {
+	StringQuery(String query) {
 
 		Assert.hasText(query, "Query must not be null or empty!");
 
@@ -67,17 +67,13 @@ class StringQuery {
 
 	/**
 	 * Returns whether we have found some like bindings.
-	 * 
-	 * @return
 	 */
-	public boolean hasParameterBindings() {
+	boolean hasParameterBindings() {
 		return !bindings.isEmpty();
 	}
 
 	/**
 	 * Returns the {@link ParameterBinding}s registered.
-	 * 
-	 * @return
 	 */
 	List<ParameterBinding> getParameterBindings() {
 		return bindings;
@@ -85,10 +81,8 @@ class StringQuery {
 
 	/**
 	 * Returns the query string.
-	 * 
-	 * @return
 	 */
-	public String getQueryString() {
+	String getQueryString() {
 		return query;
 	}
 
@@ -97,7 +91,7 @@ class StringQuery {
 	 * 
 	 * @return the alias
 	 */
-	public String getAlias() {
+	String getAlias() {
 		return alias;
 	}
 
@@ -105,9 +99,8 @@ class StringQuery {
 	 * Returns the {@link ParameterBinding} for the given name.
 	 * 
 	 * @param name must not be {@literal null} or empty.
-	 * @return
 	 */
-	public ParameterBinding getBindingFor(String name) {
+	ParameterBinding getBindingFor(String name) {
 
 		Assert.hasText(name, PARAMETER_NAME_MISSING);
 
@@ -122,11 +115,8 @@ class StringQuery {
 
 	/**
 	 * Returns the {@link ParameterBinding} for the given position.
-	 * 
-	 * @param position
-	 * @return
 	 */
-	public ParameterBinding getBindingFor(int position) {
+	ParameterBinding getBindingFor(int position) {
 
 		for (ParameterBinding binding : bindings) {
 			if (binding.hasPosition(position)) {
@@ -139,20 +129,16 @@ class StringQuery {
 
 	/**
 	 * Returns whether the query is using a constructor expression.
-	 * 
-	 * @return
 	 * @since 1.10
 	 */
-	public boolean hasConstructorExpression() {
+	boolean hasConstructorExpression() {
 		return hasConstructorExpression;
 	}
 
 	/**
 	 * Returns whether the query uses the default projection, i.e. returns the main alias defined for the query.
-	 * 
-	 * @return
 	 */
-	public boolean isDefaultProjection() {
+	boolean isDefaultProjection() {
 		return QueryUtils.getProjection(query).equals(alias);
 	}
 
@@ -161,7 +147,7 @@ class StringQuery {
 	 * 
 	 * @author Thomas Darimont
 	 */
-	public static enum ParameterBindingParser {
+	public enum ParameterBindingParser {
 
 		INSTANCE;
 
@@ -202,12 +188,9 @@ class StringQuery {
 		/**
 		 * Parses {@link ParameterBinding} instances from the given query and adds them to the registered bindings. Returns
 		 * the cleaned up query.
-		 * 
-		 * @param query
-		 * @return
 		 */
-		private final String parseParameterBindingsOfQueryIntoBindingsAndReturnCleanedQuery(String query,
-				List<ParameterBinding> bindings) {
+		private String parseParameterBindingsOfQueryIntoBindingsAndReturnCleanedQuery(String query,
+																					  List<ParameterBinding> bindings) {
 
 			String result = query;
 			Matcher matcher = PARAMETER_BINDING_PATTERN.matcher(query);
@@ -338,7 +321,7 @@ class StringQuery {
 		 * @author Thomas Darimont
 		 * @author Oliver Gierke
 		 */
-		private static enum ParameterBindingType {
+		private enum ParameterBindingType {
 
 			// Trailing whitespace is intentional to reflect that the keywords must be used with at least one whitespace
 			// character, while = does not.
@@ -346,7 +329,7 @@ class StringQuery {
 
 			private final String keyword;
 
-			private ParameterBindingType(String keyword) {
+			ParameterBindingType(String keyword) {
 				this.keyword = keyword;
 			}
 
@@ -363,9 +346,6 @@ class StringQuery {
 			/**
 			 * Return the appropriate {@link ParameterBindingType} for the given {@link String}. Returns {@keyword #AS_IS} in
 			 * case no other {@link ParameterBindingType} could be found.
-			 * 
-			 * @param typeSource
-			 * @return
 			 */
 			static ParameterBindingType of(String typeSource) {
 
@@ -396,30 +376,17 @@ class StringQuery {
 		private final Integer position;
 
 		/**
-		 * Creates a new {@link ParameterBinding} for the parameter with the given name.
-		 * 
-		 * @param name must not be {@literal null}.
-		 */
-		public ParameterBinding(String name) {
-			this(name, null, null);
-		}
-
-		/**
 		 * Creates a new {@link ParameterBinding} for the parameter with the given position.
 		 * 
 		 * @param position must not be {@literal null}.
 		 */
-		public ParameterBinding(Integer position) {
+		ParameterBinding(Integer position) {
 			this(null, position, null);
 		}
 
 		/**
 		 * Creates a new {@link ParameterBinding} for the parameter with the given name, position and expression
 		 * information.
-		 * 
-		 * @param name
-		 * @param position
-		 * @param expression
 		 */
 		ParameterBinding(String name, Integer position, String expression) {
 
@@ -439,22 +406,16 @@ class StringQuery {
 		/**
 		 * Returns whether the binding has the given name. Will always be {@literal false} in case the
 		 * {@link ParameterBinding} has been set up from a position.
-		 * 
-		 * @param name
-		 * @return
 		 */
-		public boolean hasName(String name) {
+		boolean hasName(String name) {
 			return this.position == null && this.name != null && this.name.equals(name);
 		}
 
 		/**
 		 * Returns whether the binding has the given position. Will always be {@literal false} in case the
 		 * {@link ParameterBinding} has been set up from a name.
-		 * 
-		 * @param position
-		 * @return
 		 */
-		public boolean hasPosition(Integer position) {
+		boolean hasPosition(Integer position) {
 			return position != null && this.name == null && position.equals(this.position);
 		}
 
@@ -468,14 +429,14 @@ class StringQuery {
 		/**
 		 * @return the position
 		 */
-		public Integer getPosition() {
+		Integer getPosition() {
 			return position;
 		}
 
 		/**
 		 * @return {@literal true} if this parameter binding is a synthetic SpEL expression.
 		 */
-		public boolean isExpression() {
+		boolean isExpression() {
 			return this.expression != null;
 		}
 
@@ -522,15 +483,11 @@ class StringQuery {
 					getExpression());
 		}
 
-		/**
-		 * @param valueToBind
-		 * @return
-		 */
-		public Object prepare(Object valueToBind) {
+		Object prepare(Object valueToBind) {
 			return valueToBind;
 		}
 
-		public String getExpression() {
+		String getExpression() {
 			return expression;
 		}
 	}
@@ -545,21 +502,15 @@ class StringQuery {
 
 		/**
 		 * Creates a new {@link InParameterBinding} for the parameter with the given name.
-		 * 
-		 * @param name
-		 * @param expression
 		 */
-		public InParameterBinding(String name, String expression) {
+		InParameterBinding(String name, String expression) {
 			super(name, null, expression);
 		}
 
 		/**
 		 * Creates a new {@link InParameterBinding} for the parameter with the given position.
-		 * 
-		 * @param position
-		 * @param expression
 		 */
-		public InParameterBinding(int position, String expression) {
+		InParameterBinding(int position, String expression) {
 			super(null, position, expression);
 		}
 
@@ -568,7 +519,7 @@ class StringQuery {
 		 * @see org.springframework.data.jpa.repository.query.StringQuery.ParameterBinding#prepare(java.lang.Object)
 		 */
 		@Override
-		public Object prepare(Object value) {
+		Object prepare(Object value) {
 
 			if (!ObjectUtils.isArray(value)) {
 				return value;
@@ -605,7 +556,7 @@ class StringQuery {
 		 * @param name must not be {@literal null} or empty.
 		 * @param type must not be {@literal null}.
 		 */
-		public LikeParameterBinding(String name, Type type) {
+		LikeParameterBinding(String name, Type type) {
 			this(name, type, null);
 		}
 
@@ -617,7 +568,7 @@ class StringQuery {
 		 * @param type must not be {@literal null}.
 		 * @param expression may be {@literal null}.
 		 */
-		public LikeParameterBinding(String name, Type type, String expression) {
+		LikeParameterBinding(String name, Type type, String expression) {
 
 			super(name, null, expression);
 
@@ -636,7 +587,7 @@ class StringQuery {
 		 * @param position
 		 * @param type must not be {@literal null}.
 		 */
-		public LikeParameterBinding(int position, Type type) {
+		LikeParameterBinding(int position, Type type) {
 			this(position, type, null);
 		}
 
@@ -647,7 +598,7 @@ class StringQuery {
 		 * @param type must not be {@literal null}.
 		 * @param expression may be {@literal null}.
 		 */
-		public LikeParameterBinding(int position, Type type, String expression) {
+		LikeParameterBinding(int position, Type type, String expression) {
 
 			super(null, position, expression);
 
@@ -665,20 +616,18 @@ class StringQuery {
 		 * 
 		 * @return the type
 		 */
-		public Type getType() {
+		Type getType() {
 			return type;
 		}
 
 		/**
 		 * Prepares the given raw keyword according to the like type.
-		 * 
-		 * @param keyword
 		 */
 		@Override
-		public Object prepare(Object value) {
+		Object prepare(Object value) {
 
 			if (value == null) {
-				return value;
+				return null;
 			}
 
 			switch (type) {
@@ -737,7 +686,6 @@ class StringQuery {
 		 * Extracts the like {@link Type} from the given JPA like expression.
 		 * 
 		 * @param expression must not be {@literal null} or empty.
-		 * @return
 		 */
 		private static Type getLikeTypeFrom(String expression) {
 

--- a/src/test/java/org/springframework/data/jpa/repository/UserRepositoryTests.java
+++ b/src/test/java/org/springframework/data/jpa/repository/UserRepositoryTests.java
@@ -2142,7 +2142,7 @@ public class UserRepositoryTests {
 	public void queryProvidesCorrectNumberOfParametersForNativeQuery() {
 
 		Query query = em.createNativeQuery("select 1 from User where firstname=? and lastname=?");
-		assertThat(query.getParameters(),hasSize(2));
+		assertThat(query.getParameters(), hasSize(2));
 	}
 
 	@Test // DATAJPA-1179

--- a/src/test/java/org/springframework/data/jpa/repository/UserRepositoryTests.java
+++ b/src/test/java/org/springframework/data/jpa/repository/UserRepositoryTests.java
@@ -2145,6 +2145,16 @@ public class UserRepositoryTests {
 		assertThat(query.getParameters(),hasSize(2));
 	}
 
+	@Test // DATAJPA-1179
+	public void duplicateSpelsWorkAsIntended() {
+
+		flushTestUsers();
+
+		List<User> users = repository.findUsersByDuplicateSpel("Oliver");
+
+		assertThat(users, hasSize(1));
+	}
+
 	private Page<User> executeSpecWithSort(Sort sort) {
 
 		flushTestUsers();

--- a/src/test/java/org/springframework/data/jpa/repository/query/StringQueryUnitTests.java
+++ b/src/test/java/org/springframework/data/jpa/repository/query/StringQueryUnitTests.java
@@ -34,6 +34,7 @@ import org.springframework.data.repository.query.parser.Part.Type;
  * 
  * @author Oliver Gierke
  * @author Thomas Darimont
+ * @author Jens Schauder
  */
 public class StringQueryUnitTests {
 
@@ -300,6 +301,20 @@ public class StringQueryUnitTests {
 		// Parentheses required
 		assertThat(new StringQuery("select new Dto() from A a").hasConstructorExpression(), is(true));
 		assertThat(new StringQuery("select new Dto from A a").hasConstructorExpression(), is(false));
+	}
+
+	@Test // DATAJPA-1179
+	public void bindingsMatchQueryForIdenticalSpelExpressions() {
+
+		StringQuery query = new StringQuery("select a from A a where a.first = :#{#exp} or a.second = :#{#exp}");
+
+		List<ParameterBinding> bindings = query.getParameterBindings();
+		assertThat(bindings, not(empty()));
+
+		for (ParameterBinding binding : bindings) {
+			assertThat(binding.getName(), notNullValue());
+			assertThat(query.getQueryString(), containsString(binding.getName()));
+		}
 	}
 
 	private void assertPositionalBinding(Class<? extends ParameterBinding> bindingType, Integer position,

--- a/src/test/java/org/springframework/data/jpa/repository/sample/UserRepository.java
+++ b/src/test/java/org/springframework/data/jpa/repository/sample/UserRepository.java
@@ -466,6 +466,10 @@ public interface UserRepository
 	// DATAJPA-858
 	List<User> findByRolesNameContaining(String name);
 
+	// DATAJPA-1179
+	@Query("select u from User u where u.firstname = :#{#firstname} and u.firstname = :#{#firstname}")
+	List<User> findUsersByDuplicateSpel(@Param("firstname") String firstname);
+
 	List<RolesAndFirstname> findRolesAndFirstnameBy();
 
 	static interface RolesAndFirstname {


### PR DESCRIPTION
Before a duplicate SpEL created one placeholder but multiple bindings resulting in exceptions during parameter binding.