### PR TITLE
 DATAJPA-1261 - Revert DATAJPA-931.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-jpa</artifactId>
-	<version>2.1.0.BUILD-SNAPSHOT</version>
+	<version>2.1.0.DATAJPA-1261-SNAPSHOT</version>
 
 	<name>Spring Data JPA</name>
 	<description>Spring Data module for JPA repositories.</description>

--- a/src/main/java/org/springframework/data/jpa/repository/support/SimpleJpaRepository.java
+++ b/src/main/java/org/springframework/data/jpa/repository/support/SimpleJpaRepository.java
@@ -488,11 +488,9 @@ public class SimpleJpaRepository<T, ID> implements JpaRepositoryImplementation<T
 		if (entityInformation.isNew(entity)) {
 			em.persist(entity);
 			return entity;
-		} else if (!em.contains(entity)) {
+		} else {
 			return em.merge(entity);
 		}
-
-		return entity;
 	}
 
 	/*

--- a/src/test/java/org/springframework/data/jpa/repository/support/SimpleJpaRepositoryUnitTests.java
+++ b/src/test/java/org/springframework/data/jpa/repository/support/SimpleJpaRepositoryUnitTests.java
@@ -145,8 +145,8 @@ public class SimpleJpaRepositoryUnitTests {
 		verify(em).merge(detachedUser);
 	}
 
-	@Test // DATAJPA-931
-	public void mergeGetsNotCalledWhenAttached() {
+	@Test // DATAJPA-931, DATAJPA-1261
+	public void mergeGetsCalledWhenAttached() {
 
 		User attachedUser = new User();
 
@@ -154,6 +154,6 @@ public class SimpleJpaRepositoryUnitTests {
 
 		repo.save(attachedUser);
 
-		verify(em, never()).merge(attachedUser);
+		verify(em).merge(attachedUser);
 	}
 }


### PR DESCRIPTION
This reverts the functional change made by DATAJPA-931.
This means merge will be called again, even if the entity for which save was called is already attached to the session.
Tests stay in place to verify the new old behavior.