### PR TITLE
DATAJPA-1562 - Made projections work with late Hibernate 4 versions.  

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-jpa</artifactId>
-	<version>1.11.23.BUILD-SNAPSHOT</version>
+	<version>1.11.23.DATAJPA-1562-on-1-11-SNAPSHOT</version>
 
 	<name>Spring Data JPA</name>
 	<description>Spring Data module for JPA repositories.</description>

--- a/src/main/java/org/springframework/data/jpa/provider/HibernateUtils.java
+++ b/src/main/java/org/springframework/data/jpa/provider/HibernateUtils.java
@@ -27,7 +27,9 @@ import org.springframework.util.ReflectionUtils;
 /**
  * Utility functions to work with Hibernate. Mostly using reflection to make sure common functionality can be executed
  * against all the Hibernate version we support.
- * 
+ *
+ * @author Oliver Gierke
+ * @author Jens Schauder
  * @since 1.10.2
  * @soundtrack Benny Greb - Soulfood (Live, https://www.youtube.com/watch?v=9_ErMa_CtSw)
  */
@@ -36,6 +38,11 @@ public abstract class HibernateUtils {
 
 	private static final List<String> TYPES = Arrays.asList("org.hibernate.jpa.HibernateQuery",
 			"org.hibernate.ejb.HibernateQuery");
+
+	private static final Version HIBERNATE4_VERSION_SUPPORTING_TUPLES = new Version(4, 2, 21);
+	private static final Version HIBERNATE5_VERSION = new Version(5, 0, 0);
+	private static final Version HIBERNATE5_VERSION_SUPPORTING_TUPLES = new Version(5, 2, 11);
+
 	private static final Method GET_HIBERNATE_QUERY;
 
 	private static final Class<?> HIBERNATE_QUERY_INTERFACE;
@@ -102,5 +109,37 @@ public abstract class HibernateUtils {
 	 */
 	public static boolean isVersionOrBetter(Version version) {
 		return HIBERNATE_VERSION.isGreaterThanOrEqualTo(version);
+	}
+
+	/**
+	 * Returns whether the currently used version of Hibernate is in the given interval of versions.
+	 *
+	 * @param lowerIncluding lower version bound to compare to. The lower version bound is inclusive. Must not be
+	 *          {@literal null}.
+	 * @param upperExcluding upper version bound to compare to. The upper version bound is exclusive. Must not be
+	 *          {@literal null}.
+	 * @return whence lowerIncluding <= Hibernate version < upperExcluding.
+	 */
+	private static boolean isVersionInInterval(Version lowerIncluding, Version upperExcluding) {
+		return HIBERNATE_VERSION.isGreaterThanOrEqualTo(lowerIncluding) && HIBERNATE_VERSION.isLessThan(upperExcluding);
+	}
+
+	/**
+	 * Returns wether the current version of Hibernate supports {@link javax.persistence.Tuple} as a return type for
+	 * native queries.
+	 */
+	public static boolean supportsTuples() {
+
+		return HibernateUtils.isVersionInInterval(HIBERNATE4_VERSION_SUPPORTING_TUPLES, HIBERNATE5_VERSION)
+				|| HibernateUtils.isVersionOrBetter(HIBERNATE5_VERSION_SUPPORTING_TUPLES);
+	}
+
+	/**
+	 * Returns wether the current version of Hibernate supports {@link javax.persistence.Tuple} as a return type for
+	 * native queries.
+	 */
+	public static boolean supportsTuplesForNativeQueries() {
+
+		return HibernateUtils.isVersionOrBetter(HIBERNATE5_VERSION_SUPPORTING_TUPLES);
 	}
 }

--- a/src/main/java/org/springframework/data/jpa/repository/query/AbstractJpaQuery.java
+++ b/src/main/java/org/springframework/data/jpa/repository/query/AbstractJpaQuery.java
@@ -47,7 +47,6 @@ import org.springframework.data.repository.query.ParametersParameterAccessor;
 import org.springframework.data.repository.query.RepositoryQuery;
 import org.springframework.data.repository.query.ResultProcessor;
 import org.springframework.data.repository.query.ReturnedType;
-import org.springframework.data.util.Version;
 import org.springframework.util.Assert;
 
 /**
@@ -57,10 +56,9 @@ import org.springframework.util.Assert;
  * @author Thomas Darimont
  * @author Mark Paluch
  * @author Nicolas Cirigliano
+ * @author Jens Schauder
  */
 public abstract class AbstractJpaQuery implements RepositoryQuery {
-
-	protected static final Version HIBERNATE_VERSION_SUPPORTING_TUPLES = new Version(5, 2, 11);
 
 	private final JpaQueryMethod method;
 	private final EntityManager em;
@@ -242,9 +240,11 @@ public abstract class AbstractJpaQuery implements RepositoryQuery {
 			return null;
 		}
 
-		return returnedType.isProjecting() && !getMetamodel().isJpaManaged(returnedType.getReturnedType()) //
-				? HibernateUtils.isVersionOrBetter(HIBERNATE_VERSION_SUPPORTING_TUPLES) ? Tuple.class : null //
-				: null;
+		return returnedType.isProjecting() //
+				&& !getMetamodel().isJpaManaged(returnedType.getReturnedType()) //
+				&& HibernateUtils.supportsTuples() //
+						? Tuple.class //
+						: null;
 	}
 
 	/**

--- a/src/main/java/org/springframework/data/jpa/repository/query/NativeJpaQuery.java
+++ b/src/main/java/org/springframework/data/jpa/repository/query/NativeJpaQuery.java
@@ -81,8 +81,10 @@ final class NativeJpaQuery extends AbstractStringBasedJpaQuery {
 			return result;
 		}
 
-		return returnedType.isProjecting() && !getMetamodel().isJpaManaged(returnedType.getReturnedType()) //
-				? HibernateUtils.isVersionOrBetter(HIBERNATE_VERSION_SUPPORTING_TUPLES) ? Tuple.class : null //
-				: result;
+		return returnedType.isProjecting() //
+				&& !getMetamodel().isJpaManaged(returnedType.getReturnedType()) //
+				&& HibernateUtils.supportsTuplesForNativeQueries() //
+						? Tuple.class //
+						: result;
 	}
 }

--- a/src/test/java/org/springframework/data/jpa/infrastructure/MetamodelIntegrationTests.java
+++ b/src/test/java/org/springframework/data/jpa/infrastructure/MetamodelIntegrationTests.java
@@ -102,7 +102,7 @@ public abstract class MetamodelIntegrationTests {
 		assertThat(elements.get(0).getAlias(), is(nullValue()));
 	}
 
-	@Test
+	@Test // DATAJPA-1273
 	@Transactional
 	public void returnsAliasesInTuple() {
 

--- a/src/test/java/org/springframework/data/jpa/repository/EclipseLinkNamespaceUserRepositoryTests.java
+++ b/src/test/java/org/springframework/data/jpa/repository/EclipseLinkNamespaceUserRepositoryTests.java
@@ -24,7 +24,6 @@ import javax.persistence.Query;
 import org.junit.Assume;
 import org.junit.Ignore;
 import org.junit.Test;
-
 import org.springframework.data.jpa.repository.sample.UserRepository;
 import org.springframework.data.util.Version;
 import org.springframework.test.context.ContextConfiguration;
@@ -123,6 +122,12 @@ public class EclipseLinkNamespaceUserRepositoryTests extends NamespaceUserReposi
 	@Override
 	@Test
 	public void bindsNativeQueryResultsToProjectionByName() {}
+
+	/**
+	 * TODO: Remove, once https://bugs.eclipse.org/bugs/show_bug.cgi?id=289141 is fixed.
+	 */
+	@Override
+	public void findListOfMap() {}
 
 	/**
 	 * Ignores the test for EclipseLink 2.7.2. Reconsider once https://bugs.eclipse.org/bugs/show_bug.cgi?id=533240 is

--- a/src/test/java/org/springframework/data/jpa/repository/OpenJpaNamespaceUserRepositoryTests.java
+++ b/src/test/java/org/springframework/data/jpa/repository/OpenJpaNamespaceUserRepositoryTests.java
@@ -132,6 +132,12 @@ public class OpenJpaNamespaceUserRepositoryTests extends NamespaceUserRepository
 	 * ignored since OpenJPA doesn't support tuples
 	 */
 	@Override
+	public void findListOfMap() {}
+
+	/**
+	 * ignored since OpenJPA doesn't support tuples
+	 */
+	@Override
 	public void supportsProjectionsWithNativeQueries() {}
 
 	/**

--- a/src/test/java/org/springframework/data/jpa/repository/sample/UserRepository.java
+++ b/src/test/java/org/springframework/data/jpa/repository/sample/UserRepository.java
@@ -493,6 +493,10 @@ public interface UserRepository
 	@Query("select firstname as firstname, lastname as lastname from User u where u.firstname = 'Oliver'")
 	Map<String, Object> findMapWithNullValues();
 
+	// DATAJPA-1562
+	@Query("select firstname as firstname, lastname as lastname from User u")
+	List<Map<String, Object>> findListOfMaps();
+
 	// DATAJPA-1334
 	List<NameOnlyDto> findByNamedQueryWithConstructorExpression();
 


### PR DESCRIPTION
For Projections we check the Hibernate version to make sure it supports Tuples.
This was only done based on Hibernate 5 versions although some Hibernate 4 versions do so as well.
This is now taken in consideration for the version check.

The actual versions used are determined by trial and error because no clear documentation when this was introduced to Hibernate could be found.

**This is only needed on the 1.11.x branch because the other versions only support later Hibernate versions anyway**