### PR TITLE
DATAJPA-1192 - Some JavaDocs and package-infos are not up-to-date

### DIFF
--- a/src/main/java/org/springframework/data/jpa/convert/threeten/package-info.java
+++ b/src/main/java/org/springframework/data/jpa/convert/threeten/package-info.java
@@ -1,5 +1,4 @@
 /**
  * Spring Data JPA specific JSR-310 converters.
  */
-@org.springframework.lang.NonNullApi
 package org.springframework.data.jpa.convert.threeten;

--- a/src/main/java/org/springframework/data/jpa/repository/package-info.java
+++ b/src/main/java/org/springframework/data/jpa/repository/package-info.java
@@ -1,7 +1,5 @@
 /**
  * Interfaces and annotations for JPA specific repositories.
  */
-@NonNullApi
+@org.springframework.lang.NonNullApi
 package org.springframework.data.jpa.repository;
-
-import org.springframework.lang.NonNullApi;

--- a/src/main/java/org/springframework/data/jpa/repository/query/JpaCountQueryCreator.java
+++ b/src/main/java/org/springframework/data/jpa/repository/query/JpaCountQueryCreator.java
@@ -39,9 +39,9 @@ public class JpaCountQueryCreator extends JpaQueryCreator {
 	 * Creates a new {@link JpaCountQueryCreator}.
 	 * 
 	 * @param tree
-	 * @param domainClass
-	 * @param parameters
-	 * @param em
+	 * @param type
+	 * @param builder
+	 * @param provider
 	 */
 	public JpaCountQueryCreator(PartTree tree, ReturnedType type, CriteriaBuilder builder,
 			ParameterMetadataProvider provider) {

--- a/src/main/java/org/springframework/data/jpa/repository/query/JpaQueryCreator.java
+++ b/src/main/java/org/springframework/data/jpa/repository/query/JpaQueryCreator.java
@@ -139,7 +139,7 @@ public class JpaQueryCreator extends AbstractQueryCreator<CriteriaQuery<? extend
 
 	/**
 	 * Finalizes the given {@link Predicate} and applies the given sort. Delegates to
-	 * {@link #complete(Predicate, Sort, CriteriaQuery, CriteriaBuilder)} and hands it the current {@link CriteriaQuery}
+	 * {@link #complete(Predicate, Sort, CriteriaQuery, CriteriaBuilder, Root)} and hands it the current {@link CriteriaQuery}
 	 * and {@link CriteriaBuilder}.
 	 */
 	@Override
@@ -200,7 +200,6 @@ public class JpaQueryCreator extends AbstractQueryCreator<CriteriaQuery<? extend
 	 *
 	 * @param part
 	 * @param root
-	 * @param iterator
 	 * @return
 	 */
 	private Predicate toPredicate(Part part, Root<?> root) {

--- a/src/main/java/org/springframework/data/jpa/repository/query/JpaQueryLookupStrategy.java
+++ b/src/main/java/org/springframework/data/jpa/repository/query/JpaQueryLookupStrategy.java
@@ -21,6 +21,7 @@ import javax.persistence.EntityManager;
 
 import org.springframework.data.jpa.provider.PersistenceProvider;
 import org.springframework.data.jpa.provider.QueryExtractor;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.projection.ProjectionFactory;
 import org.springframework.data.repository.core.NamedQueries;
 import org.springframework.data.repository.core.RepositoryMetadata;
@@ -61,7 +62,6 @@ public final class JpaQueryLookupStrategy {
 		 *
 		 * @param em
 		 * @param extractor
-		 * @param evaluationContextProvider
 		 */
 		public AbstractQueryLookupStrategy(EntityManager em, QueryExtractor extractor) {
 
@@ -192,7 +192,6 @@ public final class JpaQueryLookupStrategy {
 		 * @param extractor
 		 * @param createStrategy
 		 * @param lookupStrategy
-		 * @param evaluationContextProvider
 		 */
 		public CreateIfNotFoundQueryLookupStrategy(EntityManager em, QueryExtractor extractor,
 				CreateQueryLookupStrategy createStrategy, DeclaredQueryLookupStrategy lookupStrategy) {

--- a/src/main/java/org/springframework/data/jpa/repository/query/SimpleJpaQuery.java
+++ b/src/main/java/org/springframework/data/jpa/repository/query/SimpleJpaQuery.java
@@ -72,7 +72,7 @@ final class SimpleJpaQuery extends AbstractStringBasedJpaQuery {
 	 * Validates the given query for syntactical correctness.
 	 * 
 	 * @param query
-	 * @param em
+	 * @param errorMessage
 	 */
 	private void validateQuery(String query, String errorMessage) {
 

--- a/src/main/java/org/springframework/data/jpa/repository/query/package-info.java
+++ b/src/main/java/org/springframework/data/jpa/repository/query/package-info.java
@@ -1,7 +1,5 @@
 /**
  * Query implementation to exectue queries against JPA.
  */
-@NonNullApi
+@org.springframework.lang.NonNullApi
 package org.springframework.data.jpa.repository.query;
-
-import org.springframework.lang.NonNullApi;

--- a/src/main/java/org/springframework/data/jpa/support/ClasspathScanningPersistenceUnitPostProcessor.java
+++ b/src/main/java/org/springframework/data/jpa/support/ClasspathScanningPersistenceUnitPostProcessor.java
@@ -144,7 +144,7 @@ public class ClasspathScanningPersistenceUnitPostProcessor
 	 * an empty {@link Set} in case no {@link ResourceLoader} or mapping file name pattern was configured. Resulting paths
 	 * are resource-loadable from the application classpath according to the JPA spec.
 	 * 
-	 * @see javax.persistence.spi.PersistenceUnitInfo.PersistenceUnitInfo#getMappingFileNames()
+	 * @see javax.persistence.spi.PersistenceUnitInfo#getMappingFileNames()
 	 * @return
 	 */
 	private Set<String> scanForMappingFileLocations() {


### PR DESCRIPTION
This PR corrects some JavaDocs which point to variables not existing (anymore) and other way around. It also fixes some broken @link references in the JavaDocs. At least it removes one a @NonNullApi annotation from package-info file where affected class methods may return null.
