### PR TITLE
Document workaround for missing QAbstractPersistable error in FAQs

### DIFF
--- a/src/main/asciidoc/faq.adoc
+++ b/src/main/asciidoc/faq.adoc
@@ -40,3 +40,37 @@ Currently I have implemented a repository layer based on `HibernateDaoSupport`. 
 
 [qanda]
 I want to use Spring Data JPA auditing capabilities but have my database already configured to set modification and creation date on entities. How can I prevent Spring Data from setting the date programmatically. :: Set the `set-dates` attribute of the `auditing` namespace element to `false`.
+
+== Querydsl
+
+Since version 2.0.x the querydsl classes `QAbstractPersistable` and `QAbstractAuditable` are not included in the *spring-data-jpa* jar anymore.
+
+This will probably lead to compile errors in the generated Q-classes, stating that a class `QAbstractPersistable` is missing.
+
+====
+[source, bash]
+----
+... cannot find symbol
+    public final org.springframework.data.jpa.domain.QAbstractPersistable _super = new org.springframework.data.jpa.domain.QAbstractPersistable(this);
+                                                    ^
+  symbol:   class QAbstractPersistable
+  location: package org.springframework.data.jpa.domain
+
+----
+====
+
+This problem can be fixed by providing a `package-info.java` in your domain package with the following content.
+
+====
+[source, java]
+----
+@QueryEntities(value = {AbstractPersistable.class, AbstractAuditable.class})
+package <your-domain-package>;
+
+import com.querydsl.core.annotations.QueryEntities;
+import org.springframework.data.jpa.domain.AbstractAuditable;
+import org.springframework.data.jpa.domain.AbstractPersistable;
+----
+====
+
+This will instruct the *querydsl/mysema apt-maven-plugin* to include the stated classes in the generation step.


### PR DESCRIPTION
DATAJPA-1282 - Added a section in the faq file to describe a possible workaround.

Providing a `package-info.java` in the domain package will fix the compile errors.
See: [sample project on github](https://github.com/KlausUnger-SoftwareCraftsmen/spring-data-jpa-querydsl-sample)
 
Issues: DATAJPA-1282

Signed-off-by: Klaus UNGER <klaus.unger@software-craftsmen.at>

<!--

Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
Make sure that:

-->

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] There is a ticket in the bug tracker for the project in our [JIRA](https://jira.spring.io/browse/DATAJPA).
- [ ] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [ ] You submit test cases (unit or integration tests) that back your changes.
- [ ] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).

