### PR TITLE
DATAJPA-1350 - Add utility to use JPA in a reactive environment.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-jpa</artifactId>
-	<version>2.1.0.BUILD-SNAPSHOT</version>
+	<version>2.1.0.DATAJPA-1350-SNAPSHOT</version>
 
 	<name>Spring Data JPA</name>
 	<description>Spring Data module for JPA repositories.</description>

--- a/pom.xml
+++ b/pom.xml
@@ -158,6 +158,18 @@
 		</dependency>
 
 		<dependency>
+			<groupId>io.projectreactor</groupId>
+			<artifactId>reactor-core</artifactId>
+			<optional>true</optional>
+		</dependency>
+
+		<dependency>
+			<groupId>io.projectreactor</groupId>
+			<artifactId>reactor-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
 			<groupId>org.aspectj</groupId>
 			<artifactId>aspectjrt</artifactId>
 			<version>${aspectj}</version>

--- a/src/main/java/org/springframework/data/jpa/support/BlockingRepositoryAdapter.java
+++ b/src/main/java/org/springframework/data/jpa/support/BlockingRepositoryAdapter.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.jpa.support;
+
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import java.util.function.Function;
+
+import org.springframework.data.repository.Repository;
+
+/**
+ * Adapter that allows usage of blocking {@link Repository repositories} to be integrated in a reactive and non-blocking
+ * flow. Some modules rely solely on blocking drivers and assume an imperative programming model. This adapter offloads
+ * its workload to an underlying {@link reactor.core.scheduler.Scheduler} to prevent blocking of the subscribing
+ * {@link Thread}.
+ * <p/>
+ * <strong>This {@link BlockingRepositoryAdapter} moves blocking behavior off the subscribing {@link Thread} to a
+ * dedicated {@link reactor.core.scheduler.Scheduler}. It does not solve the blocking aspect itself, it moves work to a
+ * place where it hurts less.</strong>
+ *
+ * @author Mark Paluch
+ * @since 2.1
+ * @see BlockingResourceAdapter
+ */
+public interface BlockingRepositoryAdapter {
+
+	/**
+	 * Read one or more entities using a {@link Repository}. The returned value is emitted upon completion through the
+	 * returned {@link Mono} which also allows multiple subscriptions to run the {@link Function} multiple times.
+	 * {@literal null} values returned by the {@link Function} are translated to {@link Mono#empty()}.
+	 *
+	 * @param function must not be {@literal null}.
+	 * @param <R> Repository type.
+	 * @param <T> return type.
+	 * @return a {@link Mono} that wraps execution of the given {@link Function}. Each subscription initiates a new
+	 *         execution of the function.
+	 */
+	<R extends Repository<?, ?>, T> Mono<T> read(R repository, Function<R, T> function);
+
+	/**
+	 * Read zero, one or more entities using a {@link Repository}. The returned value is emitted upon completion through
+	 * the returned {@link Flux} which also allows multiple subscriptions to run the {@link Function} multiple times.
+	 * {@literal null} values and empty {@link Iterable} returned by the {@link Function} are translated to
+	 * {@link Flux#empty()}.
+	 *
+	 * @param function must not be {@literal null}.
+	 * @param <R> Repository type.
+	 * @param <T> return type.
+	 * @return a {@link Flux} that wraps execution of the given {@link Function} by emitting all elements returned by the
+	 *         function. Each subscription initiates a new execution of the function.
+	 */
+	default <R extends Repository<?, ?>, T> Flux<T> readMany(R repository, Function<R, ? extends Iterable<T>> function) {
+		return read(repository, function).flatMapIterable(it -> it);
+	}
+}

