### PR TITLE
DATAJPA-1416 - Unwrap proxies in JpaMetamodelEntityInformation.java.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-jpa</artifactId>
-	<version>2.1.0.BUILD-SNAPSHOT</version>
+	<version>2.1.0.DATAJPA-1416-SNAPSHOT</version>
 
 	<name>Spring Data JPA</name>
 	<description>Spring Data module for JPA repositories.</description>

--- a/src/main/java/org/springframework/data/jpa/repository/support/JpaMetamodelEntityInformation.java
+++ b/src/main/java/org/springframework/data/jpa/repository/support/JpaMetamodelEntityInformation.java
@@ -39,6 +39,7 @@ import org.springframework.data.jpa.util.JpaMetamodel;
 import org.springframework.data.util.DirectFieldAccessFallbackBeanWrapper;
 import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
+import org.springframework.util.ClassUtils;
 
 /**
  * Implementation of {@link org.springframework.data.repository.core.EntityInformation} that uses JPA {@link Metamodel}
@@ -343,8 +344,8 @@ public class JpaMetamodelEntityInformation<T, ID> extends JpaEntityInformationSu
 
 			// Derive the identifier from the nested entity that is part of the composite key.
 			@SuppressWarnings("rawtypes")
-			JpaMetamodelEntityInformation nestedEntityInformation = new JpaMetamodelEntityInformation(value.getClass(),
-					this.metamodel);
+			JpaMetamodelEntityInformation nestedEntityInformation = new JpaMetamodelEntityInformation(
+					ClassUtils.getUserClass(value), this.metamodel);
 
 			if (!nestedEntityInformation.getJavaType().isAnnotationPresent(IdClass.class)) {
 
@@ -413,7 +414,7 @@ public class JpaMetamodelEntityInformation<T, ID> extends JpaEntityInformationSu
 			}
 
 			try {
-				ManagedType<? extends Object> managedType = this.metamodel.managedType(value.getClass());
+				ManagedType<? extends Object> managedType = this.metamodel.managedType(ClassUtils.getUserClass(value));
 				return managedType != null && managedType.getPersistenceType() == PersistenceType.ENTITY;
 			} catch (IllegalArgumentException iae) {
 				// no mapped type

--- a/src/test/java/org/springframework/data/jpa/domain/sample/SampleWithIdClassIncludingEntity.java
+++ b/src/test/java/org/springframework/data/jpa/domain/sample/SampleWithIdClassIncludingEntity.java
@@ -1,0 +1,45 @@
+package org.springframework.data.jpa.domain.sample;
+
+import lombok.Data;
+
+import java.io.Serializable;
+
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.IdClass;
+import javax.persistence.ManyToOne;
+
+/**
+ * Sample class for integration testing
+ * {@link org.springframework.data.jpa.repository.support.JpaMetamodelEntityInformation}.
+ *
+ * @author Jens Schauder
+ */
+@Entity
+@IdClass(SampleWithIdClassIncludingEntity.SampleWithIdClassPK.class)
+@Data
+public class SampleWithIdClassIncludingEntity {
+
+	@Id Long first;
+	@ManyToOne @Id OtherEntity second;
+
+	@Data
+	@SuppressWarnings("serial")
+	public static class SampleWithIdClassPK implements Serializable {
+
+		Long first;
+		Long second;
+	}
+
+	@Entity
+	@Data
+	public static class OtherEntity {
+		@Id Long otherId;
+	}
+
+	/**
+	 * This class emulates a proxy at is returned from Hibernate.
+	 */
+	public static class OtherEntity$$PsudoProxy extends OtherEntity {}
+
+}

