### PR TITLE
DATAJPA-1300 - Detection of EclipseLink through Proxies.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-jpa</artifactId>
-	<version>2.1.0.BUILD-SNAPSHOT</version>
+	<version>2.1.0.DATAJPA-1300-SNAPSHOT</version>
 
 	<name>Spring Data JPA</name>
 	<description>Spring Data module for JPA repositories.</description>


### PR DESCRIPTION
For parameter binding we check the JPA provider in order to work around some limitations of EclipseLink.
This check now works even when the Query instance under consideration is wrapped in a Proxy if that proxy exposes it's delegate upon call of unwrap(null).
This is the behavior of SharedEntityManagerCreator.DeferredQueryInvocationHandler.

I wasn't able to properly test this because it would require mocking getClass or actually coding a Query implementation in an org.eclipse package.