### PR TITLE
DATAJPA-1179 (Kay) - Create multiple placeholders for duplicate SpELs.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-jpa</artifactId>
-	<version>2.0.0.BUILD-SNAPSHOT</version>
+	<version>2.0.0.DATAJPA-1179-SNAPSHOT</version>
 
 	<name>Spring Data JPA</name>
 	<description>Spring Data module for JPA repositories.</description>

--- a/src/main/java/org/springframework/data/jpa/repository/query/StringQuery.java
+++ b/src/main/java/org/springframework/data/jpa/repository/query/StringQuery.java
@@ -243,12 +243,22 @@ class StringQuery {
 				}
 
 				if (replacement != null) {
-					result = StringUtils.replace(result, matcher.group(2), replacement);
+					result = replaceFirst(result, matcher.group(2), replacement);
 				}
 
 			}
 
 			return result;
+		}
+
+		private static String replaceFirst(String text, String substring, String replacement) {
+
+			int index = text.indexOf(substring);
+			if (index < 0) {
+				return text;
+			}
+
+			return text.substring(0, index) + replacement + text.substring(index + substring.length());
 		}
 
 		private int tryFindGreatestParameterIndexIn(String query) {

--- a/src/main/java/org/springframework/data/jpa/repository/query/StringQuery.java
+++ b/src/main/java/org/springframework/data/jpa/repository/query/StringQuery.java
@@ -638,8 +638,6 @@ class StringQuery {
 
 		/**
 		 * Prepares the given raw keyword according to the like type.
-		 * 
-		 * @param keyword
 		 */
 		@Nullable
 		@Override

--- a/src/test/java/org/springframework/data/jpa/repository/UserRepositoryTests.java
+++ b/src/test/java/org/springframework/data/jpa/repository/UserRepositoryTests.java
@@ -2065,6 +2065,16 @@ public class UserRepositoryTests {
 		assertThat(query.getParameters()).hasSize(2);
 	}
 
+	@Test // DATAJPA-1179
+	public void duplicateSpelsWorkAsIntended() {
+
+		flushTestUsers();
+
+		List<User> users = repository.findUsersByDuplicateSpel("Oliver");
+
+		assertThat(users).hasSize(1);
+	}
+
 	private Page<User> executeSpecWithSort(Sort sort) {
 
 		flushTestUsers();

--- a/src/test/java/org/springframework/data/jpa/repository/query/StringQueryUnitTests.java
+++ b/src/test/java/org/springframework/data/jpa/repository/query/StringQueryUnitTests.java
@@ -33,6 +33,7 @@ import org.springframework.data.repository.query.parser.Part.Type;
  *
  * @author Oliver Gierke
  * @author Thomas Darimont
+ * @author Jens Schauder
  */
 public class StringQueryUnitTests {
 
@@ -289,6 +290,20 @@ public class StringQueryUnitTests {
 		// Parentheses required
 		assertThat(new StringQuery("select new Dto() from A a").hasConstructorExpression(), is(true));
 		assertThat(new StringQuery("select new Dto from A a").hasConstructorExpression(), is(false));
+	}
+
+	@Test // DATAJPA-1179
+	public void bindingsMatchQueryForIdenticalSpelExpressions() {
+
+		StringQuery query = new StringQuery("select a from A a where a.first = :#{#exp} or a.second = :#{#exp}");
+
+		List<ParameterBinding> bindings = query.getParameterBindings();
+		assertThat(bindings, not(empty()));
+
+		for (ParameterBinding binding : bindings) {
+			assertThat(binding.getName(), notNullValue());
+			assertThat(query.getQueryString(), containsString(binding.getName()));
+		}
 	}
 
 	private void assertPositionalBinding(Class<? extends ParameterBinding> bindingType, Integer position,

--- a/src/test/java/org/springframework/data/jpa/repository/sample/UserRepository.java
+++ b/src/test/java/org/springframework/data/jpa/repository/sample/UserRepository.java
@@ -489,6 +489,10 @@ public interface UserRepository
 	// DATAJPA-858
 	List<User> findByRolesNameContaining(String name);
 
+	// DATAJPA-1179
+	@Query("select u from User u where u.firstname = :#{#firstname} and u.firstname = :#{#firstname}")
+	List<User> findUsersByDuplicateSpel(@Param("firstname") String firstname);
+
 	List<RolesAndFirstname> findRolesAndFirstnameBy();
 
 	// DATAJPA-1172


### PR DESCRIPTION
Before a duplicate SpEL created one placeholder but multiple bindings resulting in exceptions during parameter binding.

This is #220 moved to master. The polishing commit is mostly gone since the polishing already happened as part of DATAJPA-1140.