### PR TITLE
DATAJPA-1379 - Fixed detection of PersistenceProvider when EntityManager is a proxy.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-jpa</artifactId>
-	<version>2.1.0.BUILD-SNAPSHOT</version>
+	<version>2.1.0.DATAJPA-1379-SNAPSHOT</version>
 
 	<name>Spring Data JPA</name>
 	<description>Spring Data module for JPA repositories.</description>

--- a/src/main/java/org/springframework/data/jpa/provider/JpaClassUtils.java
+++ b/src/main/java/org/springframework/data/jpa/provider/JpaClassUtils.java
@@ -43,7 +43,11 @@ abstract class JpaClassUtils {
 	 * @return
 	 */
 	public static boolean isEntityManagerOfType(EntityManager em, String type) {
-		return isOfType(em, type, em.getDelegate().getClass().getClassLoader());
+		Object delegate = em.getDelegate();
+		if (delegate instanceof EntityManager) {
+			em = (EntityManager) delegate;
+		}
+		return isOfType(em, type, delegate.getClass().getClassLoader());
 	}
 
 	public static boolean isMetamodelOfType(Metamodel metamodel, String type) {

--- a/src/main/java/org/springframework/data/jpa/provider/JpaClassUtils.java
+++ b/src/main/java/org/springframework/data/jpa/provider/JpaClassUtils.java
@@ -27,6 +27,7 @@ import org.springframework.util.ClassUtils;
  *
  * @author Oliver Gierke
  * @author Christoph Strobl
+ * @author Jens Schauder
  */
 abstract class JpaClassUtils {
 
@@ -40,9 +41,10 @@ abstract class JpaClassUtils {
 	 *
 	 * @param em must not be {@literal null}.
 	 * @param type the fully qualified expected {@link EntityManager} type, must not be {@literal null} or empty.
-	 * @return
+	 * @return wether the given {@code EntityManager} is of the given type.
 	 */
 	public static boolean isEntityManagerOfType(EntityManager em, String type) {
+
 		Object delegate = em.getDelegate();
 		if (delegate instanceof EntityManager) {
 			em = (EntityManager) delegate;

--- a/src/main/java/org/springframework/data/jpa/provider/PersistenceProvider.java
+++ b/src/main/java/org/springframework/data/jpa/provider/PersistenceProvider.java
@@ -44,6 +44,7 @@ import org.springframework.util.ConcurrentReferenceHashMap;
  * @author Oliver Gierke
  * @author Thomas Darimont
  * @author Mark Paluch
+ * @author Jens Schauder
  */
 public enum PersistenceProvider implements QueryExtractor, ProxyIdAccessor {
 
@@ -224,7 +225,7 @@ public enum PersistenceProvider implements QueryExtractor, ProxyIdAccessor {
 		String OPENJPA_JPA_METAMODEL_TYPE = "org.apache.openjpa.persistence.meta.MetamodelImpl";
 	}
 
-	private static ConcurrentReferenceHashMap<Class<?>, PersistenceProvider> CACHE = new ConcurrentReferenceHashMap<Class<?>, PersistenceProvider>();
+	static ConcurrentReferenceHashMap<Class<?>, PersistenceProvider> CACHE = new ConcurrentReferenceHashMap<Class<?>, PersistenceProvider>();
 
 	private final Iterable<String> entityManagerClassNames;
 	private final Iterable<String> metamodelClassNames;

--- a/src/main/java/org/springframework/data/jpa/provider/PersistenceProvider.java
+++ b/src/main/java/org/springframework/data/jpa/provider/PersistenceProvider.java
@@ -18,7 +18,6 @@ package org.springframework.data.jpa.provider;
 import static org.springframework.data.jpa.provider.JpaClassUtils.*;
 import static org.springframework.data.jpa.provider.PersistenceProvider.Constants.*;
 
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.NoSuchElementException;
@@ -57,8 +56,8 @@ public enum PersistenceProvider implements QueryExtractor, ProxyIdAccessor {
 	 * @see <a href="https://jira.spring.io/browse/DATAJPA-444">DATAJPA-444</a>
 	 */
 	HIBERNATE(//
-			Arrays.asList(HIBERNATE_ENTITY_MANAGER_INTERFACE), //
-			Arrays.asList(HIBERNATE_JPA_METAMODEL_TYPE)) {
+			Collections.singletonList(HIBERNATE_ENTITY_MANAGER_INTERFACE), //
+			Collections.singletonList(HIBERNATE_JPA_METAMODEL_TYPE)) {
 
 		public String extractQueryString(Query query) {
 			return HibernateUtils.getHibernateQuery(query);
@@ -117,7 +116,8 @@ public enum PersistenceProvider implements QueryExtractor, ProxyIdAccessor {
 	/**
 	 * EclipseLink persistence provider.
 	 */
-	ECLIPSELINK(Collections.singleton(ECLIPSELINK_ENTITY_MANAGER_INTERFACE), Collections.singleton(ECLIPSELINK_JPA_METAMODEL_TYPE)) {
+	ECLIPSELINK(Collections.singleton(ECLIPSELINK_ENTITY_MANAGER_INTERFACE),
+			Collections.singleton(ECLIPSELINK_JPA_METAMODEL_TYPE)) {
 
 		public String extractQueryString(Query query) {
 			return ((JpaQuery<?>) query).getDatabaseQuery().getJPQLString();
@@ -158,14 +158,14 @@ public enum PersistenceProvider implements QueryExtractor, ProxyIdAccessor {
 		 */
 		@Override
 		public CloseableIterator<Object> executeQueryWithResultStream(Query jpaQuery) {
-			return new EclipseLinkScrollableResultsIterator<Object>(jpaQuery);
+			return new EclipseLinkScrollableResultsIterator<>(jpaQuery);
 		}
 	},
 
 	/**
 	 * Unknown special provider. Use standard JPA.
 	 */
-	GENERIC_JPA(Collections.singleton(GENERIC_JPA_ENTITY_MANAGER_INTERFACE), Collections.<String> emptySet()) {
+	GENERIC_JPA(Collections.singleton(GENERIC_JPA_ENTITY_MANAGER_INTERFACE), Collections.emptySet()) {
 
 		/*
 		 * (non-Javadoc)
@@ -206,29 +206,7 @@ public enum PersistenceProvider implements QueryExtractor, ProxyIdAccessor {
 		}
 	};
 
-	/**
-	 * Holds the PersistenceProvider specific interface names.
-	 *
-	 * @author Thomas Darimont
-	 */
-	static interface Constants {
-
-		String GENERIC_JPA_ENTITY_MANAGER_INTERFACE = "javax.persistence.EntityManager";
-		String OPENJPA_ENTITY_MANAGER_INTERFACE = "org.apache.openjpa.persistence.OpenJPAEntityManager";
-		String ECLIPSELINK_ENTITY_MANAGER_INTERFACE = "org.eclipse.persistence.jpa.JpaEntityManager";
-		String HIBERNATE_SESSION_INTERFACE = "org.hibernate.Session";
-		// needed as Spring only exposes that interface via the EM proxy
-		String HIBERNATE_ENTITY_MANAGER_INTERFACE = "org.hibernate.jpa.HibernateEntityManager";
-
-		String HIBERNATE_JPA_METAMODEL_TYPE = "org.hibernate.metamodel.internal.MetamodelImpl";
-		String ECLIPSELINK_JPA_METAMODEL_TYPE = "org.eclipse.persistence.internal.jpa.metamodel.MetamodelImpl";
-		String OPENJPA_JPA_METAMODEL_TYPE = "org.apache.openjpa.persistence.meta.MetamodelImpl";
-	}
-
-	static ConcurrentReferenceHashMap<Class<?>, PersistenceProvider> CACHE = new ConcurrentReferenceHashMap<Class<?>, PersistenceProvider>();
-
-	private final Iterable<String> entityManagerClassNames;
-	private final Iterable<String> metamodelClassNames;
+	static ConcurrentReferenceHashMap<Class<?>, PersistenceProvider> CACHE = new ConcurrentReferenceHashMap<>();
 
 	/**
 	 * Creates a new {@link PersistenceProvider}.
@@ -237,10 +215,25 @@ public enum PersistenceProvider implements QueryExtractor, ProxyIdAccessor {
 	 *          be {@literal null} or empty.
 	 * @param metamodelClassNames must not be {@literal null}.
 	 */
-	private PersistenceProvider(Iterable<String> entityManagerClassNames, Iterable<String> metamodelClassNames) {
+	PersistenceProvider(Iterable<String> entityManagerClassNames, Iterable<String> metamodelClassNames) {
 
 		this.entityManagerClassNames = entityManagerClassNames;
 		this.metamodelClassNames = metamodelClassNames;
+	}
+
+	private final Iterable<String> entityManagerClassNames;
+	private final Iterable<String> metamodelClassNames;
+
+	/**
+	 * Caches the given {@link PersistenceProvider} for the given source type.
+	 *
+	 * @param type must not be {@literal null}.
+	 * @param provider must not be {@literal null}.
+	 * @return the {@code PersistenceProvider} passed in as an argument. Guaranteed to be not {@code null}.
+	 */
+	private static PersistenceProvider cacheAndReturn(Class<?> type, PersistenceProvider provider) {
+		CACHE.put(type, provider);
+		return provider;
 	}
 
 	/**
@@ -302,15 +295,12 @@ public enum PersistenceProvider implements QueryExtractor, ProxyIdAccessor {
 	}
 
 	/**
-	 * Caches the given {@link PersistenceProvider} for the given source type.
+	 * Returns the placeholder to be used for simple count queries. Default implementation returns {@code x}.
 	 *
-	 * @param type must not be {@literal null}.
-	 * @param provider must not be {@literal null}.
-	 * @return
+	 * @return a placeholder for count queries. Guaranteed to be not {@code null}.
 	 */
-	private static PersistenceProvider cacheAndReturn(Class<?> type, PersistenceProvider provider) {
-		CACHE.put(type, provider);
-		return provider;
+	public String getCountQueryPlaceholder() {
+		return "x";
 	}
 
 	/*
@@ -322,25 +312,33 @@ public enum PersistenceProvider implements QueryExtractor, ProxyIdAccessor {
 	}
 
 	/**
-	 * Returns the placeholder to be used for simple count queries. Default implementation returns {@code *}.
-	 *
-	 * @return
-	 */
-	public String getCountQueryPlaceholder() {
-		return "x";
-	}
-
-	/**
 	 * Potentially converts an empty collection to the appropriate representation of this {@link PersistenceProvider},
 	 * since some JPA providers cannot correctly handle empty collections.
 	 *
 	 * @see <a href="https://jira.spring.io/browse/DATAJPA-606">DATAJPA-606</a>
-	 * @param collection
-	 * @return
+	 * @param collection The collection to be converted. May be {@code null}.
+	 * @return a potentially converted collection. May be {@code null}.
 	 */
 	@Nullable
 	public <T> Collection<T> potentiallyConvertEmptyCollection(@Nullable Collection<T> collection) {
 		return collection;
+	}
+
+	/**
+	 * Holds the PersistenceProvider specific interface names.
+	 *
+	 * @author Thomas Darimont
+	 * @author Jens Schauder
+	 */
+	interface Constants {
+
+		String GENERIC_JPA_ENTITY_MANAGER_INTERFACE = "javax.persistence.EntityManager";
+		String ECLIPSELINK_ENTITY_MANAGER_INTERFACE = "org.eclipse.persistence.jpa.JpaEntityManager";
+		// needed as Spring only exposes that interface via the EM proxy
+		String HIBERNATE_ENTITY_MANAGER_INTERFACE = "org.hibernate.jpa.HibernateEntityManager";
+
+		String HIBERNATE_JPA_METAMODEL_TYPE = "org.hibernate.metamodel.internal.MetamodelImpl";
+		String ECLIPSELINK_JPA_METAMODEL_TYPE = "org.eclipse.persistence.internal.jpa.metamodel.MetamodelImpl";
 	}
 
 	public CloseableIterator<Object> executeQueryWithResultStream(Query jpaQuery) {
@@ -353,7 +351,6 @@ public enum PersistenceProvider implements QueryExtractor, ProxyIdAccessor {
 	 *
 	 * @author Thomas Darimont
 	 * @author Oliver Gierke
-	 * @param <T> the domain type to return≠
 	 * @since 1.8
 	 */
 	private static class HibernateScrollableResultsIterator implements CloseableIterator<Object> {
@@ -365,7 +362,7 @@ public enum PersistenceProvider implements QueryExtractor, ProxyIdAccessor {
 		 *
 		 * @param jpaQuery must not be {@literal null}.
 		 */
-		public HibernateScrollableResultsIterator(Query jpaQuery) {
+		HibernateScrollableResultsIterator(Query jpaQuery) {
 
 			org.hibernate.query.Query<?> query = jpaQuery.unwrap(org.hibernate.query.Query.class);
 			this.scrollableResults = query.setReadOnly(TransactionSynchronizationManager.isCurrentTransactionReadOnly())//
@@ -428,7 +425,7 @@ public enum PersistenceProvider implements QueryExtractor, ProxyIdAccessor {
 		 *
 		 * @param jpaQuery must not be {@literal null}.
 		 */
-		public EclipseLinkScrollableResultsIterator(Query jpaQuery) {
+		EclipseLinkScrollableResultsIterator(Query jpaQuery) {
 
 			jpaQuery.setHint("eclipselink.cursor.scrollable", true);
 

--- a/src/test/java/org/springframework/data/jpa/provider/PersistenceProviderUnitTests.java
+++ b/src/test/java/org/springframework/data/jpa/provider/PersistenceProviderUnitTests.java
@@ -152,12 +152,12 @@ public class PersistenceProviderUnitTests {
 
 		private static String[] toResourcePaths(Class<?>... interfacesToImplement) {
 
-			List<String> interfaceResourcePaths = new ArrayList<String>(interfacesToImplement.length);
+			List<String> interfaceResourcePaths = new ArrayList<>(interfacesToImplement.length);
 			for (Class<?> iface : interfacesToImplement) {
 				interfaceResourcePaths.add(ClassUtils.convertClassNameToResourcePath(iface.getName()));
 			}
 
-			return interfaceResourcePaths.toArray(new String[interfaceResourcePaths.size()]);
+			return interfaceResourcePaths.toArray(new String[0]);
 		}
 	}
 }

--- a/src/test/java/org/springframework/data/jpa/provider/PersistenceProviderUnitTests.java
+++ b/src/test/java/org/springframework/data/jpa/provider/PersistenceProviderUnitTests.java
@@ -41,6 +41,7 @@ import org.springframework.util.ClassUtils;
  * @author Thomas Darimont
  * @author Oliver Gierke
  * @author Jens Schauder
+ * @author Mark Paluch
  */
 public class PersistenceProviderUnitTests {
 
@@ -92,6 +93,7 @@ public class PersistenceProviderUnitTests {
 		EntityManager em = mockProviderSpecificEntityManagerInterface(ECLIPSELINK_ENTITY_MANAGER_INTERFACE);
 
 		EntityManager emProxy = Mockito.mock(EntityManager.class);
+		Mockito.when(emProxy.isOpen()).thenReturn(true);
 		Mockito.when(emProxy.getDelegate()).thenReturn(em);
 
 		assertThat(fromEntityManager(emProxy), is(ECLIPSELINK));


### PR DESCRIPTION
We now use the delegate to test the applicability of the PersistenceProvider not just for determining the and the key cash.

This fixes DATAJPA-1379 because the underlying issue was that the generic PersistenceProvider was used.
Which return false for `canExtractQuery` which prevented the constructor call in the query to be detected.