### PR TITLE
DATAJPA-1415 Specification totalElements's Bug ,When we use group By and pageable

### DIFF
--- a/src/main/java/org/springframework/data/jpa/repository/support/SimpleJpaRepository.java
+++ b/src/main/java/org/springframework/data/jpa/repository/support/SimpleJpaRepository.java
@@ -733,7 +733,7 @@ public class SimpleJpaRepository<T, ID> implements JpaRepositoryImplementation<T
 		Assert.notNull(query, "TypedQuery must not be null!");
 
 		List<Long> totals = query.getResultList();
-		return totals.size() == 1 ? totals.get(0) : totals.size());
+		return totals.size() == 1 ? totals.get(0) : totals.size();
 	}
 
 	private static boolean isUnpaged(Pageable pageable) {

--- a/src/main/java/org/springframework/data/jpa/repository/support/SimpleJpaRepository.java
+++ b/src/main/java/org/springframework/data/jpa/repository/support/SimpleJpaRepository.java
@@ -727,18 +727,12 @@ public class SimpleJpaRepository<T, ID> implements JpaRepositoryImplementation<T
 	 * @param query must not be {@literal null}.
 	 * @return
 	 */
-	private static Long executeCountQuery(TypedQuery<Long> query) {
+	private static long executeCountQuery(TypedQuery<Long> query) {
 
 		Assert.notNull(query, "TypedQuery must not be null!");
 
 		List<Long> totals = query.getResultList();
-		Long total = 0L;
-
-		for (Long element : totals) {
-			total += element == null ? 0 : element;
-		}
-
-		return total;
+		return totals.size() == 1 ? totals.get(0) : totals.size());
 	}
 
 	private static boolean isUnpaged(Pageable pageable) {

--- a/src/main/java/org/springframework/data/jpa/repository/support/SimpleJpaRepository.java
+++ b/src/main/java/org/springframework/data/jpa/repository/support/SimpleJpaRepository.java
@@ -67,6 +67,7 @@ import org.springframework.util.Assert;
  * @author Christoph Strobl
  * @author Stefan Fussenegger
  * @author Jens Schauder
+ * @author yangshaocong
  * @param <T> the type of the entity to handle
  * @param <ID> the type of the entity's identifier
  */


### PR DESCRIPTION
When we use both group By and pageable,for example:

Page<User> page = repository.findAll((root, query, cb) ->

{ query.groupBy(root.get("clazz")); return null; }
, PageRequest.of(0,10));

the page's total is not the total num after grouping,unless it's the last page.

I see in the SimpleJpaRepository.executeCountQuery, it add the count every group, but I only need the size of group,so I changed it.

I'm sorry I didn't create a test case, I'm not good with Mockito framework, and it says don't mock value objects.I don't know what to do.