--- a/src/main/java/org/springframework/data/jpa/support/BlockingResourceAdapter.java
+++ b/src/main/java/org/springframework/data/jpa/support/BlockingResourceAdapter.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.jpa.support;
+
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import java.util.function.Function;
+
+import javax.persistence.EntityManager;
+
+/**
+ * Adapter that allows usage of blocking resources to be integrated in a reactive and non-blocking flow. Some connection
+ * resources (such as JPA and JDBC) are blocking and assume an imperative programming model. This executor offloads its
+ * workload to an underlying {@link reactor.core.scheduler.Scheduler} to prevent blocking of the subscribing
+ * {@link Thread}.
+ * <p/>
+ * <strong>This {@link BlockingResourceAdapter} moves blocking behavior off the subscribing {@link Thread} to a
+ * dedicated {@link reactor.core.scheduler.Scheduler}. It does not solve the blocking aspect itself, it moves work to a
+ * place where it hurts less.</strong>
+ *
+ * @author Mark Paluch
+ * @param <B>
+ * @since 2.1
+ * @see BlockingRepositoryAdapter
+ */
+public interface BlockingResourceAdapter<B> {
+
+	/**
+	 * Read one or more entities using an {@link EntityManager} in a read-only transaction. The returned value is emitted
+	 * upon completion through the returned {@link Mono} which also allows multiple subscriptions to run the
+	 * {@link Function} multiple times. {@literal null} values returned by the {@link Function} are translated to
+	 * {@link Mono#empty()}.
+	 *
+	 * @param function must not be {@literal null}.
+	 * @param <T> return type.
+	 * @return a {@link Mono} that wraps execution of the given {@link Function}. Each subscription initiates a new
+	 *         execution of the function.
+	 */
+	<T> Mono<T> read(Function<B, T> function);
+
+	/**
+	 * Read zero, one or more entities using an {@link EntityManager} in a read-only transaction. The returned value is
+	 * emitted upon completion through the returned {@link Flux} which also allows multiple subscriptions to run the
+	 * {@link Function} multiple times. {@literal null} values and empty {@link Iterable} returned by the {@link Function}
+	 * are translated to {@link Flux#empty()}.
+	 *
+	 * @param function must not be {@literal null}.
+	 * @param <T> return type.
+	 * @return a {@link Flux} that wraps execution of the given {@link Function} by emitting all elements returned by the
+	 *         function. Each subscription initiates a new execution of the function.
+	 */
+	default <T> Flux<T> readMany(Function<B, ? extends Iterable<T>> function) {
+		return read(function).flatMapIterable(it -> it);
+	}
+}

