### PR TITLE
DATAJPA-1250 - Inspect repository interfaces in isolated classloader.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-jpa</artifactId>
-	<version>2.1.0.BUILD-SNAPSHOT</version>
+	<version>2.1.0.DATAJPA-1250-SNAPSHOT</version>
 
 	<name>Spring Data JPA</name>
 	<description>Spring Data module for JPA repositories.</description>
@@ -24,7 +24,7 @@
 		<eclipselink>2.6.5</eclipselink>
 		<hibernate>5.2.13.Final</hibernate>
 		<jpa>2.0.0</jpa>
-		<springdata.commons>2.1.0.BUILD-SNAPSHOT</springdata.commons>
+		<springdata.commons>2.1.0.DATACMNS-1263-SNAPSHOT</springdata.commons>
 
 		<java-module-name>spring.data.jpa</java-module-name>
 

--- a/src/main/java/org/springframework/data/jpa/repository/config/InspectionClassLoader.java
+++ b/src/main/java/org/springframework/data/jpa/repository/config/InspectionClassLoader.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.jpa.repository.config;
+
+import org.springframework.instrument.classloading.ShadowingClassLoader;
+
+/**
+ * Disposable {@link ClassLoader} used to inspect user-code classes within an isolated class loader without preventing
+ * class transformation at a later time.
+ *
+ * @author Mark Paluch
+ * @since 2.1
+ */
+class InspectionClassLoader extends ShadowingClassLoader {
+
+	/**
+	 * Create a new {@link InspectionClassLoader} instance.
+	 *
+	 * @param parent the parent classloader.
+	 */
+	InspectionClassLoader(ClassLoader parent) {
+
+		super(parent, true);
+
+		excludePackage("org.springframework.");
+	}
+}

--- a/src/test/java/org/springframework/data/jpa/repository/config/InspectionClassLoaderUnitTests.java
+++ b/src/test/java/org/springframework/data/jpa/repository/config/InspectionClassLoaderUnitTests.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.jpa.repository.config;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.Test;
+
+/**
+ * Unit tests for {@link InspectionClassLoader}.
+ *
+ * @author Mark Paluch
+ */
+public class InspectionClassLoaderUnitTests {
+
+	@Test // DATAJPA-1250
+	public void shouldLoadExternalClass() throws ClassNotFoundException {
+
+		InspectionClassLoader classLoader = new InspectionClassLoader(getClass().getClassLoader());
+
+		Class<?> isolated = classLoader.loadClass("org.hsqldb.Database");
+		Class<?> included = getClass().getClassLoader().loadClass("org.hsqldb.Database");
+
+		assertThat(isolated.getClassLoader()).isSameAs(classLoader).isNotSameAs(getClass().getClassLoader());
+		assertThat(isolated).isNotEqualTo(included);
+	}
+}


### PR DESCRIPTION
We now load repository interfaces for configuration inspection (i.e. for strict mode verification) within an isolated, throw-away classloader if Spring Instrumentation or EclipseLink are on the class path. Loading interfaces and hence domain classes in an isolated classloader does not prevent load-time weaving during `EntityManagerFactoryBean` initialization since the domain class wasn't loaded by the application classloader.

---

Related ticket: [DATAJPA-1250](https://jira.spring.io/browse/DATAJPA-1250).
Depends on: https://github.com/spring-projects/spring-data-commons/pull/276.