### PR TITLE
DATAJPA-1406 - Improved alias detection.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-jpa</artifactId>
-	<version>2.2.0.BUILD-SNAPSHOT</version>
+	<version>2.2.0.DATAJPA-1406-SNAPSHOT</version>
 
 	<name>Spring Data JPA</name>
 	<description>Spring Data module for JPA repositories.</description>
@@ -210,7 +210,7 @@
 							</execution>
 						</executions>
 					</plugin>
-					
+
 					<plugin>
 						<groupId>org.codehaus.mojo</groupId>
 						<artifactId>build-helper-maven-plugin</artifactId>

--- a/src/main/java/org/springframework/data/jpa/repository/query/AbstractStringBasedJpaQuery.java
+++ b/src/main/java/org/springframework/data/jpa/repository/query/AbstractStringBasedJpaQuery.java
@@ -83,7 +83,7 @@ abstract class AbstractStringBasedJpaQuery extends AbstractJpaQuery {
 	public Query doCreateQuery(Object[] values) {
 
 		ParameterAccessor accessor = new ParametersParameterAccessor(getQueryMethod().getParameters(), values);
-		String sortedQueryString = QueryUtils.applySorting(query.getQueryString(), accessor.getSort(), query.getAlias());
+		String sortedQueryString = query.deriveQueryWithSort(accessor.getSort()).getQueryString();
 		ResultProcessor processor = getQueryMethod().getResultProcessor().withDynamicProjection(accessor);
 
 		Query query = createJpaQuery(sortedQueryString, processor.getReturnedType());

--- a/src/main/java/org/springframework/data/jpa/repository/query/DeclaredQuery.java
+++ b/src/main/java/org/springframework/data/jpa/repository/query/DeclaredQuery.java
@@ -17,6 +17,7 @@ package org.springframework.data.jpa.repository.query;
 
 import java.util.List;
 
+import org.springframework.data.domain.Sort;
 import org.springframework.lang.Nullable;
 import org.springframework.util.StringUtils;
 
@@ -83,6 +84,16 @@ interface DeclaredQuery {
 	 * @return a new {@literal DeclaredQuery} instance.
 	 */
 	DeclaredQuery deriveCountQuery(@Nullable String countQuery, @Nullable String countQueryProjection);
+
+	/**
+	 * Creates a new {@link DeclaredQuery} derived from the original query but with an added order by. The sort criteria
+	 * come on top (after) any already existing order by clauses.
+	 *
+	 * @param sort a specification of the order by clause to be added. Must not be {@code null}.
+	 * @return a new {@link DeclaredQuery} instance. Guaranteed to be not {@code null}.
+	 * @since 2.2.0
+	 */
+	DeclaredQuery deriveQueryWithSort(Sort sort);
 
 	/**
 	 * @return whether paging is implemented in the query itself, e.g. using SpEL expressions.

--- a/src/main/java/org/springframework/data/jpa/repository/query/EmptyDeclaredQuery.java
+++ b/src/main/java/org/springframework/data/jpa/repository/query/EmptyDeclaredQuery.java
@@ -18,6 +18,7 @@ package org.springframework.data.jpa.repository.query;
 import java.util.Collections;
 import java.util.List;
 
+import org.springframework.data.domain.Sort;
 import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
 
@@ -98,6 +99,15 @@ class EmptyDeclaredQuery implements DeclaredQuery {
 		Assert.hasText(countQuery, "CountQuery must not be empty!");
 
 		return DeclaredQuery.of(countQuery);
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.jpa.repository.query.DeclaredQuery#deriveQueryWithAdditionalSort(org.springframework.data.domain.Sort)
+	 */
+	@Override
+	public DeclaredQuery deriveQueryWithSort(Sort sort) {
+		return this;
 	}
 
 	/*

--- a/src/main/java/org/springframework/data/jpa/repository/query/ListParsers.java
+++ b/src/main/java/org/springframework/data/jpa/repository/query/ListParsers.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.jpa.repository.query;
+
+import lombok.experimental.UtilityClass;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.function.Predicate;
+
+/**
+ * Parsers with source type List that are useful for parsing the result of a Tokenizer. A parser must not change the
+ * list it parses.
+ *
+ * @author Jens Schauder
+ * @since 2.2.0
+ */
+@UtilityClass
+final class ListParsers {
+
+	/**
+	 * Parses a single element from the list. By testing that it extends the provided class and then with the predicate.
+	 * 
+	 * @param <S> element type of the list to parse
+	 * @param <T> result type of the parser.
+	 */
+	static <S, T> Parser<List<S>, T> element(Class<T> targetType, Predicate<T> predicate) {
+		return new ElementParser<>(targetType, predicate);
+	}
+
+	/**
+	 * Parses a single element from the list. By testing it with the predicate.
+	 *
+	 * @param <T> element type of the source list and result type of the parser.
+	 */
+	@SuppressWarnings("unchecked")
+	static <T> Parser<List<T>, T> element(Predicate<T> predicate) {
+		return new ElementParser<T, T>((Class<T>) Object.class, predicate);
+	}
+
+	/**
+	 * Parses any element of a list.
+	 *
+	 * @param <T> element type of the source list and result type of the parser.
+	 * @return a parser that can parse the first element of a list.
+	 */
+	static <T> Parser<List<T>, T> any() {
+		return element(s -> true);
+	}
+
+	static <S> Parser<List<S>, ? extends String> keyword(String keyword) {
+		return element(String.class, s -> s.equalsIgnoreCase(keyword));
+	}
+
+	static <S, T> Parser<List<S>, List<T>> filtering(Parser<List<S>, T> parser) {
+		return new FilteringParser<>(parser);
+	}
+
+	/**
+	 * Parses a single element from the list. By testing it with the predicate.
+	 * 
+	 * @param <S> element type of the list to parse
+	 * @param <T> result type of the parser.
+	 */
+	private class ElementParser<S, T> implements Parser<List<S>, T> {
+
+		private final Predicate<S> predicate;
+
+		@SuppressWarnings("unchecked")
+		private ElementParser(Class<T> targetType, Predicate<T> predicate) {
+			this.predicate = s -> targetType.isAssignableFrom(s.getClass()) && predicate.test((T) s);
+		}
+
+		@SuppressWarnings("unchecked")
+		@Override
+		public ParseResult<List<S>, T> parse(List<S> toParse) {
+
+			if (toParse.isEmpty()) {
+				return new Failure<>("Nothing to parse.", toParse);
+			}
+
+			S element = toParse.get(0);
+			if (predicate.test(element)) {
+				return new Success<>((T) element, toParse.subList(1, toParse.size()));
+			}
+
+			return new Failure<>("Does not match.", toParse);
+		}
+	}
+
+	/**
+	 * A parser that scans a List for matches of the provided parser and returns all the parts of the list matched by that
+	 * parser, discarding everything else.
+	 *
+	 * @param <S> element type of the list to parse.
+	 * @param <T> result type of the parser.
+	 */
+	private class FilteringParser<S, T> implements Parser<List<S>, List<T>> {
+
+		private final Parser<List<S>, T> parser;
+
+		FilteringParser(Parser<List<S>, T> parser) {
+			this.parser = parser;
+		}
+
+		@Override
+		public ParseResult<List<S>, List<T>> parse(List<S> toParse) {
+
+			List<T> results = new ArrayList<>();
+
+			List<S> rest = toParse;
+			while (rest.size() > 1) {
+
+				ParseResult<List<S>, T> result = parser.parse(rest);
+				if (result instanceof Success) {
+
+					Success<List<S>, T> success = (Success<List<S>, T>) result;
+					results.add(success.getResult());
+					rest = success.getRemainder();
+				} else {
+					rest = rest.subList(1, rest.size());
+				}
+			}
+
+			return new Success<>(results, Collections.emptyList());
+		}
+	}
+}

--- a/src/main/java/org/springframework/data/jpa/repository/query/Parser.java
+++ b/src/main/java/org/springframework/data/jpa/repository/query/Parser.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.jpa.repository.query;
+
+import lombok.NonNull;
+import lombok.Value;
+
+import java.util.function.Function;
+
+/**
+ * A basic library for Parser Combinators. A parser is a function from the thing to parse (e.g. a {@code String} or a
+ * {@code List<Object>} to the {@link ParseResult}. The {@link ParseResult} is either a {@link Success} or a
+ * {@link Failure}. Both contain the unparsed remainder of the original object to parse and either the parsed element or
+ * an error message.
+ *
+ * @author Jens Schauder
+ * @since 2.2.0
+ */
+interface Parser<S, T> {
+
+	/**
+	 * Attempts to parse an input value.
+	 *
+	 * @param toParse the object to be parsed. Must not be {@code null}.
+	 * @return the result of the parsing attempt.
+	 */
+	ParseResult<S, T> parse(S toParse);
+
+	/**
+	 * Creates a new {@code Parser} from the current one, by applying a function to the result of a successful parse
+	 * attempt.
+	 *
+	 * @param function the function to apply. Must not be {@code null}.
+	 * @param <U> the result type of the new {@code Parser}.
+	 * @return a new Parser. Guaranteed to be not {@code null}.
+	 */
+	default <U> Parser<S, U> map(Function<T, U> function) {
+
+		return toParse -> this.parse(toParse).map(function);
+	}
+
+	/**
+	 * The result of a parse attempt.
+	 *
+	 * @param <S> the type that was attempted to parse
+	 * @param <T> the result type of the parse attempt.
+	 */
+	interface ParseResult<S, T> {
+
+		/**
+		 * Maps a {@code ParseResult} to a new {@code ParseResult} by applying the function to the result.
+		 *
+		 * @param function used to map the result. Must not be {@code null}.
+		 * @param <U> result type of the function and the resulting {@code ParseResult}.
+		 * @return a new {@code ParseResult}
+		 */
+		<U> ParseResult<S, U> map(Function<T, U> function);
+
+		/**
+		 * The remaining part of the original object to be parsed that didn't get parsed.
+		 *
+		 * @return an Object that still needs parsing. Guaranteed to be not {@code null}.
+		 */
+		S getRemainder();
+	}
+
+	/**
+	 * Signals a successful parse attempt. The meaning of success depends on the parser. Typically it means the parser
+	 * consumed at least some of the input. But a parser parsing an optional token it might even succeed without consuming
+	 * anything.
+	 *
+	 * @param <S> type that is getting parsed.
+	 * @param <T> type of the result.
+	 */
+	@Value
+	class Success<S, T> implements ParseResult<S, T> {
+
+		/** The result of the parse attempt. May be {@code null}. */
+		T result;
+		@NonNull S remainder;
+
+		@Override
+		public <U> ParseResult<S, U> map(Function<T, U> f) {
+			return new Success<>(f.apply(result), remainder);
+		}
+	}
+
+	/**
+	 * Signals a failure to parse the input.
+	 *
+	 * @param <S> type that is getting parsed.
+	 * @param <T> type of the result.
+	 */
+	@Value
+	class Failure<S, T> implements ParseResult<S, T> {
+
+		/**
+		 * Gives a reason and/or explanation for the failure to parse the input.
+		 */
+		@NonNull String message;
+		@NonNull S remainder;
+
+		@SuppressWarnings("unchecked")
+		@Override
+		public <U> ParseResult<S, U> map(Function<T, U> f) {
+			return (ParseResult<S, U>) this;
+		}
+	}
+
+}

--- a/src/main/java/org/springframework/data/jpa/repository/query/Parsers.java
+++ b/src/main/java/org/springframework/data/jpa/repository/query/Parsers.java
@@ -1,0 +1,261 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.jpa.repository.query;
+
+import static java.util.Arrays.*;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Value;
+import lombok.experimental.UtilityClass;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.function.BiFunction;
+import java.util.function.BinaryOperator;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
+import org.springframework.data.util.Lazy;
+
+/**
+ * Generic ParserCombinators.
+ *
+ * @author Jens Schauder
+ * @since 2.2.0
+ */
+@UtilityClass
+class Parsers {
+	/**
+	 * Combines a list of parser that each parses a single element into a single parser that parses all the elements in
+	 * order returnin a list of the elements.
+	 *
+	 * @param <S> the type to parse
+	 * @param <T> the type of the elements parsed by each parser
+	 */
+	@SafeVarargs
+	static <S, T> Parser<S, List<T>> concat(Supplier<Parser<S, ? extends T>>... parsers) {
+		return new Concat<>(parsers);
+	}
+
+	/**
+	 * Parser combining multiple parsers by using them one after the other until the first one succeeds.
+	 *
+	 * @param <S> the type of object to parse.
+	 * @param <T> the result type of the parser.
+	 */
+	@SafeVarargs
+	public static <S, T> Parser<S, T> either(Parser<S, ? extends T>... parsers) {
+		return new Either<>(parsers);
+	}
+
+	/**
+	 * Creates an optional parser from another parser, by returning a {@link Parser.Success} even when the original
+	 * {@link Parser.ParseResult} was a {@link Parser.Failure}.
+	 *
+	 * @param <S> the type of object to parse.
+	 * @param <T> the result type of the parser.
+	 */
+	static <S, T> Parser<S, java.util.Optional<T>> opt(Parser<S, T> parser) {
+		return new Optional<>(parser);
+	}
+
+	static <S, T> Parser<S, List<T>> many(Parser<S, T> parser) {
+		return new Many<>(parser);
+	}
+
+	static <S, T> Parser<S, List<T>> many(Parser<S, T> parser, int min) {
+		return new Many<>(parser, min);
+	}
+
+	static <S, T> Parser<S, List<T>> many(Parser<S, T> parser, int min, int max) {
+		return new Many<>(parser, min, max);
+	}
+
+	/**
+	 * Combines a list of parser that each parses a single element into a single parser that parses all the elements in
+	 * order returning a list of the elements.
+	 *
+	 * @param <S> the type to parse
+	 * @param <T> the type of the elements parsed by each parser
+	 */
+	public static class Concat<S, T> implements Parser<S, List<T>> {
+
+		private final List<Supplier<Parser<S, ? extends T>>> parsers;
+
+		@SafeVarargs
+		private Concat(Supplier<Parser<S, ? extends T>>... parsers) {
+
+			this.parsers = Arrays.stream(parsers) //
+					.map(Lazy::of) //
+					.collect(Collectors.toList());
+		}
+
+		@SuppressWarnings("unchecked")
+		@Override
+		public ParseResult<S, List<T>> parse(S toParse) {
+
+			BiFunction<ParseResult<S, List<T>>, Parser<S, ? extends T>, ParseResult<S, List<T>>> parseResultAccumulator = (
+					parseResult, nextParser) -> {
+
+				if (parseResult instanceof Failure) {
+					return parseResult;
+				}
+
+				Success<S, List<T>> success = (Success<S, List<T>>) parseResult;
+				ParseResult<S, ? extends T> nextResult = nextParser.parse(success.getRemainder());
+
+				if (nextResult instanceof Failure) {
+					return new Failure<>(((Failure<S, T>) nextResult).getMessage(), ((Failure<S, T>) nextResult).getRemainder());
+				}
+				Success<S, T> nextSuccess = (Success<S, T>) nextResult;
+
+				List<T> previousResults = ((Success<S, List<T>>) parseResult).getResult();
+				List<T> newResults = new ArrayList<>(previousResults);
+				newResults.add(nextSuccess.getResult());
+				return new Success<>(newResults, nextSuccess.getRemainder());
+			};
+
+			BinaryOperator<ParseResult<S, List<T>>> parseResultCombiner = (pr1, pr2) -> {
+				throw new UnsupportedOperationException("can't combine parsers like this. This is a strict left fold");
+			};
+
+			return parsers.stream().map(Supplier::get).reduce(new Success<>(Collections.emptyList(), toParse),
+					parseResultAccumulator, parseResultCombiner);
+		}
+	}
+
+	/**
+	 * Parser combining multiple parsers by using them one after the other until the first one succeeds.
+	 *
+	 * @param <S> the type of object to parse.
+	 * @param <T> the result type of the parser.
+	 */
+	public static class Either<S, T> implements Parser<S, T> {
+
+		private final List<Parser<S, ? extends T>> parsers;
+
+		@SafeVarargs
+		private Either(Parser<S, ? extends T>... parsers) {
+			this.parsers = asList(parsers);
+		}
+
+		@SuppressWarnings("unchecked")
+		@Override
+		public ParseResult<S, T> parse(S toParse) {
+
+			BiFunction<ParseResult<S, ? extends T>, ? super Parser<S, ? extends T>, ParseResult<S, ? extends T>> parseResultAccumulator = (
+					r, p) -> {
+				if (r instanceof Success) {
+					return r;
+				}
+
+				return p.parse(toParse);
+			};
+
+			BinaryOperator<ParseResult<S, ? extends T>> combiner = (pr1, pr2) -> {
+				throw new UnsupportedOperationException("can't combine parsers like this. This is a strict left fold");
+			};
+
+			return (ParseResult<S, T>) parsers.stream().reduce(new Failure<>("None of the options match", toParse),
+					parseResultAccumulator, combiner);
+		}
+	}
+
+	/**
+	 * Creates an optional parser from another parser, by returning a {@link Success} even when the original
+	 * {@link ParseResult} was a {@link Failure}.
+	 *
+	 * @param <S> the type of object to parse.
+	 * @param <T> the result type of the parser.
+	 */
+	public static class Optional<S, T> implements Parser<S, java.util.Optional<T>> {
+
+		/**
+		 * Underlying parser. Must not be {@code null}.
+		 */
+		Parser<S, T> parser;
+
+		private Optional(Parser<S, T> parser) {
+			this.parser = parser;
+		}
+
+		@Override
+		public ParseResult<S, java.util.Optional<T>> parse(S toParse) {
+
+			ParseResult<S, T> parseResult = parser.parse(toParse);
+			if (parseResult instanceof Failure) {
+				return new Success<>(java.util.Optional.empty(), toParse);
+			}
+			return parseResult.map(java.util.Optional::ofNullable);
+		}
+	}
+
+	@Value
+	@AllArgsConstructor(access = AccessLevel.PRIVATE)
+	public static final class Many<S, T> implements Parser<S, List<T>> {
+
+		Parser<S, T> parser;
+		int minimumMatches;
+		int maximumMatches;
+
+		private Many(Parser<S, T> parser, int minimumMatches) {
+			this(parser, minimumMatches, Integer.MAX_VALUE);
+		}
+
+		private Many(Parser<S, T> parser) {
+			this(parser, 0, Integer.MAX_VALUE);
+		}
+
+		@Override
+		public ParseResult<S, List<T>> parse(S toParse) {
+
+			List<T> results = new ArrayList<>();
+
+			S remainder = null;
+
+			ParseResult<S, T> result = parser.parse(toParse);
+
+			do {
+
+				if (result instanceof Failure) {
+					remainder = ((Failure<S, T>) result).getRemainder();
+				} else {
+
+					Success<S, T> success = (Success<S, T>) result;
+					results.add(success.getResult());
+
+					if (results.size() == maximumMatches) {
+
+						remainder = success.getRemainder();
+						break;
+					}
+
+					result = parser.parse(success.getRemainder());
+				}
+
+			} while (remainder == null && results.size() != maximumMatches);
+
+			if (results.size() >= minimumMatches)
+				return new Success<>(results, remainder);
+			else {
+				return new Failure<>("required %i matches but found only %i", toParse);
+			}
+		}
+	}
+}

--- a/src/main/java/org/springframework/data/jpa/repository/query/QlParser.java
+++ b/src/main/java/org/springframework/data/jpa/repository/query/QlParser.java
@@ -1,0 +1,233 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.jpa.repository.query;
+
+import static java.util.Arrays.*;
+
+import lombok.Value;
+import lombok.experimental.UtilityClass;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+/**
+ * A parser that parses SQL, JQL and HQL queries in order to extract information needed in order to manipulate the
+ * queries.
+ *
+ * @author Jens Schauder
+ * @since 2.2.0
+ */
+@UtilityClass
+class QlParser {
+
+	private static final Set<String> KEYWORDS = new HashSet<>(asList("order", "where", "join", "from", "case"));
+
+	// Used Regex/Unicode categories (see http://www.unicode.org/reports/tr18/#General_Category_Property):
+	// Z Separator
+	// Cc Control
+	// Cf Format
+	// P Punctuation
+	private static final Pattern IDENTIFIER = Pattern.compile("[._[\\P{Z}&&\\P{Cc}&&\\P{Cf}&&\\P{P}]]+");
+
+	/**
+	 * Parses any String enclosed in single quotes. Result does contain the quotes.
+	 */
+	static final Parser<String, String> quotedLiteral = StringParsers.regex("'.*?'");
+
+	/**
+	 * Parses white space to {@code null}.
+	 */
+	private static final Parser<String, String> ws = StringParsers.regex("\\s+").map(w -> null);
+
+	/**
+	 * Parses an inline comment and maps it to {@code null}.
+	 */
+	private static final Parser<String, String> inlineComment = StringParsers.regex("--.*").map(c -> null);
+
+	/**
+	 * Parses anything enclosed with double quotes.
+	 */
+	static final Parser<String, String> doubleQuotedIdentifier = StringParsers.regex("\".*?\"");
+
+	/**
+	 * Parses a block comment enclosed by /* and * / (without the space).
+	 */
+	static final Parser<String, String> blockComment = StringParsers.regex("/\\*.*?\\*/").map(c -> null);
+
+	private static final Parser<String, String> openParen = StringParsers.keyword("(");
+	private static final Parser<String, String> closingParen = StringParsers.keyword(")");
+	private static final Parser<String, String> comma = StringParsers.keyword(",");
+
+	/**
+	 * This is intended to parse any part of a SQL string that isn't recognised by other parsers.
+	 */
+	private static final Parser<String, String> word = StringParsers.regex("[%&*+\\-\\./\\\\:;<?\\[\\]\\^_|{}\\w]+");
+
+	/**
+	 * Parses all tokens not enclosed in parenthesis.
+	 */
+	private static final Parser<String, String> noParensToken = Parsers.either(ws, blockComment, inlineComment,
+			quotedLiteral, doubleQuotedIdentifier, comma, word);
+
+	/**
+	 * Parses all tokens including those included in parenthesis.
+	 */
+	private static final Parser<String, Object> token = Parsers.either(noParensToken, balancedParens());
+
+	private static final Parser<List<Object>, TableAlias> tableAlias = Parsers.concat( //
+			() -> keyword("from"), //
+			QlParser::any, // table expression
+			() -> Parsers.opt(keyword("as")), //
+			QlParser::identifier //
+	).map(l -> new TableAlias((String) l.get(3)));
+
+	private static final Parser<List<Object>, JoinAlias> joinAlias = Parsers.concat( //
+			() -> keyword("join"), //
+			() -> Parsers.opt(keyword("fetch")), //
+			QlParser::identifier, //
+			() -> Parsers.opt(keyword("as")), //
+			QlParser::identifier).map(l -> new JoinAlias((String) l.get(4)));
+
+	private static final Parser<List<Object>, FunctionAlias> functionAlias = Parsers.concat( //
+			QlParser::identifier, //
+			QlParser::parameterList, //
+			() -> Parsers.opt(keyword("as")), //
+			QlParser::identifier //
+	).map(l -> new FunctionAlias((String) l.get(3)));
+
+	private static final Parser<List<Object>, OrderBy> orderBy = Parsers.concat( //
+			() -> keyword("order"), //
+			() -> keyword("by")).map(l -> OrderBy.INSTANCE);
+
+	private Parser<List<Object>, SqlInfo> sqlInfoParser = Parsers.many(Parsers.either( //
+			joinAlias, //
+			functionAlias, //
+			tableAlias, //
+			orderBy, //
+			any()) // ignore all other elements
+	).map(QlParser::sqlElementsToSqlInfo);
+
+	/**
+	 * Converts a list of {@link JoinAlias}, {@link TableAlias}, {@link OrderBy}, and {@link FunctionAlias} into a single
+	 * SqlInfo instance;
+	 *
+	 * @param list list of objects to parse. Must not be {@code null}.
+	 * @return a {@link SqlInfo} instance with the condensed information from the list. Guaranteed to be not {@code null}.
+	 */
+	private static SqlInfo sqlElementsToSqlInfo(List<Object> list) {
+
+		SqlInfo sqlInfo = new SqlInfo();
+
+		list.forEach(e -> {
+
+			if (e instanceof JoinAlias) {
+				sqlInfo.joinAliases.add(((JoinAlias) e).alias);
+			} else if (e instanceof TableAlias && sqlInfo.tableAlias == null) {
+				sqlInfo.tableAlias = ((TableAlias) e).alias;
+			} else if (e instanceof FunctionAlias) {
+				sqlInfo.functionAliases.add(((FunctionAlias) e).alias);
+			} else if (e instanceof OrderBy) {
+				sqlInfo.orderBy = true;
+			}
+
+		});
+
+		return sqlInfo;
+	}
+
+	private static Parser<List<Object>, List> parameterList() {
+
+		return ListParsers.element( //
+				List.class, //
+				l -> l.size() >= 2 //
+						&& l.get(0).equals("(") //
+						&& l.get(l.size() - 1).equals(")") //
+		);
+	}
+
+	/**
+	 * Parses a SQL, JQL or HQL query and returns the essential information about the query.
+	 *
+	 * @param query the query to parse. Must not be {@code null}.
+	 * @return a {@link SqlInfo} instance. Guaranteed to be not {@code null}.
+	 */
+	static SqlInfo parseSql(String query) {
+
+		Parser.ParseResult<String, List<Object>> parseResult = tokenizer.parse(query);
+
+		if (parseResult instanceof Parser.Success) {
+
+			Parser.ParseResult<List<Object>, SqlInfo> sqlInfoParseResult = sqlInfoParser
+					.parse(((Parser.Success<String, List<Object>>) parseResult).getResult());
+
+			if (sqlInfoParseResult instanceof Parser.Success) {
+				return ((Parser.Success<List<Object>, SqlInfo>) sqlInfoParseResult).getResult();
+			}
+		}
+		return new SqlInfo();
+	}
+
+	@Value
+	private static class FunctionAlias {
+		String alias;
+	}
+
+	private static Parser<List<Object>, String> identifier() {
+
+		return ListParsers.element(String.class,
+				s -> !KEYWORDS.contains(s.toLowerCase()) && IDENTIFIER.matcher(s).matches());
+	}
+
+	private static Parser<List<Object>, Object> any() {
+		return ListParsers.element(Object.class, s -> true);
+	}
+
+	private static Parser<List<Object>, String> keyword(String keyword) {
+		return ListParsers.element(String.class, s -> s.equalsIgnoreCase(keyword));
+	}
+
+	static final Parser<String, List<Object>> tokenizer = Parsers.many(token)
+			.map(l -> l.stream().filter(Objects::nonNull).collect(Collectors.toList()));
+
+	private static Parser<String, List<Object>> balancedParens() {
+		return Parsers.concat(() -> openParen, () -> tokenizer, () -> closingParen);
+	}
+
+	enum OrderBy {
+		INSTANCE
+	}
+
+	static class SqlInfo {
+		final Set<String> joinAliases = new HashSet<>();
+		final Set<String> functionAliases = new HashSet<>();
+		String tableAlias;
+		boolean orderBy;
+	}
+
+	@Value
+	private static class TableAlias {
+		String alias;
+	}
+
+	@Value
+	private static class JoinAlias {
+		String alias;
+	}
+}

--- a/src/main/java/org/springframework/data/jpa/repository/query/QueryUtils.java
+++ b/src/main/java/org/springframework/data/jpa/repository/query/QueryUtils.java
@@ -236,7 +236,9 @@ public abstract class QueryUtils {
 	 * @param query the query string to which sorting is applied
 	 * @param sort the sort specification to apply.
 	 * @return the modified query string.
+	 * @deprecated Use {@link StringQuery#deriveQueryWithSort(Sort)}.
 	 */
+	@Deprecated
 	public static String applySorting(String query, Sort sort) {
 		return applySorting(query, sort, detectAlias(query));
 	}
@@ -248,7 +250,9 @@ public abstract class QueryUtils {
 	 * @param sort the sort specification to apply.
 	 * @param alias the alias to be used in the order by clause. May be {@literal null} or empty.
 	 * @return the modified query string.
+	 * @deprecated Use {@link StringQuery#deriveQueryWithSort(Sort)}.
 	 */
+	@Deprecated
 	public static String applySorting(String query, Sort sort, @Nullable String alias) {
 
 		Assert.hasText(query, "Query must not be null or empty!");
@@ -379,7 +383,7 @@ public abstract class QueryUtils {
 		return result;
 	}
 
-	private static String toJpaDirection(Order order) {
+	static String toJpaDirection(Order order) {
 		return order.getDirection().name().toLowerCase(Locale.US);
 	}
 
@@ -761,7 +765,7 @@ public abstract class QueryUtils {
 	 *
 	 * @param order
 	 */
-	private static void checkSortExpression(Order order) {
+	static void checkSortExpression(Order order) {
 
 		if (order instanceof JpaOrder && ((JpaOrder) order).isUnsafe()) {
 			return;

--- a/src/main/java/org/springframework/data/jpa/repository/query/StringParsers.java
+++ b/src/main/java/org/springframework/data/jpa/repository/query/StringParsers.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.jpa.repository.query;
+
+import lombok.AllArgsConstructor;
+import lombok.Value;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Parsers that parse Strings.
+ *
+ * @author Jens Schauder
+ * @since 2.2.0
+ */
+class StringParsers {
+
+	/**
+	 * Produces a parser that can parse the keyword ignoring the case at the beginning of a {@code String}. No matter how
+	 * the matched substring was written it is returned by the parser in exact the spelling as provided in the parameter.
+	 *
+	 * @param keyword the {@code String} to parse.
+	 * @return a Parser.
+	 */
+	static Parser<String, String> keyword(String keyword) {
+
+		return s -> new Regex(Pattern.quote(keyword), Pattern.CASE_INSENSITIVE) //
+				.parse(s) //
+				.map(t -> keyword);
+	}
+
+	/**
+	 * Produces a parser matching the beginning of a String that is matched by the provided regex.
+	 *
+	 * @param regexString the regular expression to be parsed by the parser.
+	 * @return a Parser.
+	 */
+	static Parser<String, String> regex(String regexString) {
+
+		return s -> new Regex(regexString) //
+				.parse(s);
+	}
+
+	@Value
+	@AllArgsConstructor
+	private static final class Regex implements Parser<String, String> {
+
+		Pattern compiled;
+
+		Regex(String pattern, int flags) {
+			this(Pattern.compile("^" + pattern, flags));
+		}
+
+		Regex(String patternString) {
+			this(patternString, 0);
+		}
+
+		@Override
+		public ParseResult<String, String> parse(String toParse) {
+
+			Matcher matcher = compiled.matcher(toParse);
+
+			if (matcher.find()) {
+				return new Success<>(matcher.group(), toParse.substring(matcher.end()));
+			} else {
+				return new Failure<>(compiled + " does not match " + toParse, toParse);
+			}
+		}
+	}
+}

--- a/src/test/java/org/springframework/data/jpa/repository/query/ListParsersUnitTests.java
+++ b/src/test/java/org/springframework/data/jpa/repository/query/ListParsersUnitTests.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.jpa.repository.query;
+
+import static java.util.Arrays.*;
+import static java.util.Collections.*;
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.Test;
+
+/**
+ * Unit tests for {@link ListParsers}.
+ *
+ * @author Jens Schauder
+ */
+public class ListParsersUnitTests {
+
+	public static class FilteringParserUnitTests {
+
+		Parser<List<String>, List<Object>> filteringParser = //
+				ListParsers.filtering( //
+						Parsers.<List<String>, String> concat( //
+								ListParsers::any, //
+								() -> ListParsers.keyword("as"), //
+								ListParsers::any //
+						).map(l -> l.get(2)));
+
+		@Test // DATAJPA-1406
+		public void noMatch() {
+
+			assertThat(filteringParser.parse(asList("blah", "blah", "blah", "blah", "blah"))) //
+					.isEqualTo(new Parser.Success<>(emptyList(), emptyList()));
+
+		}
+
+		@Test // DATAJPA-1406
+		public void startingMatch() {
+
+			assertThat(filteringParser.parse(asList("x", "as", "y", "blah"))) //
+					.isEqualTo(new Parser.Success<>(singletonList("y"), emptyList()));
+
+		}
+
+		@Test // DATAJPA-1406
+		public void singleMatch() {
+
+			assertThat(filteringParser.parse(asList("blah", "x", "as", "y", "blah"))) //
+					.isEqualTo(new Parser.Success<>(singletonList("y"), emptyList()));
+
+		}
+
+		@Test // DATAJPA-1406
+		public void multipleMatches() {
+
+			assertThat(filteringParser.parse(asList("blah", "x", "as", "y", "u", "as", "i"))) //
+					.isEqualTo(new Parser.Success<>(asList("y", "i"), emptyList()));
+
+		}
+
+		@Test // DATAJPA-1406
+		public void multipleOverlappingMatches() {
+
+			assertThat(filteringParser.parse(asList("blah", "x", "as", "y", "as", "i"))) //
+					.isEqualTo(new Parser.Success<>(Collections.singletonList("y"), emptyList()));
+
+		}
+	}
+
+	public static class ElementParserUnitTests {
+		Parser<List<Object>, String> parser = ListParsers.element(String.class, s -> true);
+
+		@Test // DATAJPA-1406
+		public void emptyListFailsToParse() {
+			assertThat(parser.parse(emptyList())).isInstanceOf(Parser.Failure.class);
+		}
+
+		@Test // DATAJPA-1406
+		public void noMatch() {
+			assertThat(parser.parse(singletonList(1))).isInstanceOf(Parser.Failure.class);
+		}
+
+		@Test // DATAJPA-1406
+		public void match() {
+
+			assertThat(parser.parse(asList("hello", "world")))
+					.isEqualTo(new Parser.Success<>("hello", singletonList("world")));
+		}
+	}
+
+	public static class TypedElementParserUnitTests {
+
+		Parser<List<Object>, Integer> parser = ListParsers.element(Integer.class, i -> i > 23);
+
+		@Test // DATAJPA-1406
+		public void emptyListFailsToParse() {
+			assertThat(parser.parse(emptyList())).isInstanceOf(Parser.Failure.class);
+		}
+
+		@Test // DATAJPA-1406
+		public void noMatchWrongType() {
+			assertThat(parser.parse(asList("x", 1))).isInstanceOf(Parser.Failure.class);
+		}
+
+		@Test // DATAJPA-1406
+		public void noMatchCondition() {
+			assertThat(parser.parse(asList(22, 1))).isInstanceOf(Parser.Failure.class);
+		}
+
+		@Test // DATAJPA-1406
+		public void match() {
+			assertThat(parser.parse(asList(24, "world"))).isEqualTo(new Parser.Success<>("hello", singletonList("world")));
+		}
+	}
+}

--- a/src/test/java/org/springframework/data/jpa/repository/query/ParserUnitTests.java
+++ b/src/test/java/org/springframework/data/jpa/repository/query/ParserUnitTests.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.jpa.repository.query;
+
+import static java.util.Arrays.*;
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.Test;
+import org.springframework.data.util.Pair;
+
+/**
+ * Unit tests for the classes in the Parser interface.
+ *
+ * @author Jens Schauder
+ */
+public class ParserUnitTests {
+
+	Parser<String, String> a = StringParsers.keyword("a");
+
+	@Test // DATAJPA-1406
+	public void mappingOfSuccess() {
+
+		Parser.Success<String, String> success = new Parser.Success<>("value", "rest");
+
+		assertThat(success.map(String::toUpperCase)).isEqualTo(new Parser.Success<>("VALUE", "rest"));
+	}
+
+	@Test // DATAJPA-1406
+	public void parseAListOfStringsIntoTuples() {
+
+		Parser<List<String>, Pair<String, String>> pairParser = toParse -> {
+
+			if (toParse.size() < 2) {
+				return new Parser.Failure<>("Not enough elements in list", toParse);
+			}
+
+			return new Parser.Success<>(Pair.of(toParse.get(0), toParse.get(1)), toParse.subList(2, toParse.size()));
+		};
+
+		Parser.ParseResult<List<String>, Pair<String, String>> result = pairParser.parse(asList("one", "two", "three"));
+		assertThat(result).isEqualTo(new Parser.Success<>(Pair.of("one", "two"), Collections.singletonList("three")));
+
+	}
+}

--- a/src/test/java/org/springframework/data/jpa/repository/query/ParsersUnitTests.java
+++ b/src/test/java/org/springframework/data/jpa/repository/query/ParsersUnitTests.java
@@ -1,0 +1,225 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.jpa.repository.query;
+
+import static java.util.Arrays.*;
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.Test;
+import org.springframework.data.util.Pair;
+
+/**
+ * Unit tests for the classes in the Parser interface.
+ *
+ * @author Jens Schauder
+ */
+public class ParsersUnitTests {
+
+	Parser<String, String> a = StringParsers.keyword("a");
+	Parser<String, String> openingParen = StringParsers.keyword("(");
+	Parser<String, String> closingParen = StringParsers.keyword(")");
+	Parser<String, List<Object>> expression = recursiveExpression();
+
+	@SuppressWarnings("unchecked")
+	private Parser<String, List<Object>> recursiveExpression() {
+
+		return Parsers.concat( //
+				() -> openingParen, //
+				() -> Parsers.either(a, recursiveExpression()), //
+				() -> closingParen //
+		);
+	}
+
+	@Test // DATAJPA-1406
+	public void recursionMatchingParens() {
+
+		assertThat(expression.parse("(((a)))")) //
+				.describedAs("matching parens") //
+				.isInstanceOf(Parser.Success.class);
+	}
+
+	@Test // DATAJPA-1406
+	public void recursionSuperfluousClosingParens() {
+
+		assertThat(expression.parse("(((a))))")) //
+				.describedAs("superfluos closing paren") //
+				.extracting(Parser.ParseResult::getRemainder) //
+				.isEqualTo(")");
+	}
+
+	@Test // DATAJPA-1406
+	public void recursionMissingClosingParens() {
+
+		assertThat(expression.parse("(((a))")) //
+				.describedAs("missing closing paren") //
+				.isInstanceOf(Parser.Failure.class);
+	}
+
+	public static class ConcatParserUnitTests {
+
+		Parser<String, String> ws = StringParsers.regex("\\s+");
+		Parser<String, String> token = StringParsers.regex("\\w+");
+		Parser<String, String> select = StringParsers.keyword("select");
+		Parser<String, String> from = StringParsers.keyword("from");
+
+		Parser<String, List<String>> sql = Parsers.concat(() -> select, () -> ws, () -> token, () -> ws, () -> from);
+
+		@Test // DATAJPA-1406
+		public void exactMatch() {
+
+			assertThat(sql.parse("select a from"))
+					.isEqualTo(new Parser.Success<>(asList("select", " ", "a", " ", "from"), ""));
+		}
+
+		@Test // DATAJPA-1406
+		public void startsWithMatch() {
+
+			assertThat(sql.parse("select a from where clause"))
+					.isEqualTo(new Parser.Success<>(asList("select", " ", "a", " ", "from"), " where clause"));
+		}
+
+		@Test // DATAJPA-1406
+		public void failureToMatch() {
+
+			assertThat(sql.parse("select a as b from")) //
+					.isInstanceOf(Parser.Failure.class) //
+					.extracting(Parser.ParseResult::getRemainder) //
+					.isEqualTo("as b from");
+		}
+	}
+
+	public static class EitherParserUnitTests {
+
+		Parser<String, String> aa = StringParsers.keyword("aa");
+		Parser<String, String> aaa = StringParsers.keyword("aaa");
+		Parser<String, String> bb = StringParsers.keyword("bb");
+
+		@Test // DATAJPA-1406
+		public void matchOnFirst() {
+
+			assertThat(Parsers.either(aa, bb).parse("aabb")).isEqualTo(new Parser.Success<>("aa", "bb"));
+		}
+
+		@Test // DATAJPA-1406
+		public void matchOnSecond() {
+
+			assertThat(Parsers.either(aa, bb).parse("bbaa")).isEqualTo(new Parser.Success<>("bb", "aa"));
+		}
+
+		@Test // DATAJPA-1406
+		public void prefersFirst() {
+
+			assertThat(Parsers.either(aa, aaa).parse("aaaa")).isEqualTo(new Parser.Success<>("aa", "aa"));
+		}
+
+		@Test // DATAJPA-1406
+		public void failure() {
+
+			assertThat(Parsers.either(aaa, bb).parse("aabb")).isInstanceOf(Parser.Failure.class)
+					.extracting((Parser.ParseResult::getRemainder)).isEqualTo("aabb");
+		}
+	}
+
+	public static class OptionalParserUnitTests {
+
+		Parser<String, String> aa = StringParsers.keyword("aa");
+
+		@Test // DATAJPA-1406
+		public void prefersFirst() {
+
+			assertThat(Parsers.opt(aa).parse("aaaa")).isEqualTo(new Parser.Success<>(Optional.of("aa"), "aa"));
+		}
+
+		@Test // DATAJPA-1406
+		public void failureToMatchResultsInEmptyResult() {
+
+			assertThat(Parsers.opt(aa).parse("bbb")).isEqualTo(new Parser.Success<>(Optional.empty(), "bbb"));
+		}
+	}
+
+	public static class ManyParserUnitTest {
+
+		Parser<String, String> aa = StringParsers.keyword("aa");
+
+		@Test // DATAJPA-1406
+		public void match() {
+
+			assertThat(Parsers.many(aa).parse("aaaaaaa")) //
+					.isEqualTo(new Parser.Success<>(asList("aa", "aa", "aa"), "a"));
+		}
+
+		@Test // DATAJPA-1406
+		public void matchNone() {
+
+			assertThat(Parsers.many(aa).parse("axaaa")) //
+					.isEqualTo(new Parser.Success<>(Collections.emptyList(), "axaaa"));
+		}
+
+		@Test // DATAJPA-1406
+		public void matchAtLeastSuccess() {
+
+			assertThat(Parsers.many(aa, 3).parse("aaaaaaa")) //
+					.isEqualTo(new Parser.Success<>(asList("aa", "aa", "aa"), "a"));
+		}
+
+		@Test // DATAJPA-1406
+		public void matchAtLeastFailure() {
+
+			assertThat(Parsers.many(aa, 3).parse("aaaaaxaa")) //
+					.isInstanceOf(Parser.Failure.class) //
+					.extracting(Parser.ParseResult::getRemainder).isEqualTo("aaaaaxaa");
+		}
+
+		@Test // DATAJPA-1406
+		public void matchAtMostSuccess() {
+
+			assertThat(Parsers.many(aa, 3, 3).parse("aaaaaaa")) //
+					.isEqualTo(new Parser.Success<>(asList("aa", "aa", "aa"), "a"));
+		}
+
+		@Test // DATAJPA-1406
+		public void matchAtMostFailure() {
+
+			assertThat(Parsers.many(aa, 1, 2).parse("aaaaaaa")) //
+					.isEqualTo(new Parser.Success<>(asList("aa", "aa"), "aaa"));
+		}
+
+	}
+
+	public static class NonStringParsersUnitTests {
+
+		@Test // DATAJPA-1406
+		public void parseAListOfStringsIntoTuples() {
+
+			Parser<List<String>, Pair<String, String>> pairParser = toParse -> {
+
+				if (toParse.size() < 2) {
+					return new Parser.Failure<>("Not enough elements in list", toParse);
+				}
+
+				return new Parser.Success<>(Pair.of(toParse.get(0), toParse.get(1)), toParse.subList(2, toParse.size()));
+			};
+
+			Parser.ParseResult<List<String>, Pair<String, String>> result = pairParser.parse(asList("one", "two", "three"));
+			assertThat(result).isEqualTo(new Parser.Success<>(Pair.of("one", "two"), Collections.singletonList("three")));
+
+		}
+	}
+}

--- a/src/test/java/org/springframework/data/jpa/repository/query/QlParserUnitTests.java
+++ b/src/test/java/org/springframework/data/jpa/repository/query/QlParserUnitTests.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.jpa.repository.query;
+
+import static java.util.Arrays.*;
+import static java.util.Collections.*;
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.List;
+
+import org.junit.Test;
+
+/**
+ * Unit tests for the QlParser;
+ *
+ * @author Jens Schauder
+ */
+public class QlParserUnitTests {
+
+	Parser<String, List<Object>> tokenizer = QlParser.tokenizer;
+
+	@Test // DATAJPA-1406
+	public void quotedLiteral() {
+
+		assertThat(QlParser.quotedLiteral.parse("'blah' something'")) //
+				.isInstanceOf(Parser.Success.class) //
+				.extracting(Parser.ParseResult::getRemainder) //
+				.isEqualTo(" something'");
+	}
+
+	@Test // DATAJPA-1406
+	public void doubleQuotedIdentifier() {
+
+		assertThat(QlParser.doubleQuotedIdentifier.parse("\"blah\" something\"")) //
+				.isInstanceOf(Parser.Success.class) //
+				.extracting(Parser.ParseResult::getRemainder) //
+				.isEqualTo(" something\"");
+	}
+
+	@Test // DATAJPA-1406
+	public void blockComment() {
+
+		assertThat(QlParser.blockComment.parse("/* something */ else*/")) //
+				.isInstanceOf(Parser.Success.class) //
+				.extracting(Parser.ParseResult::getRemainder) //
+				.isEqualTo(" else*/");
+	}
+
+	@Test // DATAJPA-1406
+	public void trivialSelect() {
+		check("Select one from table", "Select", "one", "from", "table");
+	}
+
+	@Test // DATAJPA-1406
+	public void lineBreak() {
+		check("Select one \n from table", "Select", "one", "from", "table");
+	}
+
+	@Test // DATAJPA-1406
+	public void extraWhiteSpace() {
+		check("Select one,   two from table", "Select", "one", ",", "two", "from", "table");
+	}
+
+	@Test // DATAJPA-1406
+	public void blockComments() {
+		check("Select one /*,   two*/ from table", "Select", "one", "from", "table");
+	}
+
+	@Test // DATAJPA-1406
+	public void inLineComment() {
+		check("Select one --,   two \n from table", "Select", "one", "from", "table");
+	}
+
+	@Test // DATAJPA-1406
+	public void numbers() {
+		check("select 1 as one from dual", "select", "1", "as", "one", "from", "dual");
+	}
+
+	@Test // DATAJPA-1406
+	public void stringLiterals() {
+		check("select 'one' from dual", "select", "'one'", "from", "dual");
+	}
+
+	@Test // DATAJPA-1406
+	public void bindVariables() {
+		check("select :name from dual", "select", ":name", "from", "dual");
+	}
+
+	@Test // DATAJPA-1406
+	public void subselect() {
+
+		check("Select one, (select 1 from dual), three from table", //
+				"Select", //
+				"one", //
+				",", //
+				asList( //
+						"(", //
+						asList( //
+								"select", //
+								"1", //
+								"from", //
+								"dual" //
+						), //
+						")" //
+				), //
+				",", //
+				"three", //
+				"from", //
+				"table" //
+		);
+	}
+
+	@Test // DATAJPA-1406
+	public void functionCall() {
+
+		check("Select one('something'), two from table", //
+				"Select", //
+				"one", //
+				asList( //
+						"(", //
+						singletonList("'something'"), //
+						")" //
+				), //
+				",", //
+				"two", //
+				"from", //
+				"table" //
+		);
+	}
+
+	private void check(String toParse, Object... tokens) {
+
+		List<Object> expectedTokens = asList(tokens);
+		Parser.ParseResult<String, List<Object>> parseResult = tokenizer.parse(toParse);
+
+		assertThat(parseResult).isEqualTo(new Parser.Success<>(expectedTokens, ""));
+	}
+
+}

--- a/src/test/java/org/springframework/data/jpa/repository/query/StringParsersUnitTests.java
+++ b/src/test/java/org/springframework/data/jpa/repository/query/StringParsersUnitTests.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.jpa.repository.query;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.Test;
+
+/**
+ * Unit tests for {@code String} based unit tests.
+ *
+ * @author Jens Schauder
+ */
+public class StringParsersUnitTests {
+
+	public static class KeyWordParserUnitTests {
+
+		public static final String KEYWORD_STRING = "keyword";
+		public static final Parser<String, String> KEYWORD = StringParsers.keyword(KEYWORD_STRING);
+
+		@Test // DATAJPA-1406
+		public void exactMatch() {
+
+			assertThat(KEYWORD.parse(KEYWORD_STRING)).isEqualTo(new Parser.Success<>(KEYWORD_STRING, ""));
+		}
+
+		@Test // DATAJPA-1406
+		public void ignoreCaseMatch() {
+
+			assertThat(KEYWORD.parse("kEyWoRd")).isEqualTo(new Parser.Success<>(KEYWORD_STRING, ""));
+		}
+
+		@Test // DATAJPA-1406
+		public void literalMatch() {
+
+			assertThat(StringParsers.keyword(".*").parse(KEYWORD_STRING)).isInstanceOf(Parser.Failure.class);
+			assertThat(StringParsers.keyword("Test*pattern").parse("TEST*PATTERN"))
+					.isEqualTo(new Parser.Success<>("Test*pattern", ""));
+
+		}
+
+		@Test // DATAJPA-1406
+		public void startsWithMatch() {
+
+			assertThat(KEYWORD.parse(KEYWORD_STRING + "Something"))
+					.isEqualTo(new Parser.Success<>(KEYWORD_STRING, "Something"));
+		}
+
+		@Test // DATAJPA-1406
+		public void noMatch() {
+
+			assertThat(KEYWORD.parse("Something")).isInstanceOf(Parser.Failure.class);
+		}
+
+		@Test // DATAJPA-1406
+		public void lateMatchDoesNotMatch() {
+
+			assertThat(KEYWORD.parse("Something" + KEYWORD_STRING)).isInstanceOf(Parser.Failure.class);
+		}
+	}
+
+	public static class RegexParserUnitTests {
+
+		Parser<String, String> REGEX = StringParsers.regex("ab+c*");
+
+		@Test // DATAJPA-1406
+		public void exactMatch() {
+
+			assertThat(REGEX.parse("abbb")).isEqualTo(new Parser.Success<>("abbb", ""));
+		}
+
+		@Test // DATAJPA-1406
+		public void startsWithMatch() {
+
+			assertThat(REGEX.parse("abbcc" + "Something")).isEqualTo(new Parser.Success<>("abbcc", "Something"));
+		}
+
+		@Test // DATAJPA-1406
+		public void noMatch() {
+
+			assertThat(REGEX.parse("Something")).isInstanceOf(Parser.Failure.class);
+		}
+
+		@Test // DATAJPA-1406
+		public void lateMatchDoesNotMatch() {
+
+			assertThat(REGEX.parse("Something" + "abc")).isInstanceOf(Parser.Failure.class);
+		}
+	}
+}


### PR DESCRIPTION
There is now a minimal parser combinator library available for internal use.
It's used to tokenize SQL statements and then parse the resulting list of tokens.
This identifies the primary alias, join aliases, function aliases, and order by clause.

The new parser should handle comments, character literals, quoted identifiers and subselects correctly.
It also should be easier to extend and to adapt to further requirements.