### PR TITLE
DATAJPA-1208 - Better memory management

### DIFF
--- a/src/main/java/org/springframework/data/jpa/repository/query/AbstractJpaQuery.java
+++ b/src/main/java/org/springframework/data/jpa/repository/query/AbstractJpaQuery.java
@@ -272,7 +272,6 @@ public abstract class AbstractJpaQuery implements RepositoryQuery {
 			}
 
 			Tuple tuple = (Tuple) source;
-			Map<String, Object> result = new HashMap<>();
 			List<TupleElement<?>> elements = tuple.getElements();
 
 			if (elements.size() == 1) {
@@ -284,6 +283,7 @@ public abstract class AbstractJpaQuery implements RepositoryQuery {
 				}
 			}
 
+			Map<String, Object> result = new HashMap<>();
 			for (TupleElement<?> element : elements) {
 
 				String alias = element.getAlias();

--- a/src/main/java/org/springframework/data/jpa/repository/query/JpaQueryMethod.java
+++ b/src/main/java/org/springframework/data/jpa/repository/query/JpaQueryMethod.java
@@ -155,11 +155,11 @@ public class JpaQueryMethod extends QueryMethod {
 	 */
 	List<QueryHint> getHints() {
 
-		List<QueryHint> result = new ArrayList<>();
+		List<QueryHint> result = Collections.emptyList();
 
 		QueryHints hints = AnnotatedElementUtils.findMergedAnnotation(method, QueryHints.class);
 		if (hints != null) {
-			result.addAll(Arrays.asList(hints.value()));
+			result = Arrays.asList(hints.value());
 		}
 
 		return result;

--- a/src/main/java/org/springframework/data/jpa/repository/query/PartTreeJpaQuery.java
+++ b/src/main/java/org/springframework/data/jpa/repository/query/PartTreeJpaQuery.java
@@ -156,12 +156,11 @@ public class PartTreeJpaQuery extends AbstractJpaQuery {
 				parameterBinder = getBinder(expressions);
 			}
 
-			TypedQuery<?> jpaQuery = createQuery(criteriaQuery);
-
 			if (parameterBinder == null) {
 				throw new IllegalStateException("ParameterBinder is null!");
 			}
 
+			TypedQuery<?> jpaQuery = createQuery(criteriaQuery);
 			return restrictMaxResultsIfNecessary(invokeBinding(parameterBinder, jpaQuery, values));
 		}
 


### PR DESCRIPTION
`AbstractJpaQuery`: `HashMap` created in line 275 is not used in case of fast return in line 282.
`List` returned by `JpaQueryMethod.getHints()` is only read from, so first it can be initialised with Collections.emptyList
`PartTreeJpaQuery`: `TypedQUery` created in line 159 is useless if exception is thrown, so we it should be instantiated only when we made sure it will be used