--- a/src/main/java/org/springframework/data/jpa/support/DefaultJpaExecutor.java
+++ b/src/main/java/org/springframework/data/jpa/support/DefaultJpaExecutor.java
@@ -1,0 +1,299 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.jpa.support;
+
+import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Scheduler;
+
+import java.lang.reflect.UndeclaredThrowableException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+import javax.persistence.EntityManager;
+import javax.persistence.EntityManagerFactory;
+
+import org.springframework.data.repository.Repository;
+import org.springframework.lang.Nullable;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.TransactionDefinition;
+import org.springframework.transaction.TransactionStatus;
+import org.springframework.transaction.TransactionSystemException;
+import org.springframework.transaction.support.DefaultTransactionDefinition;
+import org.springframework.transaction.support.DelegatingTransactionDefinition;
+import org.springframework.util.Assert;
+
+/**
+ * Executor to use JPA's {@link EntityManager} and {@link org.springframework.data.jpa.repository.JpaRepository JPA
+ * repositories} in a reactive application. JPA and JDBC are inherently blocking and assuming an imperative programming
+ * model. This executor implementationoffloads its workload to an underlying {@link reactor.core.scheduler.Scheduler} to
+ * prevent blocking of the subscribing {@link Thread}.
+ * <p/>
+ * <strong>This {@link DefaultJpaExecutor} moves blocking behavior off the subscribing {@link Thread} to a dedicated
+ * {@link reactor.core.scheduler.Scheduler}. It does not solve the blocking aspect itself, it moves work to a place
+ * where it hurts less.</strong>
+ *
+ * @author Mark Paluch
+ * @see 2.1
+ * @see BlockingResourceAdapter
+ * @see BlockingRepositoryAdapter
+ */
+public class DefaultJpaExecutor implements JpaExecutor {
+
+	private final EntityManagerFactory entityManagerFactory;
+	private final PlatformTransactionManager transactionManager;
+	private final Scheduler scheduler;
+
+	/**
+	 * Create a new {@link DefaultJpaExecutor} given {@link EntityManagerFactory}, {@link PlatformTransactionManager}, and
+	 * {@link Scheduler}.
+	 *
+	 * @param entityManagerFactory must not be {@literal null}.
+	 * @param transactionManager must not be {@literal null}.
+	 * @param scheduler must not be {@literal null}.
+	 */
+	public DefaultJpaExecutor(EntityManagerFactory entityManagerFactory, PlatformTransactionManager transactionManager,
+			Scheduler scheduler) {
+
+		Assert.notNull(entityManagerFactory, "EntityManagerFactory must not be null!");
+		Assert.notNull(transactionManager, "PlatformTransactionManager must not be null!");
+		Assert.notNull(scheduler, "Scheduler must not be null!");
+
+		this.entityManagerFactory = entityManagerFactory;
+		this.transactionManager = transactionManager;
+		this.scheduler = scheduler;
+	}
+
+	/* (non-Javadoc)
+	 * @see org.springframework.data.jpa.support.BlockingResourceAdapter#read(Function)
+	 */
+	@Override
+	public <T> Mono<T> read(Function<EntityManager, T> function) {
+		return transactional().readOnly().doInTransaction(function);
+	}
+
+	/* (non-Javadoc)
+	 * @see org.springframework.data.jpa.support.BlockingRepositoryAdapter#read(R, Function)
+	 */
+	@Override
+	public <R extends Repository<?, ?>, T> Mono<T> read(R repository, Function<R, T> function) {
+		return transactional().readOnly().doInTransaction(repository, function);
+	}
+
+	@Override
+	public TransactionalJpaExecutor transactional() {
+		return new DefaultTransactionalJpaExecutor(entityManagerFactory, transactionManager, scheduler);
+	}
+
+	/**
+	 * Default JPA executor implementation executing JPA callbacks within a transactional scope.
+	 */
+	static class DefaultTransactionalJpaExecutor implements TransactionalJpaExecutor {
+
+		private final EntityManagerFactory entityManagerFactory;
+		private final PlatformTransactionManager transactionManager;
+		private final Scheduler scheduler;
+		private final TransactionDefinition transactionDefinition;
+		private final Set<Class<? extends Throwable>> rollbackOn;
+		private final Set<Class<? extends Throwable>> noRollbackOn;
+
+		DefaultTransactionalJpaExecutor(EntityManagerFactory entityManagerFactory,
+				PlatformTransactionManager transactionManager, Scheduler scheduler) {
+
+			this.entityManagerFactory = entityManagerFactory;
+			this.transactionManager = transactionManager;
+			this.scheduler = scheduler;
+			this.transactionDefinition = new DefaultTransactionDefinition();
+			this.rollbackOn = Collections.emptySet();
+			this.noRollbackOn = Collections.emptySet();
+		}
+
+		private DefaultTransactionalJpaExecutor(EntityManagerFactory entityManagerFactory,
+				PlatformTransactionManager transactionManager, Scheduler scheduler, TransactionDefinition transactionDefinition,
+				Set<Class<? extends Throwable>> rollbackOn, Set<Class<? extends Throwable>> noRollbackOn) {
+
+			this.entityManagerFactory = entityManagerFactory;
+			this.transactionManager = transactionManager;
+			this.scheduler = scheduler;
+			this.transactionDefinition = transactionDefinition;
+			this.rollbackOn = rollbackOn;
+			this.noRollbackOn = noRollbackOn;
+		}
+
+		/* (non-Javadoc)
+		 * @see org.springframework.data.jpa.support.JpaExecutor.TransactionalJpaExecutor#doInTransaction(Function)
+		 */
+		@Override
+		public <T> Mono<T> doInTransaction(Function<EntityManager, T> function) {
+			return Mono.defer(() -> Mono.fromFuture(createFuture(() -> doInTransactionImpl(function))));
+		}
+
+		@Nullable
+		private <T> T doInTransactionImpl(Function<EntityManager, T> function) {
+
+			return execute(ts -> {
+
+				EntityManager entityManager = entityManagerFactory.createEntityManager();
+				try {
+					return function.apply(entityManager);
+				} finally {
+					entityManager.close();
+				}
+			});
+		}
+
+		/* (non-Javadoc)
+		 * @see org.springframework.data.jpa.support.JpaExecutor.TransactionalJpaExecutor#doInTransaction(R, Function)
+		 */
+		@Override
+		public <R extends Repository<?, ?>, T> Mono<T> doInTransaction(R repository, Function<R, T> function) {
+			return Mono.defer(() -> Mono.fromFuture(createFuture(() -> doInTransactionImpl(repository, function))));
+		}
+
+		@Nullable
+		private <R extends Repository<?, ?>, T> T doInTransactionImpl(R repository, Function<R, T> function) {
+			return execute(ts -> function.apply(repository));
+		}
+
+		@Nullable
+		private <T> T execute(Function<TransactionStatus, T> callable) {
+
+			TransactionStatus status = this.transactionManager.getTransaction(transactionDefinition);
+			T result = null;
+			try {
+				result = callable.apply(status);
+			} catch (RuntimeException | Error ex) {
+
+				// Transactional code threw application exception -> rollback
+				if (!rollbackOnException(status, ex)) {
+					this.transactionManager.commit(status);
+				}
+
+				throw ex;
+			} catch (Throwable ex) {
+
+				// Transactional code threw unexpected exception -> rollback
+
+				if (!rollbackOnException(status, ex)) {
+					this.transactionManager.commit(status);
+				}
+
+				throw new UndeclaredThrowableException(ex, "TransactionCallback threw undeclared checked exception");
+			}
+			this.transactionManager.commit(status);
+			return result;
+		}
+
+		private boolean rollbackOnException(TransactionStatus status, Throwable ex) {
+
+			if (!rollbackOn.isEmpty()) {
+				if (rollbackOn.stream().noneMatch(it -> it.isInstance(ex))) {
+					return false;
+				}
+			} else if (noRollbackOn.stream().anyMatch(it -> it.isInstance(ex))) {
+				return false;
+			}
+
+			try {
+				this.transactionManager.rollback(status);
+			} catch (TransactionSystemException e) {
+				e.initApplicationException(ex);
+				throw e;
+			}
+
+			return true;
+		}
+
+		private <T> CompletableFuture<T> createFuture(Supplier<T> supplier) {
+
+			CompletableFuture<T> future = new CompletableFuture<>();
+			scheduler.schedule(() -> {
+
+				try {
+					future.complete(supplier.get());
+				} catch (Exception e) {
+					future.completeExceptionally(e);
+				}
+			});
+
+			return future;
+		}
+
+		/* (non-Javadoc)
+		 * @see org.springframework.data.jpa.support.JpaExecutor.TransactionalJpaExecutor#withRollbackOn(java.lang.Class[])
+		 */
+		@Override
+		@SafeVarargs
+		public final TransactionalJpaExecutor withRollbackOn(Class<? extends Throwable>... classes) {
+
+			Set<Class<? extends Throwable>> rollbackOn = new HashSet<>(this.rollbackOn.size() + classes.length);
+			rollbackOn.addAll(this.rollbackOn);
+			rollbackOn.addAll(Arrays.asList(classes));
+
+			return newExecutor(transactionDefinition, rollbackOn, noRollbackOn);
+		}
+
+		/* (non-Javadoc)
+		 * @see org.springframework.data.jpa.support.JpaExecutor.TransactionalJpaExecutor#withNoRollbackOn(java.lang.Class[])
+		 */
+		@Override
+		@SafeVarargs
+		public final TransactionalJpaExecutor withNoRollbackOn(Class<? extends Throwable>... classes) {
+
+			Set<Class<? extends Throwable>> noRollbackOn = new HashSet<>(this.noRollbackOn.size() + classes.length);
+			noRollbackOn.addAll(this.rollbackOn);
+			noRollbackOn.addAll(Arrays.asList(classes));
+
+			return newExecutor(transactionDefinition, rollbackOn, noRollbackOn);
+
+		}
+
+		/* (non-Javadoc)
+		 * @see org.springframework.data.jpa.support.JpaExecutor.TransactionalJpaExecutor#withTransaction(org.springframework.transaction.TransactionDefinition)
+		 */
+		@Override
+		public TransactionalJpaExecutor withTransaction(TransactionDefinition definition) {
+			return newExecutor(definition, rollbackOn, noRollbackOn);
+		}
+
+		/* (non-Javadoc)
+		 * @see org.springframework.data.jpa.support.JpaExecutor.TransactionalJpaExecutor#readOnly()
+		 */
+		@Override
+		public TransactionalJpaExecutor readOnly() {
+
+			TransactionDefinition transactionDefinition = new DelegatingTransactionDefinition(this.transactionDefinition) {
+
+				@Override
+				public boolean isReadOnly() {
+					return true;
+				}
+			};
+
+			return newExecutor(transactionDefinition, rollbackOn, noRollbackOn);
+		}
+
+		private DefaultTransactionalJpaExecutor newExecutor(TransactionDefinition transactionDefinition,
+				Set<Class<? extends Throwable>> rollbackOn, Set<Class<? extends Throwable>> noRollbackOn) {
+			return new DefaultTransactionalJpaExecutor(entityManagerFactory, transactionManager, scheduler,
+					transactionDefinition, rollbackOn, noRollbackOn);
+		}
+	}
+}

