### PR TITLE
Fix JavaDoc link in HibernateProxyDetector

### DIFF
--- a/src/main/java/org/springframework/data/jpa/util/HibernateProxyDetector.java
+++ b/src/main/java/org/springframework/data/jpa/util/HibernateProxyDetector.java
@@ -22,7 +22,7 @@ import org.springframework.data.util.ProxyUtils.ProxyDetector;
 import org.springframework.util.ClassUtils;
 
 /**
- * {@link org.springframework.data.util.ProxyDetector} to explicitly check for Hibernate's {@link HibernateProxy}.
+ * {@link ProxyDetector} to explicitly check for Hibernate's {@link HibernateProxy}.
  * 
  * @author Oliver Gierke
  */


### PR DESCRIPTION
`ProxyDetector` is imported so there’s no need to use a full-qualified name in the JavaDoc link. It may become outdated easily – just like it did at the moment.