### PR TITLE
DATAJPA-1443 - Remove incorrect JavaDoc in Specifications

### DIFF
--- a/src/main/java/org/springframework/data/jpa/domain/Specifications.java
+++ b/src/main/java/org/springframework/data/jpa/domain/Specifications.java
@@ -68,7 +68,6 @@ public class Specifications<T> implements Specification<T>, Serializable {
 	 * ANDs the given {@link Specification} to the current one.
 	 *
 	 * @deprecated since 2.0, use {@link Specification#and} instead
-	 * @param <T>
 	 * @param other can be {@literal null}.
 	 * @return
 	 */
@@ -81,7 +80,6 @@ public class Specifications<T> implements Specification<T>, Serializable {
 	 * ORs the given specification to the current one.
 	 *
 	 * @deprecated since 2.0, use {@link Specification#or} instead
-	 * @param <T>
 	 * @param other can be {@literal null}.
 	 * @return
 	 */


### PR DESCRIPTION
The type parameter for `Specifications#and` and `Specifications#or` is not method specific and thus the according JavaDoc comments are incorrect.