### PR TITLE
DATAJPA-1307 - JDBC style query parameters work for native queries. 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-jpa</artifactId>
-	<version>2.1.0.BUILD-SNAPSHOT</version>
+	<version>2.1.0.DATAJPA-13007-SNAPSHOT</version>
 
 	<name>Spring Data JPA</name>
 	<description>Spring Data module for JPA repositories.</description>

--- a/src/main/java/org/springframework/data/jpa/repository/query/AbstractStringBasedJpaQuery.java
+++ b/src/main/java/org/springframework/data/jpa/repository/query/AbstractStringBasedJpaQuery.java
@@ -64,6 +64,9 @@ abstract class AbstractStringBasedJpaQuery extends AbstractJpaQuery {
 		this.countQuery = query.deriveCountQuery(method.getCountQuery(), method.getCountQueryProjection());
 
 		this.parser = parser;
+
+		Assert.isTrue(method.isNativeQuery() || !query.usesJdbcStyleParameters(),
+				"JDBC style parameters (?) are not supported for JPA queries.");
 	}
 
 	/*

--- a/src/main/java/org/springframework/data/jpa/repository/query/DeclaredQuery.java
+++ b/src/main/java/org/springframework/data/jpa/repository/query/DeclaredQuery.java
@@ -83,4 +83,11 @@ interface DeclaredQuery {
 	 * @return a new {@literal DeclaredQuery} instance.
 	 */
 	DeclaredQuery deriveCountQuery(@Nullable String countQuery, @Nullable String countQueryProjection);
+
+	/**
+	 * Returns wether the query uses JDBC style parameters, i.e. parameters denoted by a simple ? without any index or name.
+	 *
+	 * @return Wether the query uses JDBC style parameters.
+	 */
+	boolean usesJdbcStyleParameters();
 }

--- a/src/main/java/org/springframework/data/jpa/repository/query/EmptyDeclaredQuery.java
+++ b/src/main/java/org/springframework/data/jpa/repository/query/EmptyDeclaredQuery.java
@@ -99,4 +99,13 @@ class EmptyDeclaredQuery implements DeclaredQuery {
 
 		return DeclaredQuery.of(countQuery);
 	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.jpa.repository.query.DeclaredQuery#usesJdbcStyleParameters()
+	 */
+	@Override
+	public boolean usesJdbcStyleParameters() {
+		return false;
+	}
 }

