### PR TITLE
DATAJPA-1284 - Use generated database names in tests. 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-jpa</artifactId>
-	<version>2.1.0.BUILD-SNAPSHOT</version>
+	<version>2.1.0.DATAJPA-1284-SNAPSHOT</version>
 
 	<name>Spring Data JPA</name>
 	<description>Spring Data module for JPA repositories.</description>

--- a/src/test/resources/infrastructure.xml
+++ b/src/test/resources/infrastructure.xml
@@ -26,7 +26,7 @@
 
 	<bean name="sampleEvaluationContextExtension" class="org.springframework.data.jpa.repository.sample.SampleEvaluationContextExtension"/>
 	
-	<jdbc:embedded-database id="dataSource" type="HSQL">
+	<jdbc:embedded-database id="dataSource" type="HSQL" generate-name="true">
 		<jdbc:script execution="INIT" separator="/;" location="classpath:scripts/hsqldb-init.sql"/>
 		<jdbc:script execution="INIT" separator="/;" location="classpath:scripts/schema-stored-procedures.sql"/>
 	</jdbc:embedded-database>

--- a/src/test/resources/multiple-entity-manager-integration-context.xml
+++ b/src/test/resources/multiple-entity-manager-integration-context.xml
@@ -27,7 +27,7 @@
 	<bean id="entityManagerFactory-2" parent="abstractEntityManagerFactory">
 		<property name="persistenceUnitName" value="second" />
 		<property name="dataSource">
-			<jdbc:embedded-database type="HSQL" />
+			<jdbc:embedded-database type="HSQL" generate-name="true"/>
 		</property>
 	</bean>
 

--- a/src/test/resources/openjpa.xml
+++ b/src/test/resources/openjpa.xml
@@ -21,5 +21,5 @@
 		make OpenJPA tests work. Open JPA doesn't work with hsqldb 2.x and runs with 
 		1.x instead which doesn't support stored procedures which leads to errors 
 		at runtime when the scripts/schema-stored-procedure.sql is executed, therefore we omit the script here. -->
-	<jdbc:embedded-database id="dataSource" type="HSQL" />
+	<jdbc:embedded-database id="dataSource" type="HSQL" generate-name="true"/>
 </beans>


### PR DESCRIPTION
Use a pseudo-random unique name for the embedded database as outlined in `EmbeddedDatabaseBuilder#generateUniqueName`.
