### PR TITLE
DATAJPA-1368 - Register ExposeRepositoryInvocationInterceptor to isolate repository method call exposure.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-jpa</artifactId>
-	<version>2.2.0.BUILD-SNAPSHOT</version>
+	<version>2.2.0.DATAJPA-1368-SNAPSHOT</version>
 
 	<name>Spring Data JPA</name>
 	<description>Spring Data module for JPA repositories.</description>
@@ -210,7 +210,7 @@
 							</execution>
 						</executions>
 					</plugin>
-					
+
 					<plugin>
 						<groupId>org.codehaus.mojo</groupId>
 						<artifactId>build-helper-maven-plugin</artifactId>

--- a/src/test/java/org/springframework/data/jpa/repository/support/CrudMethodMetadataPopulatingMethodInterceptorUnitTests.java
+++ b/src/test/java/org/springframework/data/jpa/repository/support/CrudMethodMetadataPopulatingMethodInterceptorUnitTests.java
@@ -30,15 +30,16 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.springframework.aop.framework.ProxyFactory;
-import org.springframework.aop.interceptor.ExposeInvocationInterceptor;
 import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.support.CrudMethodMetadataPostProcessor.CrudMethodMetadataPopulatingMethodInterceptor;
+import org.springframework.data.jpa.repository.support.CrudMethodMetadataPostProcessor.ExposeRepositoryInvocationInterceptor;
 import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 /**
  * Unit tests for {@link CrudMethodMetadataPopulatingMethodInterceptor}.
  *
  * @author Oliver Gierke
+ * @author Mark Paluch
  */
 @RunWith(MockitoJUnitRunner.class)
 public class CrudMethodMetadataPopulatingMethodInterceptorUnitTests {
@@ -56,8 +57,8 @@ public class CrudMethodMetadataPopulatingMethodInterceptorUnitTests {
 		assertThat(TransactionSynchronizationManager.getResource(method), is(nullValue()));
 	}
 
-	@Test // DATAJPA-839
-	public void looksUpCrudMethodMetadataForEveryInvocation() throws Throwable {
+	@Test // DATAJPA-839, DATAJPA-1368
+	public void looksUpCrudMethodMetadataForEveryInvocation() {
 
 		CrudMethodMetadata metadata = new CrudMethodMetadataPostProcessor().getCrudMethodMetadata();
 
@@ -68,7 +69,7 @@ public class CrudMethodMetadataPopulatingMethodInterceptorUnitTests {
 	private Method prepareMethodInvocation(String name) throws Throwable {
 
 		Method method = Sample.class.getMethod(name);
-		ExposeInvocationInterceptor.INSTANCE.invoke(invocation);
+		ExposeRepositoryInvocationInterceptor.INSTANCE.invoke(invocation);
 		when(invocation.getMethod()).thenReturn(method);
 
 		return method;
@@ -78,7 +79,7 @@ public class CrudMethodMetadataPopulatingMethodInterceptorUnitTests {
 
 		ProxyFactory factory = new ProxyFactory(new Object());
 		factory.addInterface(Sample.class);
-		factory.addAdvice(ExposeInvocationInterceptor.INSTANCE);
+		factory.addAdvice(ExposeRepositoryInvocationInterceptor.INSTANCE);
 		factory.addAdvice(CrudMethodMetadataPopulatingMethodInterceptor.INSTANCE);
 		factory.addAdvice(new MethodInterceptor() {
 


### PR DESCRIPTION
We now ship and register `ExposeRepositoryInvocationInterceptor` to expose proxy method invocations without interfering with `ExposeInvocationInterceptor`. `ExposeRepositoryInvocationInterceptor` is a copy of `ExposeInvocationInterceptor` that holds its own instance of the invoked method and that is isolated so no other component can affect the exposure of the invoked method.

Interceptors in the invocation chain can invoke methods on proxied objects (e.g. proxied `TransactionManager`) which override the invoked proxied method as `ExposeInvocationInterceptor` is a singleton. We previously lost the invoked method details.

---

Related ticket: [DATAJPA-1368](https://jira.spring.io/browse/DATAJPA-1368).