--- a/src/main/java/org/springframework/data/jpa/repository/query/StringQuery.java
+++ b/src/main/java/org/springframework/data/jpa/repository/query/StringQuery.java
@@ -53,6 +53,7 @@ class StringQuery implements DeclaredQuery {
 	private final List<ParameterBinding> bindings;
 	private final @Nullable String alias;
 	private final boolean hasConstructorExpression;
+	private final boolean usesJdbcStyleParameters;
 
 	/**
 	 * Creates a new {@link StringQuery} from the given JPQL query.
@@ -64,9 +65,11 @@ class StringQuery implements DeclaredQuery {
 		Assert.hasText(query, "Query must not be null or empty!");
 
 		this.bindings = new ArrayList<>();
+		Metadata queryMeta = new Metadata();
 		this.query = ParameterBindingParser.INSTANCE.parseParameterBindingsOfQueryIntoBindingsAndReturnCleanedQuery(query,
-				this.bindings);
+				this.bindings, queryMeta);
 
+		this.usesJdbcStyleParameters = queryMeta.usesJdbcStyleParameters;
 		this.alias = QueryUtils.detectAlias(query);
 		this.hasConstructorExpression = QueryUtils.hasConstructorExpression(query);
 	}
@@ -100,6 +103,15 @@ class StringQuery implements DeclaredQuery {
 
 		return DeclaredQuery
 				.of(countQuery != null ? countQuery : QueryUtils.createCountQueryFor(query, countQueryProjection));
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.jpa.repository.query.DeclaredQuery#usesJdbcStyleParameters()
+	 */
+	@Override
+	public boolean usesJdbcStyleParameters() {
+		return usesJdbcStyleParameters;
 	}
 
 	/*
@@ -158,7 +170,11 @@ class StringQuery implements DeclaredQuery {
 		INSTANCE;
 
 		static final String EXPRESSION_PARAMETER_PREFIX = "__$synthetic$__";
-		private static final Pattern PARAMETER_BINDING_BY_INDEX = Pattern.compile("\\?(\\d+)");
+		public static final String POSITIONAL_OR_INDEXED_PARAMETER = "\\?(\\d*+(?![#\\w]))";
+		// .....................................................................^ not followed by a hash or a letter.
+		// .................................................................^ zero or more digits.
+		// .............................................................^ start with a question mark.
+		private static final Pattern PARAMETER_BINDING_BY_INDEX = Pattern.compile(POSITIONAL_OR_INDEXED_PARAMETER);
 		private static final Pattern PARAMETER_BINDING_PATTERN;
 		private static final String MESSAGE = "Already found parameter binding with same index / parameter name but differing binding type! "
 				+ "Already have: %s, found %s! If you bind a parameter multiple times make sure they use the same binding.";
@@ -184,7 +200,7 @@ class StringQuery implements DeclaredQuery {
 			builder.append("(?: )?"); // some whitespace
 			builder.append("\\(?"); // optional braces around parameters
 			builder.append("(");
-			builder.append("%?(\\?(\\d+))%?"); // position parameter and parameter index
+			builder.append("%?(" + POSITIONAL_OR_INDEXED_PARAMETER + ")%?"); // position parameter and parameter index
 			builder.append("|"); // or
 
 			// named parameter and the parameter name
@@ -201,8 +217,8 @@ class StringQuery implements DeclaredQuery {
 		 * Parses {@link ParameterBinding} instances from the given query and adds them to the registered bindings. Returns
 		 * the cleaned up query.
 		 */
-		String parseParameterBindingsOfQueryIntoBindingsAndReturnCleanedQuery(String query,
-				List<ParameterBinding> bindings) {
+		String parseParameterBindingsOfQueryIntoBindingsAndReturnCleanedQuery(String query, List<ParameterBinding> bindings,
+				Metadata queryMeta) {
 
 			String result = query;
 			Matcher matcher = PARAMETER_BINDING_PATTERN.matcher(query);
@@ -227,6 +243,7 @@ class StringQuery implements DeclaredQuery {
 
 			QuotationMap quotationMap = new QuotationMap(query);
 
+			boolean usesJpaStyleParameters = false;
 			while (matcher.find()) {
 
 				if (quotationMap.isQuoted(matcher.start())) {
@@ -235,30 +252,50 @@ class StringQuery implements DeclaredQuery {
 
 				String parameterIndexString = matcher.group(INDEXED_PARAMETER_GROUP);
 				String parameterName = parameterIndexString != null ? null : matcher.group(NAMED_PARAMETER_GROUP);
-				Integer parameterIndex = parameterIndexString == null ? null : Integer.valueOf(parameterIndexString);
+				Integer parameterIndex = getParameterIndex(parameterIndexString);
+
 				String typeSource = matcher.group(COMPARISION_TYPE_GROUP);
 				String expression = null;
 				String replacement = null;
 
 				if (parameterName == null && parameterIndex == null) {
+
 					expressionParameterIndex++;
 
-					if (parametersShouldBeAccessedByIndex) {
+					if ("".equals(parameterIndexString)) {
+
 						parameterIndex = expressionParameterIndex;
-						replacement = "?" + parameterIndex;
+						queryMeta.usesJdbcStyleParameters = true;
 					} else {
-						parameterName = EXPRESSION_PARAMETER_PREFIX + expressionParameterIndex;
-						replacement = ":" + parameterName;
+
+						usesJpaStyleParameters = true;
+
+						if (parametersShouldBeAccessedByIndex) {
+
+							parameterIndex = expressionParameterIndex;
+							replacement = "?" + parameterIndex;
+						} else {
+
+							parameterName = EXPRESSION_PARAMETER_PREFIX + expressionParameterIndex;
+							replacement = ":" + parameterName;
+						}
 					}
 
 					expression = matcher.group(EXPRESSION_GROUP);
+				} else {
+					usesJpaStyleParameters = true;
 				}
 
+				if (usesJpaStyleParameters && queryMeta.usesJdbcStyleParameters) {
+					throw new IllegalArgumentException("Mixing of ? parameters and other forms like ?1 is not supported");
+				}
+
+				String replacementTarget = matcher.group(2);
 				switch (ParameterBindingType.of(typeSource)) {
 
 					case LIKE:
 
-						Type likeType = LikeParameterBinding.getLikeTypeFrom(matcher.group(2));
+						Type likeType = LikeParameterBinding.getLikeTypeFrom(replacementTarget);
 						replacement = replacement != null ? replacement : matcher.group(3);
 
 						if (parameterIndex != null) {
@@ -286,15 +323,25 @@ class StringQuery implements DeclaredQuery {
 
 						bindings.add(parameterIndex != null ? new ParameterBinding(null, parameterIndex, expression)
 								: new ParameterBinding(parameterName, null, expression));
+
 				}
 
 				if (replacement != null) {
-					result = replaceFirst(result, matcher.group(2), replacement);
+					result = replaceFirst(result, replacementTarget, replacement);
 				}
 
 			}
 
 			return result;
+		}
+
+		@Nullable
+		private Integer getParameterIndex(@Nullable String parameterIndexString) {
+
+			if (parameterIndexString == null || parameterIndexString.isEmpty()) {
+				return null;
+			}
+			return Integer.valueOf(parameterIndexString);
 		}
 
 		private static String replaceFirst(String text, String substring, String replacement) {
@@ -313,8 +360,12 @@ class StringQuery implements DeclaredQuery {
 
 			int greatestParameterIndex = -1;
 			while (parameterIndexMatcher.find()) {
+
 				String parameterIndexString = parameterIndexMatcher.group(1);
-				greatestParameterIndex = Math.max(greatestParameterIndex, Integer.parseInt(parameterIndexString));
+				Integer parameterIndex = getParameterIndex(parameterIndexString);
+				if (parameterIndex != null) {
+					greatestParameterIndex = Math.max(greatestParameterIndex, parameterIndex);
+				}
 			}
 
 			return greatestParameterIndex;
@@ -825,5 +876,9 @@ class StringQuery implements DeclaredQuery {
 		public boolean isQuoted(int index) {
 			return quotedRanges.stream().anyMatch(r -> r.contains(index));
 		}
+	}
+
+	static class Metadata {
+		private boolean usesJdbcStyleParameters = false;
 	}
 }

--- a/src/test/java/org/springframework/data/jpa/repository/UserRepositoryTests.java
+++ b/src/test/java/org/springframework/data/jpa/repository/UserRepositoryTests.java
@@ -2198,6 +2198,14 @@ public class UserRepositoryTests {
 		softly.assertAll();
 	}
 
+	@Test // DATAJPA-1307
+	public void testFindByEmailAddressJdbcStyleParameter() throws Exception {
+
+		flushTestUsers();
+
+		assertThat(repository.findByEmailNativeAddressJdbcStyleParameter("gierke@synyx.de")).isEqualTo(firstUser);
+	}
+
 	private Page<User> executeSpecWithSort(Sort sort) {
 
 		flushTestUsers();

--- a/src/test/java/org/springframework/data/jpa/repository/query/ParameterBindingParserUnitTests.java
+++ b/src/test/java/org/springframework/data/jpa/repository/query/ParameterBindingParserUnitTests.java
@@ -70,7 +70,8 @@ public class ParameterBindingParserUnitTests {
 	public void checkHasParameter(SoftAssertions softly, String query, boolean containsParameter, String label) {
 
 		List<ParameterBinding> bindings = new ArrayList<>();
-		ParameterBindingParser.INSTANCE.parseParameterBindingsOfQueryIntoBindingsAndReturnCleanedQuery(query, bindings);
+		ParameterBindingParser.INSTANCE.parseParameterBindingsOfQueryIntoBindingsAndReturnCleanedQuery(query, bindings,
+				new StringQuery.Metadata());
 		softly.assertThat(bindings.size()) //
 				.describedAs(String.format("<%s> (%s)", query, label)) //
 				.isEqualTo(containsParameter ? 1 : 0);

--- a/src/test/java/org/springframework/data/jpa/repository/query/SimpleJpaQueryUnitTests.java
+++ b/src/test/java/org/springframework/data/jpa/repository/query/SimpleJpaQueryUnitTests.java
@@ -16,8 +16,6 @@
 package org.springframework.data.jpa.repository.query;
 
 import static org.assertj.core.api.Assertions.*;
-import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.assertThat;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
@@ -33,6 +31,7 @@ import javax.persistence.Tuple;
 import javax.persistence.TypedQuery;
 import javax.persistence.metamodel.Metamodel;
 
+import org.assertj.core.api.Assertions;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -113,7 +112,7 @@ public class SimpleJpaQueryUnitTests {
 		SimpleJpaQuery jpaQuery = new SimpleJpaQuery(method, em, "select u from User u", EVALUATION_CONTEXT_PROVIDER,
 				PARSER);
 
-		assertThat(jpaQuery.createCountQuery(new Object[] {}), is((javax.persistence.Query) typedQuery));
+		assertThat(jpaQuery.createCountQuery(new Object[] {})).isEqualTo((javax.persistence.Query) typedQuery);
 	}
 
 	@Test // DATAJPA-77
@@ -141,7 +140,7 @@ public class SimpleJpaQueryUnitTests {
 		AbstractJpaQuery jpaQuery = JpaQueryFactory.INSTANCE.fromQueryAnnotation(queryMethod, em,
 				EVALUATION_CONTEXT_PROVIDER);
 
-		assertThat(jpaQuery instanceof NativeJpaQuery, is(true));
+		assertThat(jpaQuery instanceof NativeJpaQuery).isTrue();
 
 		when(em.createNativeQuery(anyString(), eq(User.class))).thenReturn(query);
 		when(metadata.getReturnedDomainClass(method)).thenReturn((Class) User.class);
@@ -186,14 +185,14 @@ public class SimpleJpaQueryUnitTests {
 	public void createsASimpleJpaQueryFromAnnotation() throws Exception {
 
 		RepositoryQuery query = createJpaQuery(SampleRepository.class.getMethod("findByAnnotatedQuery"));
-		assertThat(query instanceof SimpleJpaQuery, is(true));
+		assertThat(query instanceof SimpleJpaQuery).isTrue();
 	}
 
 	@Test
 	public void createsANativeJpaQueryFromAnnotation() throws Exception {
 
 		RepositoryQuery query = createJpaQuery(SampleRepository.class.getMethod("findNativeByLastname", String.class));
-		assertThat(query instanceof NativeJpaQuery, is(true));
+		assertThat(query instanceof NativeJpaQuery).isTrue();
 	}
 
 	@Test // DATAJPA-757

--- a/src/test/java/org/springframework/data/jpa/repository/query/StringQueryUnitTests.java
+++ b/src/test/java/org/springframework/data/jpa/repository/query/StringQueryUnitTests.java
@@ -61,7 +61,7 @@ public class StringQueryUnitTests {
 		assertThat(binding.hasName("firstname"), is(true));
 	}
 
-	@Test
+	@Test // DATAJPA-292
 	public void detectsPositionalLikeBindings() {
 
 		StringQuery query = new StringQuery("select u from User u where u.firstname like %?1% or u.lastname like %?2");
@@ -83,7 +83,7 @@ public class StringQueryUnitTests {
 		assertThat(binding.getType(), is(Type.ENDING_WITH));
 	}
 
-	@Test
+	@Test // DATAJPA-292
 	public void detectsNamedLikeBindings() {
 
 		StringQuery query = new StringQuery("select u from User u where u.firstname like %:firstname");

--- a/src/test/java/org/springframework/data/jpa/repository/sample/UserRepository.java
+++ b/src/test/java/org/springframework/data/jpa/repository/sample/UserRepository.java
@@ -544,6 +544,10 @@ public interface UserRepository
 	@Query("select firstname as firstname, lastname as lastname from User u where u.firstname = 'Oliver'")
 	Map<String, Object> findMapWithNullValues();
 
+	// DATAJPA-1307
+	@Query(value = "select * from SD_User u where u.emailAddress = ?", nativeQuery = true)
+	User findByEmailNativeAddressJdbcStyleParameter(String emailAddress);
+
 	interface RolesAndFirstname {
 
 		String getFirstname();


### PR DESCRIPTION
JDBC style query parameters denoted by a simple ? work for native queries.
They can't be used with JPA queries nor with other parameter formats like ?3, :name or SpEL parameters.