### PR TITLE
DATAJPA-1620 - Updated patch version of main EclipseLink version. 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,6 @@
 		<hibernate>5.2.17.Final</hibernate>
 		<mockito>2.19.1</mockito>
 		<hibernate.groupId>org.hibernate</hibernate.groupId>
-		<jpa>2.0.0</jpa>
 		<springdata.commons>2.2.1.BUILD-SNAPSHOT</springdata.commons>
 
 		<java-module-name>spring.data.jpa</java-module-name>

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 
 		<dist.key>DATAJPA</dist.key>
 
-		<eclipselink>2.6.5</eclipselink>
+		<eclipselink>2.6.8</eclipselink>
 		<hibernate>5.2.17.Final</hibernate>
 		<mockito>2.19.1</mockito>
 		<hibernate.groupId>org.hibernate</hibernate.groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-jpa</artifactId>
-	<version>2.2.1.BUILD-SNAPSHOT</version>
+	<version>2.2.1.DATAJPA-1620-2.2-SNAPSHOT</version>
 
 	<name>Spring Data JPA</name>
 	<description>Spring Data module for JPA repositories.</description>


### PR DESCRIPTION
Hibernate patch level is still up to date.

This PR is for the branches 2.2.x and 2.1.x

https://jira.spring.io/browse/DATAJPA-1620