### PR TITLE
DATAJPA-1544 - Delete totals.size() == 1 condition in count method

### DIFF
--- a/src/main/java/org/springframework/data/jpa/repository/query/JpaQueryExecution.java
+++ b/src/main/java/org/springframework/data/jpa/repository/query/JpaQueryExecution.java
@@ -211,18 +211,28 @@ public abstract class JpaQueryExecution {
 
 		private long count(AbstractJpaQuery repositoryQuery, Object[] values) {
 			StringBuilder builder = new StringBuilder();
-			builder.append("(.*)?(group\\s+by\\s+).*");
-			Pattern GROUP_MATCH = compile(builder.toString(), CASE_INSENSITIVE);
+			String queryString;
 			
 			List<?> totals = repositoryQuery.createCountQuery(values).getResultList();
 			
-			Matcher matcher = GROUP_MATCH.matcher(repositoryQuery.getQueryMethod().getCountQuery());
+			if(repositoryQuery instanceof AbstractStringBasedJpaQuery) {
+				queryString = ((AbstractStringBasedJpaQuery)repositoryQuery).getQuery().getQueryString();
+			} else if(repositoryQuery instanceof NamedQuery) {
+				queryString = ((NamedQuery)repositoryQuery).getQuery().getQueryString();
+			} else {
+				//OartTreeJpaQuery, StoredProcedureJpaQuery, etc.
+				queryString = "";
+			}
+			
+			builder.append("(.*)?(group\\s+by\\s+).*");
+			Pattern GROUP_MATCH = compile(builder.toString(), CASE_INSENSITIVE);
+			Matcher matcher = GROUP_MATCH.matcher(queryString);
+			
 			if(matcher.matches()) {
 				return totals.size();
 			} else {
 				return (totals.size() == 1 ? CONVERSION_SERVICE.convert(totals.get(0), Long.class) : totals.size());
 			}
-
 		}
 	}
 

--- a/src/main/java/org/springframework/data/jpa/repository/query/JpaQueryExecution.java
+++ b/src/main/java/org/springframework/data/jpa/repository/query/JpaQueryExecution.java
@@ -56,6 +56,7 @@ import org.springframework.util.ReflectionUtils;
  * @author Christoph Strobl
  * @author Nicolas Cirigliano
  * @author Jens Schauder
