### PR TITLE
DATAJPA-1500 - Fix RegEx to support whitespace characters at the end.

### DIFF
--- a/src/main/java/org/springframework/data/jpa/repository/query/QueryUtils.java
+++ b/src/main/java/org/springframework/data/jpa/repository/query/QueryUtils.java
@@ -95,7 +95,7 @@ public abstract class QueryUtils {
 	private static final String COUNT_REPLACEMENT_TEMPLATE = "select count(%s) $5$6$7";
 	private static final String SIMPLE_COUNT_VALUE = "$2";
 	private static final String COMPLEX_COUNT_VALUE = "$3$6";
-	private static final String ORDER_BY_PART = "(?iu)\\s+order\\s+by\\s+.*$";
+	private static final String ORDER_BY_PART = "(?iu)\\s+order\\s+by\\s+.*";
 
 	private static final Pattern ALIAS_MATCH;
 	private static final Pattern COUNT_MATCH;

--- a/src/test/java/org/springframework/data/jpa/repository/query/QueryUtilsUnitTests.java
+++ b/src/test/java/org/springframework/data/jpa/repository/query/QueryUtilsUnitTests.java
@@ -413,6 +413,15 @@ public class QueryUtilsUnitTests {
 		assertThat(detectAlias("select * from User u order by name")).isEqualTo("u");
 	}
 
+	@Test // DATAJPA-1500
+	public void createCountQuerySupportsWhitespaceCharacters() {
+		assertThat(createCountQueryFor("select * from User user\n" +
+						"  where user.age = 18\n" +
+						"  order by user.name\n "),
+				is("select count(user) from User user\n" +
+						"  where user.age = 18\n "));
+	}
+
 	private static void assertCountQuery(String originalQuery, String countQuery) {
 		assertThat(createCountQueryFor(originalQuery), is(countQuery));
 	}


### PR DESCRIPTION
When using the creteCountQueryFor method before, the order by clause did not get removed when having a specific combination of whitespace characters at the end of the input.
By removing the $ for matching the end of the line, this is now fixed.

[Link to the issue in Jira](https://jira.spring.io/browse/DATAJPA-1500)
