### PR TITLE
DATAJPA-1318 Make query projection regex case insensitive.

### DIFF
--- a/src/main/java/org/springframework/data/jpa/repository/query/QueryUtils.java
+++ b/src/main/java/org/springframework/data/jpa/repository/query/QueryUtils.java
@@ -74,6 +74,7 @@ import org.springframework.util.StringUtils;
  * @author Mark Paluch
  * @author Sébastien Péralta
  * @author Jens Schauder
+ * @author Nils Borrmann
  */
 public abstract class QueryUtils {
 
@@ -96,7 +97,7 @@ public abstract class QueryUtils {
 
 	private static final Pattern ALIAS_MATCH;
 	private static final Pattern COUNT_MATCH;
-	private static final Pattern PROJECTION_CLAUSE = Pattern.compile("select\\s+(.+)\\s+from");
+	private static final Pattern PROJECTION_CLAUSE = Pattern.compile("select\\s+(.+)\\s+from", Pattern.CASE_INSENSITIVE);
 
 	private static final Pattern NO_DIGITS = Pattern.compile("\\D+");
 

--- a/src/test/java/org/springframework/data/jpa/repository/query/StringQueryUnitTests.java
+++ b/src/test/java/org/springframework/data/jpa/repository/query/StringQueryUnitTests.java
@@ -37,6 +37,7 @@ import org.springframework.data.repository.query.parser.Part.Type;
  * @author Oliver Gierke
  * @author Thomas Darimont
  * @author Jens Schauder
+ * @author Nils Borrmann
  */
 public class StringQueryUnitTests {
 
@@ -314,7 +315,7 @@ public class StringQueryUnitTests {
 	@Test // DATAJPA-1235
 	public void getProjection() {
 
-		checkProjection("SELECT something FROM", "", "only lowercase is supported (!?)");
+		checkProjection("SELECT something FROM", "something", "uppercase is supported");
 		checkProjection("select something from", "something", "single expression");
 		checkProjection("select x, y, z from", "x, y, z", "tuple");
 		checkProjection("sect x, y, z from", "", "missing select");


### PR DESCRIPTION
The `PROJECTION_CLAUSE` regex in `QueryUtils` is case sensitive. This is inconsistent with the rest of the code and the documentation and leads to a bug when projecting the results of a native query. 


- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] There is a ticket in the bug tracker for the project in our [JIRA](https://jira.spring.io/browse/DATAJPA).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).

