### PR TITLE
URL Cleanup

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 
 	<modelVersion>4.0.0</modelVersion>
 
@@ -9,7 +9,7 @@
 
 	<name>Spring Data JPA</name>
 	<description>Spring Data module for JPA repositories.</description>
-	<url>http://projects.spring.io/spring-data-jpa</url>
+	<url>https://projects.spring.io/spring-data-jpa</url>
 
 	<parent>
 		<groupId>org.springframework.data.build</groupId>
@@ -306,7 +306,7 @@
 					<artifactId>commons-logging</artifactId>
 				</exclusion>
 				<!-- Transitive dependency pulls in JUnit 3.8.1 -->
-				<!-- http://sourceforge.net/tracker/?func=detail&aid=2572567&group_id=31479&atid=402282 -->
+				<!-- https://sourceforge.net/tracker/?func=detail&aid=2572567&group_id=31479&atid=402282 -->
 				<exclusion>
 					<groupId>junit</groupId>
 					<artifactId>junit</artifactId>


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* http://maven.apache.org/xsd/maven-4.0.0.xsd with 1 occurrences migrated to:  
  https://maven.apache.org/xsd/maven-4.0.0.xsd ([https](https://maven.apache.org/xsd/maven-4.0.0.xsd) result 200).
* http://projects.spring.io/spring-data-jpa with 1 occurrences migrated to:  
  https://projects.spring.io/spring-data-jpa ([https](https://projects.spring.io/spring-data-jpa) result 301).
* http://sourceforge.net/tracker/?func=detail&aid=2572567&group_id=31479&atid=402282 with 1 occurrences migrated to:  
  https://sourceforge.net/tracker/?func=detail&aid=2572567&group_id=31479&atid=402282 ([https](https://sourceforge.net/tracker/?func=detail&aid=2572567&group_id=31479&atid=402282) result 301).

# Ignored
These URLs were intentionally ignored.

* http://maven.apache.org/POM/4.0.0 with 2 occurrences
* http://www.w3.org/2001/XMLSchema-instance with 1 occurrences