### PR TITLE
Fixing a typo Montary -> Monetary

### DIFF
--- a/src/main/asciidoc/jpa.adoc
+++ b/src/main/asciidoc/jpa.adoc
@@ -722,7 +722,7 @@ public class CustomerSpecs {
     };
   }
 
-  public static Specification<Customer> hasSalesOfMoreThan(MontaryAmount value) {
+  public static Specification<Customer> hasSalesOfMoreThan(MonetaryAmount value) {
     return new Specification<Customer>() {
       public Predicate toPredicate(Root<T> root, CriteriaQuery<?> query,
             CriteriaBuilder builder) {


### PR DESCRIPTION
Fixing a simple typo, obvious fix.