--- a/src/main/java/org/springframework/data/jpa/support/JpaExecutor.java
+++ b/src/main/java/org/springframework/data/jpa/support/JpaExecutor.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.jpa.support;
+
+import reactor.core.publisher.Mono;
+
+import java.util.function.Function;
+
+import javax.persistence.EntityManager;
+
+import org.springframework.data.repository.Repository;
+import org.springframework.transaction.TransactionDefinition;
+import org.springframework.transaction.TransactionStatus;
+import org.springframework.util.Assert;
+
+/**
+ * Executor to use JPA's {@link EntityManager} and {@link org.springframework.data.jpa.repository.JpaRepository JPA
+ * repositories} in a reactive application. JPA and JDBC are inherently blocking and assuming an imperative programming
+ * model. This executor offloads its workload to an underlying {@link reactor.core.scheduler.Scheduler} to prevent
+ * blocking of the subscribing {@link Thread}.
+ * <p/>
+ * <strong>This {@link JpaExecutor} moves blocking behavior off the subscribing thread to a dedicated
+ * {@link reactor.core.scheduler.Scheduler}. It does not solve the blocking aspect itself, it puts it to a place where
+ * it hurts less.</strong>
+ * <p/>
+ * This interface declares methods to interact with JPA within read-only and regular transactions. Transaction
+ * attributes are customizable through {@link #transactional()}. Methods of {@link TransactionalJpaExecutor} create
+ * immutable {@link TransactionalJpaExecutor} instances each.
+ *
+ * @author Mark Paluch
+ * @since 2.1
+ * @see BlockingResourceAdapter
+ * @see BlockingRepositoryAdapter
+ */
+public interface JpaExecutor extends BlockingResourceAdapter<EntityManager>, BlockingRepositoryAdapter {
+
+	/**
+	 * Obtain a {@link TransactionalJpaExecutor} object to customize transaction attributes in preparation of
+	 * transactional execution.
+	 *
+	 * @return the {@link TransactionalJpaExecutor}.
+	 */
+	TransactionalJpaExecutor transactional();
+
+	/**
+	 * Transaction JPA executor allowing customization of transaction attributes and executing callbacks for JPA
+	 * interaction within a transaction.
+	 * <p/>
+	 * {@code doInTransaction} execute the callback on a dedicated {@link reactor.core.scheduler.Scheduler} within a
+	 * managed transaction. Transactions are started before callback invocation and committed upon successful execution
+	 * (i.e. no {@link Exception} is thrown). By default, all {@link Exception}s cause a
+	 * {@link org.springframework.transaction.PlatformTransactionManager#rollback(TransactionStatus) rollback}. This
+	 * behavior can be customized through {@link #withNoRollbackOn(Class[])} and {@link #withRollbackOn(Class[])} methods.
+	 *
+	 * @author Mark Paluch
+	 * @since 2.1
+	 */
+	interface TransactionalJpaExecutor {
+
+		/**
+		 * Execute a callback {@link Function} that obtains access to a managed {@link EntityManager} enclosed in a
+		 * transaction.
+		 *
+		 * @param function must not be {@literal null}.
+		 * @return
+		 */
+		<T> Mono<T> doInTransaction(Function<EntityManager, T> function);
+
+		/**
+		 * Execute a callback {@link Function} that obtains access to a provided {@link Repository} enclosed in a
+		 * transaction.
+		 *
+		 * @param repository must not be {@literal null}.
+		 * @param function must not be {@literal null}.
+		 * @return
+		 */
+		<R extends Repository<?, ?>, T> Mono<T> doInTransaction(R repository, Function<R, T> function);
+
+		/**
+		 * Configure a read-only transaction.
+		 *
+		 * @return a new {@link TransactionalJpaExecutor} containing all previous settings and the configured read-only
+		 *         attribute.
+		 */
+		TransactionalJpaExecutor readOnly();
+
+		/**
+		 * Configure {@link Throwable exception types} that force a rollback.
+		 *
+		 * @param exceptionClass exception class to enforce a rollback.
+		 * @return a new {@link TransactionalJpaExecutor} containing all previous settings and the configured exception
+		 *         types.
+		 */
+		@SuppressWarnings("unchecked")
+		default TransactionalJpaExecutor withRollbackOn(Class<? extends Throwable> exceptionClass) {
+
+			Assert.notNull(exceptionClass, "Exception class must not be null!");
+
+			return withRollbackOn(new Class[] { exceptionClass });
+		}
+
+		/**
+		 * Configure {@link Throwable exception types} that force a rollback.
+		 *
+		 * @param classes exception classes to enforce a rollback.
+		 * @return a new {@link TransactionalJpaExecutor} containing all previous settings and the configured exception
+		 *         types.
+		 */
+		TransactionalJpaExecutor withRollbackOn(Class<? extends Throwable>... classes);
+
+		/**
+		 * Configure {@link Throwable exception types} that do not lead to a rollback.
+		 *
+		 * @param exceptionClass exception classe to exclude from rolllback.
+		 * @return a new {@link TransactionalJpaExecutor} containing all previous settings and the configured exception
+		 *         types.
+		 */
+		@SuppressWarnings("unchecked")
+		default TransactionalJpaExecutor withNoRollbackOn(Class<? extends Throwable> exceptionClass) {
+
+			Assert.notNull(exceptionClass, "Exception class must not be null!");
+
+			return withNoRollbackOn(new Class[] { exceptionClass });
+		}
+
+		/**
+		 * Configure {@link Throwable exception types} that do not lead to a rollback.
+		 *
+		 * @param classes exception classes to exclude from rolllback.
+		 * @return a new {@link TransactionalJpaExecutor} containing all previous settings and the configured exception
+		 *         types.
+		 */
+		TransactionalJpaExecutor withNoRollbackOn(Class<? extends Throwable>... classes);
+
+		/**
+		 * Configure a {@link TransactionDefinition}.
+		 *
+		 * @return a new {@link TransactionalJpaExecutor} containing all previous settings and the configured
+		 *         {@link TransactionDefinition}.
+		 */
+		TransactionalJpaExecutor withTransaction(TransactionDefinition definition);
+	}
+}

