### PR TITLE
DATAJPA-1061 - Fix Sorting doesn't work for field alias.

### DIFF
--- a/src/main/java/org/springframework/data/jpa/repository/query/QueryUtils.java
+++ b/src/main/java/org/springframework/data/jpa/repository/query/QueryUtils.java
@@ -75,6 +75,7 @@ import org.springframework.util.StringUtils;
  * @author Sébastien Péralta
  * @author Jens Schauder
  * @author Nils Borrmann
+ * @author Grégoire Druant
  */
 public abstract class QueryUtils {
 
@@ -119,6 +120,7 @@ public abstract class QueryUtils {
 
 	private static final Pattern PUNCTATION_PATTERN = Pattern.compile(".*((?![\\._])[\\p{Punct}|\\s])");
 	private static final Pattern FUNCTION_PATTERN;
+	private static final Pattern FIELD_ALIAS_PATTERN;
 
 	private static final String UNSAFE_PROPERTY_REFERENCE = "Sort expression '%s' must only contain property references or "
 			+ "aliases used in the select clause. If you really want to use something other than that for sorting, please use "
@@ -174,6 +176,14 @@ public abstract class QueryUtils {
 		builder.append("\\s+[as|AS]+\\s+(([\\w\\.]+))"); // the potential alias
 
 		FUNCTION_PATTERN = compile(builder.toString());
+
+		builder = new StringBuilder();
+		builder.append("\\s+"); // at least one space
+		builder.append("[^\\s\\(\\)]+"); // No white char no bracket
+		builder.append("\\s+[as|AS]+\\s+(([\\w\\.]+))"); // the potential alias
+
+		FIELD_ALIAS_PATTERN = compile(builder.toString());
+
 	}
 
 	/**
@@ -250,10 +260,11 @@ public abstract class QueryUtils {
 		}
 
 		Set<String> aliases = getOuterJoinAliases(query);
-		Set<String> functionAliases = getFunctionAliases(query);
+		Set<String> fieldAliases = getFunctionAliases(query);
+		fieldAliases.addAll(getFieldAliases(query));
 
 		for (Order order : sort) {
-			builder.append(getOrderClause(aliases, functionAliases, alias, order)).append(", ");
+			builder.append(getOrderClause(aliases, fieldAliases, alias, order)).append(", ");
 		}
 
 		builder.delete(builder.length() - 2, builder.length());
@@ -270,14 +281,14 @@ public abstract class QueryUtils {
 	 * @param order the order object to build the clause for. Must not be {@literal null}.
 	 * @return a String containing a order clause. Guaranteed to be not {@literal null}.
 	 */
-	private static String getOrderClause(Set<String> joinAliases, Set<String> functionAlias, @Nullable String alias,
+	private static String getOrderClause(Set<String> joinAliases, Set<String> fieldAlias, @Nullable String alias,
 			Order order) {
 
 		String property = order.getProperty();
 
 		checkSortExpression(order);
 
-		if (functionAlias.contains(property)) {
+		if (fieldAlias.contains(property)) {
 			return String.format("%s %s", property, toJpaDirection(order));
 		}
 
@@ -316,6 +327,26 @@ public abstract class QueryUtils {
 			}
 		}
 
+		return result;
+	}
+
+	/**
+	 * Returns the aliases used for fields in the query.
+	 *
+	 * @param query a {@literal String} containing a query. Must not be {@literal null}.
+	 * @return a {@literal Set} containing all found aliases. Guaranteed to be not {@literal null}.
+	 */
+	private static Set<String> getFieldAliases(String query) {
+		Set<String> result = new HashSet<>();
+		Matcher matcher = FIELD_ALIAS_PATTERN.matcher(query);
+
+		while (matcher.find()) {
+			String alias = matcher.group(1);
+
+			if (StringUtils.hasText(alias)) {
+				result.add(alias);
+			}
+		}
 		return result;
 	}
 

--- a/src/test/java/org/springframework/data/jpa/repository/query/QueryUtilsUnitTests.java
+++ b/src/test/java/org/springframework/data/jpa/repository/query/QueryUtilsUnitTests.java
@@ -38,6 +38,7 @@ import org.springframework.data.jpa.domain.JpaSort;
  * @author Komi Innocent
  * @author Christoph Strobl
  * @author Jens Schauder
+ * @author Grégoire Druant
  */
 public class QueryUtilsUnitTests {
 
@@ -393,6 +394,30 @@ public class QueryUtilsUnitTests {
 
 		assertThat(QueryUtils.getExistsQueryString("entity", "x", Collections.singleton("id"))) //
 				.endsWith("WHERE x.id = :id");
+	}
+
+	@Test // DATAJPA-1061
+	public void appliesSortCorrectlyForFieldAliases() {
+		String query = "SELECT  m.price, lower(m.title) AS title, a.name as authorName   FROM Magazine   m INNER JOIN m.author a";
+		Sort sort = Sort.by("authorName");
+		String fullQuery = applySorting(query, sort);
+		assertThat(fullQuery, endsWith("order by authorName asc"));
+	}
+
+	@Test // DATAJPA-1061
+	public void appliesSortCorrectlyForFunctionAliases() {
+		String query = "SELECT  m.price, lower(m.title) AS title, a.name as authorName   FROM Magazine   m INNER JOIN m.author a";
+		Sort sort = Sort.by("title");
+		String fullQuery = applySorting(query, sort);
+		assertThat(fullQuery, endsWith("order by title asc"));
+	}
+
+	@Test // DATAJPA-1061
+	public void appliesSortCorrectlyForSimpleField() {
+		String query = "SELECT  m.price, lower(m.title) AS title, a.name as authorName   FROM Magazine   m INNER JOIN m.author a";
+		Sort sort = Sort.by("price");
+		String fullQuery = applySorting(query, sort);
+		assertThat(fullQuery, endsWith("order by m.price asc"));
 	}
 
 	private static void assertCountQuery(String originalQuery, String countQuery) {


### PR DESCRIPTION
Extract field aliases in QueryUtils and add them in the set of possible sort criterias, to enable the possibility to sort query results based on fields' aliases.

<!--

Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
Make sure that:

-->

- [*] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [*] There is a ticket in the bug tracker for the project in our [JIRA](https://jira.spring.io/browse/DATAJPA).
- [*] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [*] You submit test cases (unit or integration tests) that back your changes.
- [*] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).

