### PR TITLE
DATAJPA-1205 - Reinstantiate entity manager injection in QueryDslRepositorySupport.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-jpa</artifactId>
-	<version>1.11.9.BUILD-SNAPSHOT</version>
+	<version>1.11.9.DATAJPA-1205-SNAPSHOT</version>
 
 	<name>Spring Data JPA</name>
 	<description>Spring Data module for JPA repositories.</description>

--- a/src/main/java/org/springframework/data/jpa/repository/support/QueryDslRepositorySupport.java
+++ b/src/main/java/org/springframework/data/jpa/repository/support/QueryDslRepositorySupport.java
@@ -18,6 +18,7 @@ package org.springframework.data.jpa.repository.support;
 import javax.annotation.PostConstruct;
 import javax.persistence.EntityManager;
 
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Repository;
 import org.springframework.util.Assert;
 
@@ -60,6 +61,7 @@ public abstract class QueryDslRepositorySupport {
 	 * 
 	 * @param entityManager must not be {@literal null}.
 	 */
+	@Autowired
 	public void setEntityManager(EntityManager entityManager) {
 
 		Assert.notNull(entityManager, "EntityManager must not be null!");

--- a/src/test/java/org/springframework/data/jpa/repository/support/QueryDslRepositorySupportIntegrationTests.java
+++ b/src/test/java/org/springframework/data/jpa/repository/support/QueryDslRepositorySupportIntegrationTests.java
@@ -38,7 +38,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 /**
  * Integration test for the setup of beans extending {@link QueryDslRepositorySupport}.
- * 
+ *
  * @author Oliver Gierke
  * @author Thomas Darimont
  * @author Mark Paluch
@@ -60,6 +60,11 @@ public class QueryDslRepositorySupportIntegrationTests {
 					super.setEntityManager(entityManager);
 				}
 			};
+		}
+
+		@Bean
+		EntityManagerBeanDefinitionRegistrarPostProcessor entityManagerBeanDefinitionRegistrarPostProcessor() {
+			return new EntityManagerBeanDefinitionRegistrarPostProcessor();
 		}
 
 		@Bean

--- a/src/test/java/org/springframework/data/jpa/repository/support/QueryDslRepositorySupportIntegrationTests.java
+++ b/src/test/java/org/springframework/data/jpa/repository/support/QueryDslRepositorySupportIntegrationTests.java
@@ -41,6 +41,7 @@ import org.springframework.transaction.annotation.Transactional;
  * 
  * @author Oliver Gierke
  * @author Thomas Darimont
+ * @author Mark Paluch
  */
 @Transactional
 @ContextConfiguration
@@ -67,6 +68,11 @@ public class QueryDslRepositorySupportIntegrationTests {
 		}
 
 		@Bean
+		public CustomRepoUsingQueryDsl customRepo() {
+			return new CustomRepoUsingQueryDsl();
+		}
+
+		@Bean
 		public EntityManagerContainer entityManagerContainer() {
 			return new EntityManagerContainer();
 		}
@@ -82,6 +88,7 @@ public class QueryDslRepositorySupportIntegrationTests {
 	}
 
 	@Autowired UserRepository repository;
+	@Autowired CustomRepoUsingQueryDsl querydslCustom;
 	@Autowired ReconfiguringUserRepositoryImpl reconfiguredRepo;
 
 	@PersistenceContext(unitName = "querydsl") EntityManager em;
@@ -96,6 +103,13 @@ public class QueryDslRepositorySupportIntegrationTests {
 
 		assertThat(reconfiguredRepo, is(notNullValue()));
 		assertThat(reconfiguredRepo.getEntityManager().getEntityManagerFactory(), is(em.getEntityManagerFactory()));
+	}
+
+	@Test // DATAJPA-1205
+	public void createsRepositoryWithCustomImplementationUsingQueryDsl() {
+
+		assertThat(querydslCustom, is(notNullValue()));
+		assertThat(querydslCustom.getEntityManager().getEntityManagerFactory(), is(em.getEntityManagerFactory()));
 	}
 
 	static class ReconfiguringUserRepositoryImpl extends QueryDslRepositorySupport {
@@ -114,5 +128,12 @@ public class QueryDslRepositorySupportIntegrationTests {
 	static class EntityManagerContainer {
 
 		@PersistenceContext(unitName = "querydsl") EntityManager em;
+	}
+
+	static class CustomRepoUsingQueryDsl extends QueryDslRepositorySupport {
+
+		public CustomRepoUsingQueryDsl() {
+			super(User.class);
+		}
 	}
 }


### PR DESCRIPTION
We now reinstantiated entity manager injection in QueryDslRepositorySupport using @AutoWired.

Previously, we removed dependency injection through @PersistenceContext to avoid bootstrap errors caused by class scanning in application containers signaled by deployment annotation use.

---

Related tickets: [DATAJPA-1205](https://jira.spring.io/browse/DATAJPA-1205), [DATAJPA-1175](https://jira.spring.io/browse/DATAJPA-1175)