--- a/src/test/java/org/springframework/data/jpa/support/DefaultJpaExecutorIntegrationTests.java
+++ b/src/test/java/org/springframework/data/jpa/support/DefaultJpaExecutorIntegrationTests.java
@@ -1,0 +1,177 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.jpa.support;
+
+import static org.assertj.core.api.Assertions.*;
+
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
+import reactor.test.StepVerifier;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import javax.persistence.EntityManagerFactory;
+import javax.transaction.Transactional;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.jpa.domain.sample.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.sample.UserRepository;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.transaction.PlatformTransactionManager;
+
+/**
+ * Integration tests for {@link JpaExecutor}.
+ *
+ * @author Mark Paluch
+ */
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration(locations = "classpath:config/namespace-application-context.xml")
+public class DefaultJpaExecutorIntegrationTests {
+
+	@Autowired EntityManagerFactory emf;
+
+	@Autowired UserRepository repository;
+
+	@Autowired PlatformTransactionManager transactionManager;
+
+	JpaExecutor executor;
+
+	private User firstUser;
+	private User secondUser;
+
+	@Before
+	@Transactional
+	public void before() {
+
+		executor = new DefaultJpaExecutor(emf, transactionManager, Schedulers.newParallel("jpa", 2));
+
+		firstUser = new User("Oliver", "Gierke", "gierke@synyx.de");
+		firstUser.setAge(28);
+
+		secondUser = new User("Joachim", "Arrasz", "arrasz@synyx.de");
+		secondUser.setAge(35);
+
+		repository.deleteAll();
+
+		repository.saveAndFlush(firstUser);
+		repository.saveAndFlush(secondUser);
+	}
+
+	@After
+	@Transactional
+	public void after() {
+		repository.deleteAll();
+	}
+
+	@Test // DATAJPA-1350
+	public void shouldCallAsync() {
+
+		AtomicReference<Thread> callingThread = new AtomicReference<>();
+
+		Flux<User> read = executor.readMany(em -> {
+
+			callingThread.set(Thread.currentThread());
+			return em.createQuery("SELECT u FROM User u").getResultList();
+		});
+
+		assertThat(callingThread).hasValue(null);
+
+		read.as(StepVerifier::create).expectNextCount(2).verifyComplete();
+		assertThat(callingThread).doesNotHaveValue(Thread.currentThread());
+	}
+
+	@Test // DATAJPA-1350
+	public void shouldReturnEmptyResult() {
+
+		Flux<User> read = executor.readMany(em -> {
+
+			return em.createQuery("SELECT u FROM User u WHERE u.firstname = ?0").setParameter(0, "foo").getResultList();
+		});
+
+		read.as(StepVerifier::create).verifyComplete();
+	}
+
+	@Test // DATAJPA-1350
+	public void shouldReadFromRepository() {
+
+		Flux<User> read = executor.readMany(repository, JpaRepository::findAll);
+
+		read.as(StepVerifier::create).expectNextCount(2).verifyComplete();
+	}
+
+	@Test // DATAJPA-1350
+	public void shouldCommitTransaction() {
+
+		Mono<Object> delete = executor.transactional().doInTransaction(repository, userRepository -> {
+			userRepository.deleteAll();
+			return null;
+		});
+
+		delete.as(StepVerifier::create).verifyComplete();
+
+		assertThat(repository.findAll()).isEmpty();
+	}
+
+	@Test // DATAJPA-1350
+	public void shouldRollbackTransaction() {
+
+		Mono<Void> delete = executor.transactional().doInTransaction(repository, userRepository -> {
+			userRepository.deleteAll();
+			throw new IllegalStateException("e");
+		});
+
+		delete.as(StepVerifier::create).expectError(IllegalStateException.class).verify();
+
+		assertThat(repository.findAll()).isNotEmpty();
+	}
+
+	@Test // DATAJPA-1350
+	public void shouldCommitWithExceptionTransaction() {
+
+		Mono<Void> delete = executor.transactional().withNoRollbackOn(IllegalStateException.class)
+				.doInTransaction(repository, userRepository -> {
+					userRepository.deleteAll();
+					throw new IllegalStateException("e");
+				});
+
+		delete.as(StepVerifier::create).expectError(IllegalStateException.class).verify();
+
+		assertThat(repository.findAll()).isEmpty();
+	}
+
+	@Test // DATAJPA-1350
+	public void shouldRollbackWithExceptionTransaction() {
+
+		Mono<Void> delete = executor.transactional() //
+				.withNoRollbackOn(RuntimeException.class) //
+				.withRollbackOn(IllegalStateException.class) //
+				.doInTransaction(repository, userRepository -> {
+					userRepository.deleteAll();
+					throw new IllegalStateException("e");
+				});
+
+		delete.as(StepVerifier::create).expectError(IllegalStateException.class).verify();
+
+		assertThat(repository.findAll()).isNotEmpty();
+	}
+}


