### PR TITLE
DATAJPA-1403 - Fixed failing Tests for Hibernate 5.2+.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,6 +48,12 @@
 			</properties>
 		</profile>
 		<profile>
+			<id>spring51-next</id>
+			<properties>
+				<skip-openjpa>true</skip-openjpa>
+			</properties>
+		</profile>
+		<profile>
 			<id>hibernate-41</id>
 			<properties>
 				<hibernate>4.1.12.Final</hibernate>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-jpa</artifactId>
-	<version>1.11.15.BUILD-SNAPSHOT</version>
+	<version>1.11.15.DATAJPA-1403-SNAPSHOT</version>
 
 	<name>Spring Data JPA</name>
 	<description>Spring Data module for JPA repositories.</description>

--- a/src/test/java/org/springframework/data/jpa/repository/EclipseLinkNamespaceUserRepositoryTests.java
+++ b/src/test/java/org/springframework/data/jpa/repository/EclipseLinkNamespaceUserRepositoryTests.java
@@ -22,7 +22,6 @@ import javax.persistence.Query;
 
 import org.eclipse.persistence.Version;
 import org.junit.Assume;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.springframework.data.jpa.repository.sample.UserRepository;
 import org.springframework.test.context.ContextConfiguration;
@@ -101,6 +100,12 @@ public class EclipseLinkNamespaceUserRepositoryTests extends NamespaceUserReposi
 	 */
 	@Override
 	public void supportsProjectionsWithNativeQueriesAndCamelCaseProperty() {}
+
+	/**
+	 * Ignored until https://bugs.eclipse.org/bugs/show_bug.cgi?id=525319 is fixed.
+	 */
+	@Override
+	public void supportsProjectionsWithNativeQueries() {}
 
 	/**
 	 * Ignored until https://bugs.eclipse.org/bugs/show_bug.cgi?id=525319 is fixed.

--- a/src/test/java/org/springframework/data/jpa/repository/OpenJpaNamespaceUserRepositoryTests.java
+++ b/src/test/java/org/springframework/data/jpa/repository/OpenJpaNamespaceUserRepositoryTests.java
@@ -15,7 +15,7 @@
  */
 package org.springframework.data.jpa.repository;
 
-import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.*;
@@ -98,10 +98,9 @@ public class OpenJpaNamespaceUserRepositoryTests extends NamespaceUserRepository
 	@Override
 	public void shouldFindUsersInNativeQueryWithPagination() {}
 
-
 	/**
-	 * OpenJpa doesn't provide the correct values in the version referenced in this branch.
-	 * Since the problem is already gone in the version referenced in master no bug was created.
+	 * OpenJpa doesn't provide the correct values in the version referenced in this branch. Since the problem is already
+	 * gone in the version referenced in master no bug was created.
 	 */
 	@Override
 	@Test // DATAJPA-1172
@@ -110,4 +109,28 @@ public class OpenJpaNamespaceUserRepositoryTests extends NamespaceUserRepository
 		Query query = em.createNativeQuery("select 1 from User where firstname=? and lastname=?");
 		assertThat(query.getParameters().size(), equalTo(0));
 	}
+
+	/**
+	 * ignored since OpenJPA doesn't support tuples
+	 */
+	@Override
+	public void returnsNullValueInMap() {}
+
+	/**
+	 * ignored since OpenJPA doesn't support tuples
+	 */
+	@Override
+	public void supportsProjectionsWithNativeQueriesAndCamelCaseProperty() throws Exception {}
+
+	/**
+	 * ignored since OpenJPA doesn't support tuples
+	 */
+	@Override
+	public void bindsNativeQueryResultsToProjectionByName() {}
+
+	/**
+	 * ignored since OpenJPA doesn't support tuples
+	 */
+	@Override
+	public void supportsProjectionsWithNativeQueries() {}
 }

--- a/src/test/java/org/springframework/data/jpa/repository/cdi/EntityManagerFactoryProducer.java
+++ b/src/test/java/org/springframework/data/jpa/repository/cdi/EntityManagerFactoryProducer.java
@@ -21,6 +21,8 @@ import javax.enterprise.inject.Produces;
 import javax.persistence.EntityManagerFactory;
 import javax.persistence.Persistence;
 
