### PR TITLE
DATAJPA-1497 Allow to add a special parameter type from a Spring Data JPA extension

### DIFF
--- a/src/main/java/org/springframework/data/jpa/repository/query/JpaParameters.java
+++ b/src/main/java/org/springframework/data/jpa/repository/query/JpaParameters.java
@@ -33,6 +33,7 @@ import org.springframework.lang.Nullable;
  *
  * @author Thomas Darimont
  * @author Mark Paluch
+ * @author Réda Housni Alaoui
  */
 public class JpaParameters extends Parameters<JpaParameters, JpaParameter> {
 
@@ -73,7 +74,7 @@ public class JpaParameters extends Parameters<JpaParameters, JpaParameter> {
 	 * @author Thomas Darimont
 	 * @author Oliver Gierke
 	 */
-	static class JpaParameter extends Parameter {
+	public static class JpaParameter extends Parameter {
 
 		private final @Nullable Temporal annotation;
 		private @Nullable TemporalType temporalType;
@@ -83,7 +84,7 @@ public class JpaParameters extends Parameters<JpaParameters, JpaParameter> {
 		 *
 		 * @param parameter must not be {@literal null}.
 		 */
-		JpaParameter(MethodParameter parameter) {
+		protected JpaParameter(MethodParameter parameter) {
 
 			super(parameter);
 

--- a/src/main/java/org/springframework/data/jpa/repository/query/JpaQueryMethod.java
+++ b/src/main/java/org/springframework/data/jpa/repository/query/JpaQueryMethod.java
@@ -54,6 +54,7 @@ import org.springframework.util.StringUtils;
  * @author Nicolas Cirigliano
  * @author Mark Paluch
  * @author Сергей Цыпанов
+ * @author Réda Housni Alaoui
  */
 public class JpaQueryMethod extends QueryMethod {
 
@@ -97,7 +98,7 @@ public class JpaQueryMethod extends QueryMethod {
 	 * @param factory must not be {@literal null}
 	 * @param extractor must not be {@literal null}
 	 */
-	public JpaQueryMethod(Method method, RepositoryMetadata metadata, ProjectionFactory factory,
+	protected JpaQueryMethod(Method method, RepositoryMetadata metadata, ProjectionFactory factory,
 			QueryExtractor extractor) {
 
 		super(method, metadata, factory);
@@ -425,5 +426,20 @@ public class JpaQueryMethod extends QueryMethod {
 		}
 
 		return storedProcedureAttributes;
+	}
+
+	public static class Factory implements JpaQueryMethodFactory {
+
+		public static final Factory INSTANCE = new Factory();
+
+		private Factory() {
+
+		}
+
+		@Override
+		public JpaQueryMethod build(Method method, RepositoryMetadata metadata, ProjectionFactory factory,
+				QueryExtractor extractor) {
+			return new JpaQueryMethod(method, metadata, factory, extractor);
+		}
 	}
 }

--- a/src/main/java/org/springframework/data/jpa/repository/query/JpaQueryMethodFactory.java
+++ b/src/main/java/org/springframework/data/jpa/repository/query/JpaQueryMethodFactory.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2012-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.jpa.repository.query;
+
+import java.lang.reflect.Method;
+
+import org.springframework.data.jpa.provider.QueryExtractor;
+import org.springframework.data.projection.ProjectionFactory;
+import org.springframework.data.repository.core.RepositoryMetadata;
+
+/**
+ * @author Réda Housni Alaoui
+ */
+public interface JpaQueryMethodFactory {
+
+	/**
+	 * Creates a {@link JpaQueryMethod}.
+	 *
+	 * @param method must not be {@literal null}
+	 * @param metadata must not be {@literal null}
+	 * @param factory must not be {@literal null}
+	 * @param extractor must not be {@literal null}
+	 */
+	JpaQueryMethod build(Method method, RepositoryMetadata metadata, ProjectionFactory factory, QueryExtractor extractor);
+
+}

--- a/src/main/java/org/springframework/data/jpa/repository/support/JpaRepositoryFactoryBean.java
+++ b/src/main/java/org/springframework/data/jpa/repository/support/JpaRepositoryFactoryBean.java
@@ -21,6 +21,8 @@ import javax.persistence.PersistenceContext;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.jpa.repository.query.EscapeCharacter;
+import org.springframework.data.jpa.repository.query.JpaQueryMethod;
+import org.springframework.data.jpa.repository.query.JpaQueryMethodFactory;
 import org.springframework.data.mapping.context.MappingContext;
 import org.springframework.data.querydsl.EntityPathResolver;
 import org.springframework.data.querydsl.SimpleEntityPathResolver;
@@ -38,6 +40,7 @@ import org.springframework.util.Assert;
  * @author Eberhard Wolff
  * @author Mark Paluch
  * @author Jens Schauder
+ * @author Réda Housni Alaoui
  * @param <T> the type of the repository
  */
 public class JpaRepositoryFactoryBean<T extends Repository<S, ID>, S, ID>
@@ -46,6 +49,7 @@ public class JpaRepositoryFactoryBean<T extends Repository<S, ID>, S, ID>
 	private @Nullable EntityManager entityManager;
 	private EntityPathResolver entityPathResolver;
 	private EscapeCharacter escapeCharacter = EscapeCharacter.DEFAULT;
+	private JpaQueryMethodFactory queryMethodFactory;
 
 	/**
 	 * Creates a new {@link JpaRepositoryFactoryBean} for the given repository interface.
@@ -86,6 +90,17 @@ public class JpaRepositoryFactoryBean<T extends Repository<S, ID>, S, ID>
 		this.entityPathResolver = resolver.getIfAvailable(() -> SimpleEntityPathResolver.INSTANCE);
 	}
 
+	/**
+	 * Configures the {@link JpaQueryMethodFactory} to be used. Will expect a canonical bean to be present but fallback to
+	 * {@link JpaQueryMethod.Factory#INSTANCE} in case none is available.
+	 *
+	 * @param resolver must not be {@literal null}.
+	 */
+	@Autowired
+	public void setQueryMethodFactory(ObjectProvider<JpaQueryMethodFactory> resolver) {
+		this.queryMethodFactory = resolver.getIfAvailable(() -> JpaQueryMethod.Factory.INSTANCE);
+	}
+
 	/*
 	 * (non-Javadoc)
 	 * @see org.springframework.data.repository.core.support.TransactionalRepositoryFactoryBeanSupport#doCreateRepositoryFactory()
@@ -106,6 +121,8 @@ public class JpaRepositoryFactoryBean<T extends Repository<S, ID>, S, ID>
 		JpaRepositoryFactory jpaRepositoryFactory = new JpaRepositoryFactory(entityManager);
 		jpaRepositoryFactory.setEntityPathResolver(entityPathResolver);
 		jpaRepositoryFactory.setEscapeCharacter(escapeCharacter);
+		jpaRepositoryFactory.setQueryMethodFactory(queryMethodFactory);
+
 		return jpaRepositoryFactory;
 	}
 

--- a/src/test/java/org/springframework/data/jpa/repository/query/CustomNonBindableJpaParametersTests.java
+++ b/src/test/java/org/springframework/data/jpa/repository/query/CustomNonBindableJpaParametersTests.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2013-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.jpa.repository.query;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.lang.reflect.Method;
+import java.util.Optional;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.context.annotation.ImportResource;
+import org.springframework.core.MethodParameter;
+import org.springframework.data.jpa.domain.sample.Product;
+import org.springframework.data.jpa.provider.QueryExtractor;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+import org.springframework.data.projection.ProjectionFactory;
+import org.springframework.data.repository.core.RepositoryMetadata;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+/**
+ * @author Réda Housni Alaoui
+ */
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration
+public class CustomNonBindableJpaParametersTests {
+
+	@Autowired ProductRepository products;
+
+	@Test
+	public void test() {
+		Product product = products.save(new Product());
+		assertThat(products.findById(product.getId(), new NonBindable())).isNotEmpty();
+	}
+
+	private static class NonBindable {
+
+	}
+
+	public interface ProductRepository extends JpaRepository<Product, Long> {
+		Optional<Product> findById(long id, NonBindable nonBindable);
+	}
+
+	private static class NonBindableAwareJpaParameter extends JpaParameters.JpaParameter {
+
+		private final MethodParameter parameter;
+
+		NonBindableAwareJpaParameter(MethodParameter parameter) {
+			super(parameter);
+			this.parameter = parameter;
+		}
+
+		@Override
+		public boolean isBindable() {
+			return !NonBindable.class.equals(parameter.getParameterType()) && super.isBindable();
+		}
+	}
+
+	private static class NonBindableAwareJpaParameters extends JpaParameters {
+
+		public NonBindableAwareJpaParameters(Method method) {
+			super(method);
+		}
+
+		@Override
+		protected JpaParameter createParameter(MethodParameter parameter) {
+			return new NonBindableAwareJpaParameter(parameter);
+		}
+	}
+
+	private static class NonBindableAwareJpaQueryMethod extends JpaQueryMethod {
+
+		NonBindableAwareJpaQueryMethod(Method method, RepositoryMetadata metadata, ProjectionFactory factory,
+				QueryExtractor extractor) {
+			super(method, metadata, factory, extractor);
+		}
+
+		@Override
+		protected JpaParameters createParameters(Method method) {
+			return new NonBindableAwareJpaParameters(method);
+		}
+	}
+
+	private static class NonBindableAwareJpaQueryMethodFactory implements JpaQueryMethodFactory {
+
+		@Override
+		public JpaQueryMethod build(Method method, RepositoryMetadata metadata, ProjectionFactory factory,
+				QueryExtractor extractor) {
+			return new NonBindableAwareJpaQueryMethod(method, metadata, factory, extractor);
+		}
+	}
+
+	@Configuration
+	@ImportResource("classpath:infrastructure.xml")
+	@EnableJpaRepositories(considerNestedRepositories = true, basePackageClasses = ProductRepository.class, //
+			includeFilters = @ComponentScan.Filter(value = { ProductRepository.class }, type = FilterType.ASSIGNABLE_TYPE))
+	static class Config {
+
+		@Bean
+		JpaQueryMethodFactory jpaQueryMethodFactory() {
+			return new NonBindableAwareJpaQueryMethodFactory();
+		}
+
+	}
+
+}

--- a/src/test/java/org/springframework/data/jpa/repository/query/JpaQueryLookupStrategyUnitTests.java
+++ b/src/test/java/org/springframework/data/jpa/repository/query/JpaQueryLookupStrategyUnitTests.java
@@ -15,9 +15,9 @@
  */
 package org.springframework.data.jpa.repository.query;
 
-import static org.assertj.core.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.*;
-import static org.mockito.Mockito.*;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
 
 import java.lang.reflect.Method;
 import java.util.List;
@@ -50,11 +50,13 @@ import org.springframework.data.repository.query.QueryMethodEvaluationContextPro
  * @author Oliver Gierke
  * @author Thomas Darimont
  * @author Jens Schauder
+ * @author Réda Housni Alaoui
  */
 @RunWith(MockitoJUnitRunner.class)
 public class JpaQueryLookupStrategyUnitTests {
 
 	private static final QueryMethodEvaluationContextProvider EVALUATION_CONTEXT_PROVIDER = QueryMethodEvaluationContextProvider.DEFAULT;
+	private static final JpaQueryMethodFactory QUERY_METHOD_FACTORY = JpaQueryMethod.Factory.INSTANCE;
 
 	@Mock EntityManager em;
 	@Mock EntityManagerFactory emf;
@@ -76,7 +78,7 @@ public class JpaQueryLookupStrategyUnitTests {
 	public void invalidAnnotatedQueryCausesException() throws Exception {
 
 		QueryLookupStrategy strategy = JpaQueryLookupStrategy.create(em, Key.CREATE_IF_NOT_FOUND, extractor,
-				EVALUATION_CONTEXT_PROVIDER, EscapeCharacter.DEFAULT);
+				QUERY_METHOD_FACTORY, EVALUATION_CONTEXT_PROVIDER, EscapeCharacter.DEFAULT);
 		Method method = UserRepository.class.getMethod("findByFoo", String.class);
 		RepositoryMetadata metadata = new DefaultRepositoryMetadata(UserRepository.class);
 
@@ -92,7 +94,7 @@ public class JpaQueryLookupStrategyUnitTests {
 	public void sholdThrowMorePreciseExceptionIfTryingToUsePaginationInNativeQueries() throws Exception {
 
 		QueryLookupStrategy strategy = JpaQueryLookupStrategy.create(em, Key.CREATE_IF_NOT_FOUND, extractor,
-				EVALUATION_CONTEXT_PROVIDER, EscapeCharacter.DEFAULT);
+				QUERY_METHOD_FACTORY, EVALUATION_CONTEXT_PROVIDER, EscapeCharacter.DEFAULT);
 		Method method = UserRepository.class.getMethod("findByInvalidNativeQuery", String.class, Sort.class);
 		RepositoryMetadata metadata = new DefaultRepositoryMetadata(UserRepository.class);
 


### PR DESCRIPTION
This change allows to add a special parameter type by overriding org.springframework.data.jpa.repository.query.JpaParameters.JpaParameter.isBindable()