### PR TITLE
DATAJPA-1404 - Create explicit outer join for inverse, optional one-to-one relationships.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-jpa</artifactId>
-	<version>2.2.0.BUILD-SNAPSHOT</version>
+	<version>2.2.0.DATAJPA-1404-SNAPSHOT</version>
 
 	<name>Spring Data JPA</name>
 	<description>Spring Data module for JPA repositories.</description>

--- a/src/test/resources/META-INF/persistence.xml
+++ b/src/test/resources/META-INF/persistence.xml
@@ -78,6 +78,7 @@
 	<persistence-unit name="merchant">
 		<class>org.springframework.data.jpa.domain.sample.User</class>
 		<class>org.springframework.data.jpa.repository.query.QueryUtilsIntegrationTests$Merchant</class>
+		<class>org.springframework.data.jpa.repository.query.QueryUtilsIntegrationTests$Address</class>
 		<class>org.springframework.data.jpa.repository.query.QueryUtilsIntegrationTests$Employee</class>
 		<class>org.springframework.data.jpa.repository.query.QueryUtilsIntegrationTests$Credential</class>
 		<exclude-unlisted-classes>true</exclude-unlisted-classes>


### PR DESCRIPTION
When deciding between simple navigation and explicit outer join we consider this additional case to work around peculiar behavior of JPA implementations.

See also:
https://hibernate.atlassian.net/browse/HHH-12712
eclipse-ee4j/jpa-api#170