### PR TITLE
DATAJPA-931 - Avoid unnecessary merging on save.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-jpa</artifactId>
-	<version>2.1.0.BUILD-SNAPSHOT</version>
+	<version>2.1.0.DATAJPA-931-SNAPSHOT</version>
 
 	<name>Spring Data JPA</name>
 	<description>Spring Data module for JPA repositories.</description>

--- a/src/main/java/org/springframework/data/jpa/repository/support/SimpleJpaRepository.java
+++ b/src/main/java/org/springframework/data/jpa/repository/support/SimpleJpaRepository.java
@@ -66,6 +66,7 @@ import org.springframework.util.Assert;
  * @author Mark Paluch
  * @author Christoph Strobl
  * @author Stefan Fussenegger
+ * @author Jens Schauder
  * @param <T> the type of the entity to handle
  * @param <ID> the type of the entity's identifier
  */
@@ -487,9 +488,11 @@ public class SimpleJpaRepository<T, ID> implements JpaRepositoryImplementation<T
 		if (entityInformation.isNew(entity)) {
 			em.persist(entity);
 			return entity;
-		} else {
+		} else if (!em.contains(entity)) {
 			return em.merge(entity);
 		}
+
+		return entity;
 	}
 
 	/*

--- a/src/test/java/org/springframework/data/jpa/domain/support/AuditingEntityListenerTests.java
+++ b/src/test/java/org/springframework/data/jpa/domain/support/AuditingEntityListenerTests.java
@@ -41,6 +41,7 @@ import org.springframework.transaction.annotation.Transactional;
  * Integration test for {@link AuditingEntityListener}.
  *
  * @author Oliver Gierke
+ * @author Jens Schauder
  */
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration("classpath:auditing/auditing-entity-listener.xml")
@@ -89,7 +90,7 @@ public class AuditingEntityListenerTests {
 		role.setName("ADMIN");
 
 		user.addRole(role);
-		repository.save(user);
+		repository.flush();
 		role = user.getRoles().iterator().next();
 
 		assertDatesSet(user);

--- a/src/test/java/org/springframework/data/jpa/repository/support/SimpleJpaRepositoryUnitTests.java
+++ b/src/test/java/org/springframework/data/jpa/repository/support/SimpleJpaRepositoryUnitTests.java
@@ -44,6 +44,7 @@ import org.springframework.data.repository.CrudRepository;
  * @author Oliver Gierke
  * @author Thomas Darimont
  * @author Mark Paluch
+ * @author Jens Schauder
  */
 @RunWith(MockitoJUnitRunner.Silent.class)
 public class SimpleJpaRepositoryUnitTests {
@@ -130,5 +131,29 @@ public class SimpleJpaRepositoryUnitTests {
 		repo.findById(id);
 
 		verify(em).find(User.class, id, singletonMap(EntityGraphType.LOAD.getKey(), (Object) entityGraph));
+	}
+
+	@Test // DATAJPA-931
+	public void mergeGetsCalledWhenDetached() {
+
+		User detachedUser = new User();
+
+		when(em.contains(detachedUser)).thenReturn(false);
+
+		repo.save(detachedUser);
+
+		verify(em).merge(detachedUser);
+	}
+
+	@Test // DATAJPA-931
+	public void mergeGetsNotCalledWhenAttached() {
+
+		User attachedUser = new User();
+
+		when(em.contains(attachedUser)).thenReturn(true);
+
+		repo.save(attachedUser);
+
+		verify(em, never()).merge(attachedUser);
 	}
 }


### PR DESCRIPTION
Checking if entity is already attached to entity manager before calling merge.
    
Fixed one test that was relying on the implicit flush triggered by the save.

See also: https://vladmihalcea.com/2016/07/19/jpa-persist-and-merge/