### PR TITLE
DATAJPA-1163 - Allow expression "#{#entityName}" in count queries

### DIFF
--- a/src/main/java/org/springframework/data/jpa/repository/query/AbstractStringBasedJpaQuery.java
+++ b/src/main/java/org/springframework/data/jpa/repository/query/AbstractStringBasedJpaQuery.java
@@ -34,6 +34,7 @@ import org.springframework.util.Assert;
  * @author Oliver Gierke
  * @author Thomas Darimont
  * @author Jens Schauder
+ * @author Tom Hombergs
  */
 abstract class AbstractStringBasedJpaQuery extends AbstractJpaQuery {
 
@@ -63,7 +64,9 @@ abstract class AbstractStringBasedJpaQuery extends AbstractJpaQuery {
 
 		this.evaluationContextProvider = evaluationContextProvider;
 		this.query = new ExpressionBasedStringQuery(queryString, method.getEntityInformation(), parser);
-		this.countQuery = query.deriveCountQuery(method.getCountQuery(), method.getCountQueryProjection());
+
+		DeclaredQuery countQuery = query.deriveCountQuery(method.getCountQuery(), method.getCountQueryProjection());
+		this.countQuery = ExpressionBasedStringQuery.from(countQuery, method.getEntityInformation(), parser);
 
 		this.parser = parser;
 

--- a/src/main/java/org/springframework/data/jpa/repository/query/ExpressionBasedStringQuery.java
+++ b/src/main/java/org/springframework/data/jpa/repository/query/ExpressionBasedStringQuery.java
@@ -34,6 +34,7 @@ import org.springframework.util.Assert;
  *
  * @author Thomas Darimont
  * @author Oliver Gierke
+ * @author Tom Hombergs
  */
 class ExpressionBasedStringQuery extends StringQuery {
 
@@ -57,6 +58,19 @@ class ExpressionBasedStringQuery extends StringQuery {
 	 */
 	public ExpressionBasedStringQuery(String query, JpaEntityMetadata<?> metadata, SpelExpressionParser parser) {
 		super(renderQueryIfExpressionOrReturnQuery(query, metadata, parser));
+	}
+
+	/**
+	 * Creates an {@link ExpressionBasedStringQuery} from a given {@link DeclaredQuery}.
+	 * 
+	 * @param query the original query. Must not be {@literal null}.
+	 * @param metadata the {@link JpaEntityMetadata} for the given entity. Must not be {@literal null}.
+	 * @param parser Parser for resolving SpEL expressions. Must not be {@literal null}.
+	 * @return A query supporting SpEL expressions.
+	 */
+	public static ExpressionBasedStringQuery from(DeclaredQuery query, JpaEntityMetadata metadata,
+			SpelExpressionParser parser) {
+		return new ExpressionBasedStringQuery(query.getQueryString(), metadata, parser);
 	}
 
 	/**

--- a/src/test/java/org/springframework/data/jpa/repository/sample/UserRepository.java
+++ b/src/test/java/org/springframework/data/jpa/repository/sample/UserRepository.java
@@ -556,6 +556,10 @@ public interface UserRepository
 	// DATAJPA-1334
 	List<NameOnlyDto> findByNamedQueryWithConstructorExpression();
 
+	// DATAJPA-1163
+	@Query(value = "select u from #{#entityName} u", countQuery = "select count(u.id) from #{#entityName} u")
+	List<User> findAllWithExpressionInCountQuery(Pageable pageable);
+
 	interface RolesAndFirstname {
 
 		String getFirstname();


### PR DESCRIPTION
This PR solves [DATAJPA-1163](https://jira.spring.io/browse/DATAJPA-1163) and allows using the expression "#{#entityName}" in count queries.

The issue described in DATAJPA-1163 was reproducible with the test case I added.