### PR TITLE
DATAJPA-1359 - Remove reference to org.hibernate.Query by simplifying HibernateUtils.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,13 +48,13 @@
 		<profile>
 			<id>hibernate-53</id>
 			<properties>
-				<hibernate>5.3.0.Final</hibernate>
+				<hibernate>5.3.1.Final</hibernate>
 			</properties>
 		</profile>
 		<profile>
 			<id>hibernate-53-next</id>
 			<properties>
-				<hibernate>5.3.1-SNAPSHOT</hibernate>
+				<hibernate>5.3.2-SNAPSHOT</hibernate>
 			</properties>
 			<repositories>
 				<repository>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-jpa</artifactId>
-	<version>2.1.0.BUILD-SNAPSHOT</version>
+	<version>2.1.0.DATAJPA-1359-SNAPSHOT</version>
 
 	<name>Spring Data JPA</name>
 	<description>Spring Data module for JPA repositories.</description>

--- a/src/main/java/org/springframework/data/jpa/provider/HibernateUtils.java
+++ b/src/main/java/org/springframework/data/jpa/provider/HibernateUtils.java
@@ -15,14 +15,8 @@
  */
 package org.springframework.data.jpa.provider;
 
-import java.lang.reflect.Method;
-import java.util.Arrays;
-import java.util.List;
-
-import org.hibernate.Query;
+import org.hibernate.query.Query;
 import org.springframework.lang.Nullable;
-import org.springframework.util.ClassUtils;
-import org.springframework.util.ReflectionUtils;
 
 /**
  * Utility functions to work with Hibernate. Mostly using reflection to make sure common functionality can be executed
@@ -30,44 +24,13 @@ import org.springframework.util.ReflectionUtils;
  *
  * @author Oliver Gierke
  * @author Mark Paluch
+ * @author Jens Schauder
  * @since 1.10.2
  * @soundtrack Benny Greb - Soulfood (Live, https://www.youtube.com/watch?v=9_ErMa_CtSw)
  */
 public abstract class HibernateUtils {
 
-	private static final List<String> TYPES = Arrays.asList("org.hibernate.jpa.HibernateQuery",
-			"org.hibernate.ejb.HibernateQuery");
-	private static final @Nullable Method GET_HIBERNATE_QUERY;
-	private static final @Nullable Class<?> HIBERNATE_QUERY_INTERFACE;
-	private static final @Nullable Method QUERY_STRING_METHOD;
-
 	private HibernateUtils() {}
-
-	static {
-
-		Class<?> type = null;
-		Method method = null;
-		ClassLoader classLoader = HibernateUtils.class.getClassLoader();
-
-		for (String typeName : TYPES) {
-			try {
-				type = ClassUtils.forName(typeName, classLoader);
-				method = type.getMethod("getHibernateQuery");
-			} catch (Exception o_O) {}
-		}
-
-		GET_HIBERNATE_QUERY = method;
-
-		Class<?> queryInterface = null;
-
-		try {
-			queryInterface = ClassUtils.forName("org.hibernate.query.Query", classLoader);
-		} catch (Exception o_O) {}
-
-		HIBERNATE_QUERY_INTERFACE = queryInterface == null ? type : queryInterface;
-		QUERY_STRING_METHOD = HIBERNATE_QUERY_INTERFACE == null ? null
-				: ReflectionUtils.findMethod(HIBERNATE_QUERY_INTERFACE, "getQueryString");
-	}
 
 	/**
 	 * Return the query string of the underlying native Hibernate query.
@@ -78,21 +41,10 @@ public abstract class HibernateUtils {
 	@Nullable
 	public static String getHibernateQuery(Object query) {
 
-		if (HIBERNATE_QUERY_INTERFACE != null && QUERY_STRING_METHOD != null
-				&& HIBERNATE_QUERY_INTERFACE.isInstance(query)) {
-			return String.class.cast(ReflectionUtils.invokeMethod(QUERY_STRING_METHOD, query));
+		if (query instanceof Query) {
+			return ((Query) query).getQueryString();
+		} else {
+			throw new IllegalArgumentException("Don't know how to extract the query string from " + query);
 		}
-
-		if (HIBERNATE_QUERY_INTERFACE != null && !HIBERNATE_QUERY_INTERFACE.isInstance(query)) {
-			query = ((javax.persistence.Query) query).unwrap(HIBERNATE_QUERY_INTERFACE);
-		}
-
-		if (GET_HIBERNATE_QUERY == null) {
-			throw new IllegalStateException(
-					"Cannot invoke getHibernateQuery(…). No underlying method for a reflective call found.");
-		}
-
-		Query q = (Query) ReflectionUtils.invokeMethod(GET_HIBERNATE_QUERY, query);
-		return q == null ? "" : q.getQueryString();
 	}
 }


### PR DESCRIPTION
HibernateUtils made heavy use of reflection in order to support different versions of Hibernate.
With the current required version of Hibernate as indicated by the pom.xml this degree of flexibility is no longer needed.


Also:
Upgraded the Hibernate dependencies because 5.3.1 is now final and the latest Snapshot seems to be broken.
Therefore it seems sensible to depend on 5.3.1-Final and 5.3.2-SNAPSHOT respectively in hibernate-53 and hibernate-53-next.