### PR TITLE
DATAJPA-1549 - Polish StoredProcedureAttributeSourceUnitTests

### DIFF
--- a/src/test/java/org/springframework/data/jpa/repository/query/StoredProcedureAttributeSourceUnitTests.java
+++ b/src/test/java/org/springframework/data/jpa/repository/query/StoredProcedureAttributeSourceUnitTests.java
@@ -103,7 +103,7 @@ public class StoredProcedureAttributeSourceUnitTests {
 		assertThat(attr.getOutputParameterName(), is(StoredProcedureAttributes.SYNTHETIC_OUTPUT_PARAMETER_NAME));
 	}
         
-    @Test // DATAJPA-1297
+	@Test // DATAJPA-1297
 	public void shouldCreateStoredProcedureAttributesFromProcedureMethodWithExplictProcedureNameAliasAndOutputParameterName() {
 
 		StoredProcedureAttributes attr = creator
@@ -179,7 +179,7 @@ public class StoredProcedureAttributeSourceUnitTests {
 		Integer explicitPlus1inoutViaProcedureNameAlias(Integer arg);
 
                 /**
-		 * Explicitly mapped to a procedure with name "plus1inout" in database via alias and explicityly named ouput parameter.
+		 * Explicitly mapped to a procedure with name "plus1inout" in database via alias and explicitly named ouput parameter.
 		 */
 		@Procedure(procedureName = "plus1inout", outputParameterName = "res") // DATAJPA-1297
 		Integer explicitPlus1inoutViaProcedureNameAliasAndOutputParameterName(Integer arg);


### PR DESCRIPTION
This PR polishes `StoredProcedureAttributeSourceUnitTests` simply by fixing indentation and typo.