### PR DESCRIPTION
Provide an Executor API that allows `EntityManager` and `JpaRepository` usage within a reactive application environment. Workloads are offloaded to a dedicated Scheduler to unblock the subscribing thread and to not block application threads. `DefaultJpaExecutor` requires a dedicated `Scheduler` that is exclusively used to process blocking workloads.


```java
Flux<User> read = executor.readMany(repository, JpaRepository::findAll);

Flux<User> read = executor.readMany(em -> {
	return em.createQuery("SELECT u FROM User u WHERE u.firstname = ?0")
				.setParameter(0, "foo")
				.getResultList();
});

Mono<Void> delete = executor.transactional().doInTransaction(repository, userRepository -> {
	userRepository.deleteAll();
	return null;
});

Mono<Void> delete = executor.transactional() //
		.withNoRollbackOn(RuntimeException.class) //
		.withRollbackOn(IllegalStateException.class) //
		.doInTransaction(repository, userRepository -> {
			userRepository.deleteAll();
			throw new IllegalStateException("e");
});
```

---

Related ticket: [DATAJPA-1350](https://jira.spring.io/browse/DATAJPA-1350).
See also https://github.com/spring-projects/spring-data-examples/tree/3fa8586b398f756994fb962ca6cb6fb82cf50e7d/web/webflux to see usage of `JpaExecutor` in the context of a WebFlux application.
