### PR TITLE
DATAJPA-1617 - Fix quotation on IsEndingWith in documentation

### DIFF
--- a/src/main/asciidoc/jpa.adoc
+++ b/src/main/asciidoc/jpa.adoc
@@ -190,7 +190,7 @@ This section describes the various ways to create a query with Spring Data JPA.
 
 The JPA module supports defining a query manually as a String or having it being derived from the method name.
 
-Derived queries with the predicates `IsStartingWith`, `StartingWith`, `StartsWith`, IsEndingWith", `EndingWith`, `EndsWith`,
+Derived queries with the predicates `IsStartingWith`, `StartingWith`, `StartsWith`, `IsEndingWith`, `EndingWith`, `EndsWith`,
 `IsNotContaining`, `NotContaining`, `NotContains`, `IsContaining`, `Containing`, `Contains` the respective arguments for these queries will get sanitized.
 This means if the arguments actually contain characters recognized by `LIKE` as wildcards these will get escaped so they match only as literals.
 The escape character used can be configured by setting the `escapeCharacter` of the `@EnableJpaRepositories` annotation.


### PR DESCRIPTION
Fixing typo in formatting thing.
- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [ ] There is a ticket in the bug tracker for the project in our [JIRA](https://jira.spring.io/browse/DATAJPA).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [ ] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).