+ * @author Chao Jiang
  */
 public abstract class JpaQueryExecution {
 
@@ -206,7 +207,7 @@ public abstract class JpaQueryExecution {
 		private long count(AbstractJpaQuery repositoryQuery, Object[] values) {
 
 			List<?> totals = repositoryQuery.createCountQuery(values).getResultList();
-			return (totals.size() == 1 ? CONVERSION_SERVICE.convert(totals.get(0), Long.class) : totals.size());
+			return totals.size();
 		}
 	}
 

--- a/src/main/java/org/springframework/data/jpa/repository/query/NamedQuery.java
+++ b/src/main/java/org/springframework/data/jpa/repository/query/NamedQuery.java
@@ -41,6 +41,7 @@ import org.springframework.lang.Nullable;
  * @author Oliver Gierke
  * @author Thomas Darimont
  * @author Mark Paluch
+ * @author Chao Jiang
  */
 final class NamedQuery extends AbstractJpaQuery {
 
@@ -223,5 +224,12 @@ final class NamedQuery extends AbstractJpaQuery {
 		return declaredQuery.hasConstructorExpression() //
 				? Optional.empty() //
 				: super.getTypeToRead(returnedType);
+	}
+	
+	/**
+	 * @return the query
+	 */
+	public DeclaredQuery getQuery() {
+		return declaredQuery;
 	}
 }

--- a/src/test/java/org/springframework/data/jpa/repository/query/JpaQueryExecutionUnitTests.java
+++ b/src/test/java/org/springframework/data/jpa/repository/query/JpaQueryExecutionUnitTests.java
@@ -191,13 +191,13 @@ public class JpaQueryExecutionUnitTests {
 		PagedExecution execution = new PagedExecution(parameters);
 		Page<Object> page = (Page<Object>) execution.doExecute(jpaQuery, new Object[] { PageRequest.of(0, 1) });
 
-    assertEquals(page.getTotalElements(), 20);
+		assertEquals(page.getTotalElements(), 20);
 
 		when(declaredQuery.getQueryString()).thenReturn("select count(1) from User u group by u.id");
 				
 		page = (Page<Object>) execution.doExecute(jpaQuery, new Object[] { PageRequest.of(0, 1) });
 		
-    assertEquals(page.getTotalElements(), 1);
+		assertEquals(page.getTotalElements(), 1);
 
 	}
 

--- a/src/test/java/org/springframework/data/jpa/repository/query/JpaQueryExecutionUnitTests.java
+++ b/src/test/java/org/springframework/data/jpa/repository/query/JpaQueryExecutionUnitTests.java
@@ -68,6 +68,7 @@ public class JpaQueryExecutionUnitTests {
 		when(query.executeUpdate()).thenReturn(0);
 		when(jpaQuery.createQuery(Mockito.any(Object[].class))).thenReturn(query);
 		when(jpaQuery.getQueryMethod()).thenReturn(method);
+		when(method.getCountQuery()).thenReturn("select count(1) from User u");
 	}
 
 	@Test(expected = IllegalArgumentException.class)
@@ -179,20 +180,19 @@ public class JpaQueryExecutionUnitTests {
 		when(jpaQuery.createQuery(Mockito.any(Object[].class))).thenReturn(query);
 		when(countQuery.getResultList()).thenReturn(Arrays.asList(20L));
 		when(query.getResultList()).thenReturn(Arrays.asList(20L));
-		
+		when(method.getCountQuery()).thenReturn("select count(1) from User u");
+
 		PagedExecution execution = new PagedExecution(parameters);
-		Page<Object> largePage = (Page<Object>) execution.doExecute(jpaQuery, new Object[] { PageRequest.of(0, 10) });
-		Page<Object> equalPage = (Page<Object>) execution.doExecute(jpaQuery, new Object[] { PageRequest.of(0, 1) });
+		Page<Object> page = (Page<Object>) execution.doExecute(jpaQuery, new Object[] { PageRequest.of(0, 1) });
 
-    assertEquals(largePage.getTotalElements(), 1);
-    assertEquals(equalPage.getTotalElements(), 1);
-    
-		when(countQuery.getResultList()).thenReturn(Arrays.asList(20L, 20L));
-		when(query.getResultList()).thenReturn(Arrays.asList(20L, 20L));
+    assertEquals(page.getTotalElements(), 20);
+
+		when(method.getCountQuery()).thenReturn("select count(1) from User u group by u.id");
 		
-		Page<Object> smallPage = (Page<Object>) execution.doExecute(jpaQuery, new Object[] { PageRequest.of(0, 1) });
+		page = (Page<Object>) execution.doExecute(jpaQuery, new Object[] { PageRequest.of(0, 1) });
+		
+    assertEquals(page.getTotalElements(), 1);
 
-    assertEquals(smallPage.getTotalElements(), 2);
 	}
 
 	@Test // DATAJPA-912

--- a/src/test/java/org/springframework/data/jpa/repository/query/JpaQueryExecutionUnitTests.java
+++ b/src/test/java/org/springframework/data/jpa/repository/query/JpaQueryExecutionUnitTests.java
@@ -59,6 +59,7 @@ public class JpaQueryExecutionUnitTests {
 	@Mock AbstractStringBasedJpaQuery jpaQuery;
 	@Mock Query query;
 	@Mock JpaQueryMethod method;
+	@Mock DeclaredQuery declaredQuery;
 
 	@Mock TypedQuery<Long> countQuery;
 
@@ -68,7 +69,6 @@ public class JpaQueryExecutionUnitTests {
 		when(query.executeUpdate()).thenReturn(0);
 		when(jpaQuery.createQuery(Mockito.any(Object[].class))).thenReturn(query);
 		when(jpaQuery.getQueryMethod()).thenReturn(method);
-		when(method.getCountQuery()).thenReturn("select count(1) from User u");
 	}
 
 	@Test(expected = IllegalArgumentException.class)
@@ -150,6 +150,9 @@ public class JpaQueryExecutionUnitTests {
 		when(jpaQuery.createCountQuery(Mockito.any(Object[].class))).thenReturn(countQuery);
 		when(jpaQuery.createQuery(Mockito.any(Object[].class))).thenReturn(query);
 		when(countQuery.getResultList()).thenReturn(Arrays.asList(20L));
+		
+		when(jpaQuery.getQuery()).thenReturn(declaredQuery);
+		when(declaredQuery.getQueryString()).thenReturn("select count(1) from User u");
 
 		PagedExecution execution = new PagedExecution(parameters);
 		execution.doExecute(jpaQuery, new Object[] { PageRequest.of(2, 10) });
@@ -182,13 +185,16 @@ public class JpaQueryExecutionUnitTests {
 		when(query.getResultList()).thenReturn(Arrays.asList(20L));
 		when(method.getCountQuery()).thenReturn("select count(1) from User u");
 
+		when(jpaQuery.getQuery()).thenReturn(declaredQuery);
+		when(declaredQuery.getQueryString()).thenReturn("select count(1) from User u");
+		
 		PagedExecution execution = new PagedExecution(parameters);
 		Page<Object> page = (Page<Object>) execution.doExecute(jpaQuery, new Object[] { PageRequest.of(0, 1) });
 
     assertEquals(page.getTotalElements(), 20);
 
-		when(method.getCountQuery()).thenReturn("select count(1) from User u group by u.id");
-		
+		when(declaredQuery.getQueryString()).thenReturn("select count(1) from User u group by u.id");
+				
 		page = (Page<Object>) execution.doExecute(jpaQuery, new Object[] { PageRequest.of(0, 1) });
 		
     assertEquals(page.getTotalElements(), 1);
@@ -231,6 +237,9 @@ public class JpaQueryExecutionUnitTests {
 		when(jpaQuery.createCountQuery(Mockito.any(Object[].class))).thenReturn(query);
 		when(countQuery.getResultList()).thenReturn(Arrays.asList(20L));
 
+		when(jpaQuery.getQuery()).thenReturn(declaredQuery);
+		when(declaredQuery.getQueryString()).thenReturn("select count(1) from User u");
+		
 		PagedExecution execution = new PagedExecution(parameters);
 		execution.doExecute(jpaQuery, new Object[] { PageRequest.of(4, 4) });
 
@@ -247,6 +256,9 @@ public class JpaQueryExecutionUnitTests {
 		when(jpaQuery.createCountQuery(Mockito.any(Object[].class))).thenReturn(query);
 		when(countQuery.getResultList()).thenReturn(Arrays.asList(20L));
 
+		when(jpaQuery.getQuery()).thenReturn(declaredQuery);
+		when(declaredQuery.getQueryString()).thenReturn("select count(1) from User u");
+		
 		PagedExecution execution = new PagedExecution(parameters);
 		execution.doExecute(jpaQuery, new Object[] { PageRequest.of(4, 4) });
 


### PR DESCRIPTION
The totals.get(0) cannot always get the correct count result no matter
whether there is a group by clause or not. There is also
misunderstanding when we use getTotalElements method for paging.

<!--

Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
Make sure that:

-->

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] There is a ticket in the bug tracker for the project in our [JIRA](https://jira.spring.io/browse/DATAJPA).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).

