### PR TITLE
DATAJPA-1418 Interface-based Projections - Generate inner join instead of left join

### DIFF
--- a/src/main/java/org/springframework/data/jpa/repository/query/JpaQueryCreator.java
+++ b/src/main/java/org/springframework/data/jpa/repository/query/JpaQueryCreator.java
@@ -52,6 +52,7 @@ import org.springframework.util.Assert;
  * @author Mark Paluch
  * @author Michael Cramer
  * @author Mark Paluch
+ * @author Reda.Housni-Alaoui
  */
 public class JpaQueryCreator extends AbstractQueryCreator<CriteriaQuery<? extends Object>, Predicate> {
 
@@ -168,7 +169,7 @@ public class JpaQueryCreator extends AbstractQueryCreator<CriteriaQuery<? extend
 			for (String property : returnedType.getInputProperties()) {
 
 				PropertyPath path = PropertyPath.from(property, returnedType.getDomainType());
-				selections.add(toExpressionRecursively(root, path).alias(property));
+				selections.add(toExpressionRecursively(root, path, true).alias(property));
 			}
 
 			query = query.multiselect(selections);

--- a/src/test/java/org/springframework/data/jpa/repository/projections/ProjectionJoinIntegrationTests.java
+++ b/src/test/java/org/springframework/data/jpa/repository/projections/ProjectionJoinIntegrationTests.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.jpa.repository.projections;
+
+import static org.assertj.core.api.Assertions.*;
+
+import lombok.Data;
+
+import javax.persistence.Access;
+import javax.persistence.AccessType;
+import javax.persistence.CascadeType;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.OneToOne;
+import javax.persistence.Table;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * @author Reda.Housni-Alaoui
+ */
+@Transactional
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration(classes = ProjectionsIntegrationTests.Config.class)
+public class ProjectionJoinIntegrationTests {
+
+	@Autowired private UserRepository userRepository;
+
+	@Test
+	public void findByIdPerformsAnOuterJoin() {
+		User user = userRepository.save(new User());
+
+		UserProjection projection = userRepository.findById(user.getId(), UserProjection.class);
+
+		assertThat(projection).isNotNull();
+		assertThat(projection.getId()).isEqualTo(user.getId());
+		assertThat(projection.getAddress()).isNull();
+	}
+
+	@Data
+	private static class UserProjection {
+
+		private final int id;
+		private final Address address;
+
+		public UserProjection(int id, Address address) {
+			this.id = id;
+			this.address = address;
+		}
+	}
+
+	public interface UserRepository extends CrudRepository<User, Integer> {
+
+		<T> T findById(int id, Class<T> projectionClass);
+	}
+
+	@Data
+	@Table(name = "ProjectionJoinIntegrationTests_User")
+	@Entity
+	static class User {
+		@Id @GeneratedValue(strategy = GenerationType.IDENTITY) @Access(value = AccessType.PROPERTY) int id;
+
+		@OneToOne(cascade = CascadeType.ALL) Address address;
+	}
+
+	@Data
+	@Table(name = "ProjectionJoinIntegrationTests_Address")
+	@Entity
+	static class Address {
+		@Id @GeneratedValue(strategy = GenerationType.IDENTITY) @Access(value = AccessType.PROPERTY) int id;
+
+		String streetName;
+	}
+}


### PR DESCRIPTION
If the PR is accepted, I think a merge to 2.0.x is needed.

By default, when a foreign entity, without further sub attribute, is involved, Hibernate generates an inner join on the table of the foreign entity. Hibernate internals do this before processing the EntityGraph. So even when the final SQL query only fetch the foreign entity ID hold by the primary table, it joins on the foreign table. I don't think Hibernate is going to change this behaviour before 6.0.

The current bug was introduced by DATAJPA-1238 fix. The goal of DATAJPA-1238 was to avoid a useless left outer join when a foreign entity was involved in the query predicate (findByX where X is an entity). Its fix removed the outer join when the navigated foreign entity was a leaf, regardless of the location of the property representing the entity.

My pull request creates a distinction between properties navigated inside the select clause and other properties (i.e. navigated in the predicate). If the entity property is a leaf outside a select clause, DATAJPA-1238 fix is kept, no outer join is generated. If the property is a leaf inside a select clause, an outer join is created as it was before DATAJPA-1238 fix.