### PR TITLE
DATAJPA-1506 - Fix alias detection for native query.

### DIFF
--- a/src/main/java/org/springframework/data/jpa/repository/query/QueryUtils.java
+++ b/src/main/java/org/springframework/data/jpa/repository/query/QueryUtils.java
@@ -76,6 +76,7 @@ import org.springframework.util.StringUtils;
  * @author Jens Schauder
  * @author Nils Borrmann
  * @author Reda.Housni-Alaoui
+ * @author Florian Lüdiger
  */
 public abstract class QueryUtils {
 
@@ -133,7 +134,7 @@ public abstract class QueryUtils {
 		builder.append(IDENTIFIER_GROUP); // Entity name, can be qualified (any
 		builder.append("(?:\\sas)*"); // exclude possible "as" keyword
 		builder.append("(?:\\s)+"); // at least one space separating
-		builder.append("(?!(?:where))(\\w+)"); // the actual alias
+		builder.append("(?!(?:where|group by|order by))(\\w+)"); // the actual alias
 
 		ALIAS_MATCH = compile(builder.toString(), CASE_INSENSITIVE);
 

--- a/src/test/java/org/springframework/data/jpa/repository/query/QueryUtilsUnitTests.java
+++ b/src/test/java/org/springframework/data/jpa/repository/query/QueryUtilsUnitTests.java
@@ -38,6 +38,7 @@ import org.springframework.data.jpa.domain.JpaSort;
  * @author Komi Innocent
  * @author Christoph Strobl
  * @author Jens Schauder
+ * @author Florian Lüdiger
  */
 public class QueryUtilsUnitTests {
 
@@ -114,6 +115,11 @@ public class QueryUtilsUnitTests {
 		assertThat(detectAlias("select u from  User u"), IS_U);
 		assertThat(detectAlias("select u from  com.acme.User u"), IS_U);
 		assertThat(detectAlias("select u from T05User u"), IS_U);
+		assertThat(detectAlias("select * from User group by name"), isEmptyOrNullString());
+		assertThat(detectAlias("select * from User order by name"), isEmptyOrNullString());
+		assertThat(detectAlias("select * from User u group by name"), IS_U);
+		assertThat(detectAlias("select * from User u order by name"), IS_U);
+
 	}
 
 	@Test


### PR DESCRIPTION
When no alias is specified in a native query that does not contain a WHERE clause right after the FROM clause, this is now correctly detected.

[Link to Jira Ticket](https://jira.spring.io/browse/DATAJPA-1506)

I have added support for the `ORDER BY` and `GROUP BY` clauses because these are fairly common and available in almost every SQL flavor. Should I consider to add more possible clauses like `LIMIT`?