### PR TITLE
Feature/datajpa 1277 additional extension point for simple jpa repository

### DIFF
--- a/src/main/java/org/springframework/data/jpa/repository/support/SimpleJpaRepository.java
+++ b/src/main/java/org/springframework/data/jpa/repository/support/SimpleJpaRepository.java
@@ -619,6 +619,21 @@ public class SimpleJpaRepository<T, ID> implements JpaRepositoryImplementation<T
 	 */
 	protected <S extends T> TypedQuery<S> getQuery(@Nullable Specification<S> spec, Class<S> domainClass, Sort sort) {
 
+		CriteriaQuery<S> query = buildCriteriaQuery(spec, domainClass, sort);
+		return applyRepositoryMethodMetadata(em.createQuery(query));
+	}
+
+	/**
+	 * Build the CriteriaQuery for {@link #getQuery(Specification, Sort)}. Enable extensability for all queries created
+	 * through {@link #getQuery} method calls
+	 *
+	 * @param @param spec can be {@literal null}.
+	 * @param domainClass must not be {@literal null}.
+	 * @param sort must not be {@literal null}.
+	 * @return the CriteriaQuery to be used by {@link #getQuery(Specification, Sort)} calls
+	 */
+	protected <S extends T> CriteriaQuery<S> buildCriteriaQuery(@Nullable Specification<S> spec, Class<S> domainClass,
+		Sort sort) {
 		CriteriaBuilder builder = em.getCriteriaBuilder();
 		CriteriaQuery<S> query = builder.createQuery(domainClass);
 
@@ -628,8 +643,7 @@ public class SimpleJpaRepository<T, ID> implements JpaRepositoryImplementation<T
 		if (sort.isSorted()) {
 			query.orderBy(toOrders(sort, root, builder));
 		}
-
-		return applyRepositoryMethodMetadata(em.createQuery(query));
+		return query;
 	}
 
 	/**
@@ -653,6 +667,20 @@ public class SimpleJpaRepository<T, ID> implements JpaRepositoryImplementation<T
 	 */
 	protected <S extends T> TypedQuery<Long> getCountQuery(@Nullable Specification<S> spec, Class<S> domainClass) {
 
+		CriteriaQuery<Long> query = buildCountCriteriaQuery(spec, domainClass);
+		return em.createQuery(query);
+	}
+
+	/**
+	 * Build the CriteriaQuery for {@link #getCountQuery(Specification, Class)}. Enable extensability for all queries created
+	 * through {@link #getCountQuery} method calls
+	 *
+	 * @param @param spec can be {@literal null}.
+	 * @param domainClass must not be {@literal null}.
+	 * @return the CriteriaQuery to be used by {@link #getQuery(Specification, Sort)} calls
+	 */
+	protected <S extends T> CriteriaQuery<Long> buildCountCriteriaQuery(@Nullable Specification<S> spec,
+		Class<S> domainClass) {
 		CriteriaBuilder builder = em.getCriteriaBuilder();
 		CriteriaQuery<Long> query = builder.createQuery(Long.class);
 
@@ -666,8 +694,7 @@ public class SimpleJpaRepository<T, ID> implements JpaRepositoryImplementation<T
 
 		// Remove all Orders the Specifications might have applied
 		query.orderBy(Collections.<Order> emptyList());
-
-		return em.createQuery(query);
+		return query;
 	}
 
 	/**

--- a/src/main/java/org/springframework/data/jpa/repository/support/SimpleJpaRepository.java
+++ b/src/main/java/org/springframework/data/jpa/repository/support/SimpleJpaRepository.java
@@ -66,7 +66,7 @@ import static org.springframework.data.jpa.repository.query.QueryUtils.*;
  * @author Christoph Strobl
  * @author Stefan Fussenegger
  * @author Jens Schauder
- * @author Thomas Zirke
+ * @author No Name
  * @param <T> the type of the entity to handle
  * @param <ID> the type of the entity's identifier
  */

--- a/src/main/java/org/springframework/data/jpa/repository/support/SimpleJpaRepository.java
+++ b/src/main/java/org/springframework/data/jpa/repository/support/SimpleJpaRepository.java
@@ -66,6 +66,7 @@ import static org.springframework.data.jpa.repository.query.QueryUtils.*;
  * @author Christoph Strobl
  * @author Stefan Fussenegger
  * @author Jens Schauder
+ * @author Thomas Zirke
  * @param <T> the type of the entity to handle
  * @param <ID> the type of the entity's identifier
  */


### PR DESCRIPTION
- made CriteriaQuery building for methods: "getQuery" and "getCountQuery" more extensible (protected methods extracted)
- allows for generic query modification while using the core SimpleJpaRepository functionality
- can reuse more logic from SimpleJpaRepository on extensions/derivations of this class
- feedback welcome

<!--

Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
Make sure that:

-->

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] There is a ticket in the bug tracker for the project in our [JIRA](https://jira.spring.io/browse/DATAJPA-1277).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [ ] You submit test cases (unit or integration tests) that back your changes.
Well - this was just a refactoring - not entirely sure what test cases I was supposed to add (suggestions are very welcome here)
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).