+import org.hibernate.Version;
+
 /**
  * Produces and {@link EntityManagerFactory}.
  *
@@ -32,7 +34,7 @@ class EntityManagerFactoryProducer {
 	@Produces
 	@ApplicationScoped
 	public EntityManagerFactory createEntityManagerFactory() {
-		return Persistence.createEntityManagerFactory("cdi");
+		return Persistence.createEntityManagerFactory(Version.getVersionString().startsWith("5.") ? "cdi-5x" : "cdi");
 	}
 
 	public void close(@Disposes EntityManagerFactory entityManagerFactory) {

--- a/src/test/java/org/springframework/data/jpa/repository/support/JpaMetamodelEntityInformationIntegrationTests.java
+++ b/src/test/java/org/springframework/data/jpa/repository/support/JpaMetamodelEntityInformationIntegrationTests.java
@@ -25,38 +25,15 @@ import java.io.Serializable;
 import java.sql.Timestamp;
 import java.util.Date;
 
-import javax.persistence.Access;
-import javax.persistence.AccessType;
-import javax.persistence.Entity;
-import javax.persistence.EntityManager;
-import javax.persistence.EntityManagerFactory;
-import javax.persistence.Id;
-import javax.persistence.IdClass;
-import javax.persistence.ManyToOne;
-import javax.persistence.MappedSuperclass;
-import javax.persistence.Persistence;
-import javax.persistence.PersistenceContext;
+import javax.persistence.*;
 import javax.persistence.metamodel.Metamodel;
 
+import org.hibernate.Version;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.data.jpa.domain.AbstractPersistable;
-import org.springframework.data.jpa.domain.sample.ConcreteType1;
-import org.springframework.data.jpa.domain.sample.Item;
-import org.springframework.data.jpa.domain.sample.ItemId;
-import org.springframework.data.jpa.domain.sample.ItemSite;
-import org.springframework.data.jpa.domain.sample.ItemSiteId;
-import org.springframework.data.jpa.domain.sample.PersistableWithIdClass;
-import org.springframework.data.jpa.domain.sample.PersistableWithIdClassPK;
-import org.springframework.data.jpa.domain.sample.PrimitiveVersionProperty;
-import org.springframework.data.jpa.domain.sample.Role;
-import org.springframework.data.jpa.domain.sample.SampleWithIdClass;
-import org.springframework.data.jpa.domain.sample.SampleWithPrimitiveId;
-import org.springframework.data.jpa.domain.sample.SampleWithTimestampVersion;
-import org.springframework.data.jpa.domain.sample.Site;
-import org.springframework.data.jpa.domain.sample.User;
-import org.springframework.data.jpa.domain.sample.VersionedUser;
+import org.springframework.data.jpa.domain.sample.*;
 import org.springframework.data.repository.core.EntityInformation;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
@@ -310,7 +287,7 @@ public class JpaMetamodelEntityInformationIntegrationTests {
 	}
 
 	protected String getMetadadataPersitenceUnitName() {
-		return "metadata";
+		return Version.getVersionString().startsWith("5.") ? "metadata-5x": "metadata";
 	}
 
 	@SuppressWarnings("serial")

--- a/src/test/resources/META-INF/persistence.xml
+++ b/src/test/resources/META-INF/persistence.xml
@@ -72,7 +72,7 @@
 		</properties>
 	</persistence-unit>
 
-	<persistence-unit name="cdi-52">
+	<persistence-unit name="cdi-5x">
 		<provider>org.hibernate.jpa.HibernatePersistenceProvider</provider>
 		<class>org.springframework.data.jpa.domain.sample.MailMessage</class>
 		<class>org.springframework.data.jpa.domain.sample.MailSender</class>
@@ -120,7 +120,7 @@
 			<property name="hibernate.dialect" value="org.hibernate.dialect.HSQLDialect" />
 		</properties>
 	</persistence-unit>
-	<persistence-unit name="metadata-52">
+	<persistence-unit name="metadata-5x">
 		<provider>org.hibernate.jpa.HibernatePersistenceProvider</provider>
 		<class>org.springframework.data.jpa.domain.sample.CustomAbstractPersistable</class>
 		<class>org.springframework.data.jpa.domain.sample.MailMessage</class>


### PR DESCRIPTION
The PersistenceProvider of Hibernate changed its name.
Therefore we need to provide multiple persistence contexts for Hibernate 5 vs Hibernate 4.

Also, some tests were ignored for Hibernate 4 which now run with Hibernate 5 on the classpath.
This happens even when the actual JPA Provider used is EclipseLink or OpenJPA.
Both don't have proper support for Tuples which is what is needed for those tests.
Therefore the affected tests got added to the ever longer lists of ignored tests.

We do not execute OpenJpa Tests for spring-51-next as Spring 5 and above require a JPA version which is not supported by OpenJPA.