--- a/src/test/java/org/springframework/data/jpa/repository/support/EclipseLinkJpaMetamodelEntityInformationIntegrationTests.java
+++ b/src/test/java/org/springframework/data/jpa/repository/support/EclipseLinkJpaMetamodelEntityInformationIntegrationTests.java
@@ -71,13 +71,28 @@ public class EclipseLinkJpaMetamodelEntityInformationIntegrationTests
 	}
 
 	/**
-	 * Ignored due to https://bugs.eclipse.org/bugs/show_bug.cgi?id=531528 EclipseLink doesn't support
-	 * {@link javax.persistence.IdClass} referencing inner classes.
+	 * This test fails due to https://bugs.eclipse.org/bugs/show_bug.cgi?id=531528 IdentifiableType.hasSingleIdAttribute()
+	 * returns true when IdClass references an inner class. This bug is supposedly fixed, but the test still fails.
 	 */
 	@Ignore
 	@Test
 	@Override
-	public void correctlyDeterminesIdValueForNestedIdClassesWithNonPrimitiveNonManagedType() {}
+	public void correctlyDeterminesIdValueForNestedIdClassesWithNonPrimitiveNonManagedType() {
+		super.correctlyDeterminesIdValueForNestedIdClassesWithNonPrimitiveNonManagedType();
+	}
+
+	/**
+	 * This test fails due to https://bugs.eclipse.org/bugs/show_bug.cgi?id=531528 IdentifiableType.hasSingleIdAttribute()
+	 * returns true when IdClass references an inner class. This bug is supposedly fixed, but the test still fails.
+	 */
+	@Ignore
+	@Test
+	@Override
+	public void proxiedIdClassElement() {
+		super.proxiedIdClassElement();
+	}
+
+
 
 	@Override
 	protected String getMetadadataPersitenceUnitName() {

--- a/src/test/java/org/springframework/data/jpa/repository/support/JpaMetamodelEntityInformationIntegrationTests.java
+++ b/src/test/java/org/springframework/data/jpa/repository/support/JpaMetamodelEntityInformationIntegrationTests.java
@@ -15,8 +15,7 @@
  */
 package org.springframework.data.jpa.repository.support;
 
-import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.*;
+import static org.assertj.core.api.Assertions.*;
 import static org.springframework.data.jpa.repository.support.JpaEntityInformationSupport.*;
 
 import lombok.Data;
@@ -56,7 +55,7 @@ public class JpaMetamodelEntityInformationIntegrationTests {
 	public void detectsIdTypeForEntity() {
 
 		JpaEntityInformation<User, ?> information = getEntityInformation(User.class, em);
-		assertThat(information.getIdType(), is(typeCompatibleWith(Integer.class)));
+		assertThat(information.getIdType()).isAssignableFrom(Integer.class);
 	}
 
 	/**
@@ -70,14 +69,14 @@ public class JpaMetamodelEntityInformationIntegrationTests {
 	public void detectsIdTypeForMappedSuperclass() {
 
 		JpaEntityInformation<?, ?> information = getEntityInformation(AbstractPersistable.class, em);
-		assertEquals(Serializable.class, information.getIdType());
+		assertThat(information.getIdType()).isEqualTo(Serializable.class);
 	}
 
 	@Test // DATAJPA-50
 	public void detectsIdClass() {
 
 		EntityInformation<PersistableWithIdClass, ?> information = getEntityInformation(PersistableWithIdClass.class, em);
-		assertThat(information.getIdType(), is(typeCompatibleWith(PersistableWithIdClassPK.class)));
+		assertThat(information.getIdType()).isAssignableFrom(PersistableWithIdClassPK.class);
 	}
 
 	@Test // DATAJPA-50
@@ -89,7 +88,7 @@ public class JpaMetamodelEntityInformationIntegrationTests {
 				em);
 		Object id = information.getId(entity);
 
-		assertThat(id, is(new PersistableWithIdClassPK(2L, 4L)));
+		assertThat(id).isEqualTo(new PersistableWithIdClassPK(2L, 4L));
 	}
 
 	@Test // DATAJPA-413
@@ -100,7 +99,7 @@ public class JpaMetamodelEntityInformationIntegrationTests {
 		JpaEntityInformation<Item, ?> information = getEntityInformation(Item.class, em);
 		Object id = information.getId(item);
 
-		assertThat(id, is(new ItemId(2, 1)));
+		assertThat(id).isEqualTo(new ItemId(2, 1));
 	}
 
 	@Test // DATAJPA-413
@@ -114,7 +113,7 @@ public class JpaMetamodelEntityInformationIntegrationTests {
 		JpaEntityInformation<ItemSite, ?> information = getEntityInformation(ItemSite.class, em);
 		Object id = information.getId(itemSite);
 
-		assertThat(id, is(new ItemSiteId(new ItemId(1, 2), 3)));
+		assertThat(id).isEqualTo(new ItemSiteId(new ItemId(1, 2), 3));
 	}
 
 	@Test // DATAJPA-413
@@ -128,23 +127,23 @@ public class JpaMetamodelEntityInformationIntegrationTests {
 		JpaEntityInformation<ItemSite, ?> information = getEntityInformation(ItemSite.class, em);
 		Object id = information.getId(itemSite);
 
-		assertThat(id, is(new ItemSiteId(new ItemId(1, null), 3)));
+		assertThat(id).isEqualTo(new ItemSiteId(new ItemId(1, null), 3));
 	}
 
 	@Test // DATAJPA-119
 	public void favoursVersionAnnotationIfPresent() {
 
-		EntityInformation<VersionedUser, Long> information = new JpaMetamodelEntityInformation<VersionedUser, Long>(
-				VersionedUser.class, em.getMetamodel());
+		EntityInformation<VersionedUser, Long> information = new JpaMetamodelEntityInformation<>(VersionedUser.class,
+				em.getMetamodel());
 
 		VersionedUser entity = new VersionedUser();
-		assertThat(information.isNew(entity), is(true));
+		assertThat(information.isNew(entity)).isTrue();
 		entity.setId(1L);
-		assertThat(information.isNew(entity), is(true));
+		assertThat(information.isNew(entity)).isTrue();
 		entity.setVersion(1L);
-		assertThat(information.isNew(entity), is(false));
+		assertThat(information.isNew(entity)).isFalse();
 		entity.setId(null);
-		assertThat(information.isNew(entity), is(false));
+		assertThat(information.isNew(entity)).isFalse();
 	}
 
 	@Test // DATAJPA-348
@@ -153,68 +152,67 @@ public class JpaMetamodelEntityInformationIntegrationTests {
 		EntityManagerFactory emf = Persistence.createEntityManagerFactory(getMetadadataPersitenceUnitName());
 		EntityManager em = emf.createEntityManager();
 
-		EntityInformation<Sample, BaseIdClass> information = new JpaMetamodelEntityInformation<Sample, BaseIdClass>(
-				Sample.class, em.getMetamodel());
+		EntityInformation<Sample, BaseIdClass> information = new JpaMetamodelEntityInformation<>(Sample.class,
+				em.getMetamodel());
 
-		assertThat(information.getIdType(), is((Object) BaseIdClass.class));
+		assertThat(information.getIdType()).isEqualTo(BaseIdClass.class);
 	}
 
 	@Test // DATACMNS-357
 	public void detectsNewStateForEntityWithPrimitiveId() {
 
-		EntityInformation<SampleWithPrimitiveId, Long> information = new JpaMetamodelEntityInformation<SampleWithPrimitiveId, Long>(
+		EntityInformation<SampleWithPrimitiveId, Long> information = new JpaMetamodelEntityInformation<>(
 				SampleWithPrimitiveId.class, em.getMetamodel());
 
 		SampleWithPrimitiveId sample = new SampleWithPrimitiveId();
-		assertThat(information.isNew(sample), is(true));
+		assertThat(information.isNew(sample)).isTrue();
 
 		sample.setId(5L);
-		assertThat(information.isNew(sample), is(false));
+		assertThat(information.isNew(sample)).isFalse();
 	}
 
 	@Test // DATAJPA-509
 	public void jpaMetamodelEntityInformationShouldRespectExplicitlyConfiguredEntityNameFromOrmXml() {
 
-		JpaEntityInformation<Role, Integer> info = new JpaMetamodelEntityInformation<Role, Integer>(Role.class,
-				em.getMetamodel());
+		JpaEntityInformation<Role, Integer> info = new JpaMetamodelEntityInformation<>(Role.class, em.getMetamodel());
 
-		assertThat(info.getEntityName(), is("ROLE"));
+		assertThat(info.getEntityName()).isEqualTo("ROLE");
 	}
 
 	@Test // DATAJPA-561
 	public void considersEntityWithPrimitiveVersionPropertySetToDefaultNew() {
 
-		EntityInformation<PrimitiveVersionProperty, Serializable> information = new JpaMetamodelEntityInformation<PrimitiveVersionProperty, Serializable>(
+		EntityInformation<PrimitiveVersionProperty, Serializable> information = new JpaMetamodelEntityInformation<>(
 				PrimitiveVersionProperty.class, em.getMetamodel());
 
-		assertThat(information.isNew(new PrimitiveVersionProperty()), is(true));
+		assertThat(information.isNew(new PrimitiveVersionProperty())).isTrue();
 	}
 
 	@Test // DATAJPA-568
 	public void considersEntityAsNotNewWhenHavingIdSetAndUsingPrimitiveTypeForVersionProperty() {
 
-		EntityInformation<PrimitiveVersionProperty, Serializable> information = new JpaMetamodelEntityInformation<PrimitiveVersionProperty, Serializable>(
+		EntityInformation<PrimitiveVersionProperty, Serializable> information = new JpaMetamodelEntityInformation<>(
 				PrimitiveVersionProperty.class, em.getMetamodel());
 
 		PrimitiveVersionProperty pvp = new PrimitiveVersionProperty();
 		pvp.id = 100L;
 
-		assertThat(information.isNew(pvp), is(false));
+		assertThat(information.isNew(pvp)).isFalse();
 	}
 
 	@Test // DATAJPA-568
 	public void fallsBackToIdInspectionForAPrimitiveVersionProperty() {
 
-		EntityInformation<PrimitiveVersionProperty, Serializable> information = new JpaMetamodelEntityInformation<PrimitiveVersionProperty, Serializable>(
+		EntityInformation<PrimitiveVersionProperty, Serializable> information = new JpaMetamodelEntityInformation<>(
 				PrimitiveVersionProperty.class, em.getMetamodel());
 
 		PrimitiveVersionProperty pvp = new PrimitiveVersionProperty();
 		pvp.version = 1L;
 
-		assertThat(information.isNew(pvp), is(true));
+		assertThat(information.isNew(pvp)).isTrue();
 
 		pvp.id = 1L;
-		assertThat(information.isNew(pvp), is(false));
+		assertThat(information.isNew(pvp)).isFalse();
 	}
 
 	@Test // DATAJPA-582
@@ -222,7 +220,7 @@ public class JpaMetamodelEntityInformationIntegrationTests {
 
 		EntityInformation<SampleWithIdClass, ?> information = getEntityInformation(SampleWithIdClass.class, em);
 
-		assertThat(information.isNew(new SampleWithIdClass()), is(true));
+		assertThat(information.isNew(new SampleWithIdClass())).isTrue();
 	}
 
 	@Test // DATAJPA-582
@@ -234,7 +232,7 @@ public class JpaMetamodelEntityInformationIntegrationTests {
 		SampleWithTimestampVersion entity = new SampleWithTimestampVersion();
 		entity.version = new Timestamp(new Date().getTime());
 
-		assertThat(information.isNew(entity), is(false));
+		assertThat(information.isNew(entity)).isFalse();
 	}
 
 	@Test // DATAJPA-582, DATAJPA-581
@@ -243,10 +241,10 @@ public class JpaMetamodelEntityInformationIntegrationTests {
 		EntityInformation<User, ?> information = getEntityInformation(User.class, em);
 
 		User user = new User();
-		assertThat(information.isNew(user), is(true));
+		assertThat(information.isNew(user)).isTrue();
 
 		user.setId(0);
-		assertThat(information.isNew(user), is(false));
+		assertThat(information.isNew(user)).isFalse();
 	}
 
 	/**
@@ -258,7 +256,7 @@ public class JpaMetamodelEntityInformationIntegrationTests {
 
 		EntityInformation<ConcreteType1, ?> information = getEntityInformation(ConcreteType1.class, em);
 
-		assertThat(ReflectionTestUtils.getField(information, "versionAttribute"), is(notNullValue()));
+		assertThat(ReflectionTestUtils.getField(information, "versionAttribute")).isNotNull();
 	}
 
 	@Test // DATAJPA-1105
@@ -278,7 +276,7 @@ public class JpaMetamodelEntityInformationIntegrationTests {
 
 		Object id = information.getId(entity);
 
-		assertThat(id, is(notNullValue()));
+		assertThat(id).isNotNull();
 	}
 
 	@Test // DATAJPA-1416
@@ -295,12 +293,12 @@ public class JpaMetamodelEntityInformationIntegrationTests {
 
 		Object id = information.getId(entity);
 
-		assertTrue(id instanceof SampleWithIdClassIncludingEntity.SampleWithIdClassPK);
+		assertThat(id).isInstanceOf(SampleWithIdClassIncludingEntity.SampleWithIdClassPK.class);
 
 		SampleWithIdClassIncludingEntity.SampleWithIdClassPK pk = (SampleWithIdClassIncludingEntity.SampleWithIdClassPK) id;
 
-		assertThat(pk.getFirst(), equalTo(23L));
-		assertThat(pk.getSecond(), equalTo(42L));
+		assertThat(pk.getFirst()).isEqualTo(23L);
+		assertThat(pk.getSecond()).isEqualTo(42L);
 	}
 
 	protected String getMetadadataPersitenceUnitName() {

--- a/src/test/java/org/springframework/data/jpa/repository/support/JpaMetamodelEntityInformationIntegrationTests.java
+++ b/src/test/java/org/springframework/data/jpa/repository/support/JpaMetamodelEntityInformationIntegrationTests.java
@@ -281,6 +281,28 @@ public class JpaMetamodelEntityInformationIntegrationTests {
 		assertThat(id, is(notNullValue()));
 	}
 
+	@Test // DATAJPA-1416
+	public void proxiedIdClassElement() {
+
+		JpaEntityInformation<SampleWithIdClassIncludingEntity, ?> information = getEntityInformation(
+				SampleWithIdClassIncludingEntity.class, em);
+
+		SampleWithIdClassIncludingEntity entity = new SampleWithIdClassIncludingEntity();
+		entity.setFirst(23L);
+		SampleWithIdClassIncludingEntity.OtherEntity$$PsudoProxy inner = new SampleWithIdClassIncludingEntity.OtherEntity$$PsudoProxy();
+		inner.setOtherId(42L);
+		entity.setSecond(inner);
+
+		Object id = information.getId(entity);
+
+		assertTrue(id instanceof SampleWithIdClassIncludingEntity.SampleWithIdClassPK);
+
+		SampleWithIdClassIncludingEntity.SampleWithIdClassPK pk = (SampleWithIdClassIncludingEntity.SampleWithIdClassPK) id;
+
+		assertThat(pk.getFirst(), equalTo(23L));
+		assertThat(pk.getSecond(), equalTo(42L));
+	}
+
 	protected String getMetadadataPersitenceUnitName() {
 		return "metadata";
 	}

--- a/src/test/resources/META-INF/persistence.xml
+++ b/src/test/resources/META-INF/persistence.xml
@@ -42,6 +42,8 @@
 		<class>org.springframework.data.jpa.domain.sample.User</class>
 		<class>org.springframework.data.jpa.domain.sample.VersionedUser</class>
 		<class>org.springframework.data.jpa.domain.sample.Dummy</class>
+		<class>org.springframework.data.jpa.domain.sample.SampleWithIdClassIncludingEntity</class>
+		<class>org.springframework.data.jpa.domain.sample.SampleWithIdClassIncludingEntity$OtherEntity</class>
 		<exclude-unlisted-classes>true</exclude-unlisted-classes>
 	</persistence-unit>
 	<persistence-unit name="querydsl">


### PR DESCRIPTION
When JpaMetamodelEntityInfortmation operates on a proxy class it fails to detect it as an entity.
This problem is solved by unwrapping the potential proxy before passing it into JpaMetamodelEntityInformation.