### PR TITLE
DATAJPA-1622 - Removed `@nullable` annotation for return types of `Specification`.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-jpa</artifactId>
-	<version>2.4.0-SNAPSHOT</version>
+	<version>2.4.0.DATAJPA-1622-SNAPSHOT</version>
 
 	<name>Spring Data JPA</name>
 	<description>Spring Data module for JPA repositories.</description>

--- a/src/main/java/org/springframework/data/jpa/domain/Specification.java
+++ b/src/main/java/org/springframework/data/jpa/domain/Specification.java
@@ -34,6 +34,7 @@ import org.springframework.lang.Nullable;
  * @author Krzysztof Rzymkowski
  * @author Sebastian Staudt
  * @author Mark Paluch
+ * @author Jens Schauder
  */
 public interface Specification<T> extends Serializable {
 
@@ -62,7 +63,6 @@ public interface Specification<T> extends Serializable {
 	 * @return
 	 * @since 2.0
 	 */
-	@Nullable
 	static <T> Specification<T> where(@Nullable Specification<T> spec) {
 		return spec == null ? (root, query, builder) -> null : spec;
 	}
@@ -74,7 +74,7 @@ public interface Specification<T> extends Serializable {
 	 * @return The conjunction of the specifications
 	 * @since 2.0
 	 */
-	@Nullable
+
 	default Specification<T> and(@Nullable Specification<T> other) {
 		return composed(this, other, (builder, left, rhs) -> builder.and(left, rhs));
 	}
@@ -86,7 +86,6 @@ public interface Specification<T> extends Serializable {
 	 * @return The disjunction of the specifications
 	 * @since 2.0
 	 */
-	@Nullable
 	default Specification<T> or(@Nullable Specification<T> other) {
 		return composed(this, other, (builder, left, rhs) -> builder.or(left, rhs));
 	}

--- a/src/main/java/org/springframework/data/jpa/domain/Specification.java
+++ b/src/main/java/org/springframework/data/jpa/domain/Specification.java
@@ -43,9 +43,9 @@ public interface Specification<T> extends Serializable {
 	/**
 	 * Negates the given {@link Specification}.
 	 *
-	 * @param <T>
+	 * @param <T> the type of the {@link Root} the resulting {@literal Specification} operates on.
 	 * @param spec can be {@literal null}.
-	 * @return
+	 * @return guaranteed to be not {@literal null}.
 	 * @since 2.0
 	 */
 	static <T> Specification<T> not(@Nullable Specification<T> spec) {
@@ -58,9 +58,9 @@ public interface Specification<T> extends Serializable {
 	/**
 	 * Simple static factory method to add some syntactic sugar around a {@link Specification}.
 	 *
-	 * @param <T>
+	 * @param <T> the type of the {@link Root} the resulting {@literal Specification} operates on.
 	 * @param spec can be {@literal null}.
-	 * @return
+	 * @return guaranteed to be not {@literal null}.
 	 * @since 2.0
 	 */
 	static <T> Specification<T> where(@Nullable Specification<T> spec) {
@@ -76,7 +76,7 @@ public interface Specification<T> extends Serializable {
 	 */
 
 	default Specification<T> and(@Nullable Specification<T> other) {
-		return composed(this, other, (builder, left, rhs) -> builder.and(left, rhs));
+		return composed(this, other, CriteriaBuilder::and);
 	}
 
 	/**
@@ -87,7 +87,7 @@ public interface Specification<T> extends Serializable {
 	 * @since 2.0
 	 */
 	default Specification<T> or(@Nullable Specification<T> other) {
-		return composed(this, other, (builder, left, rhs) -> builder.or(left, rhs));
+		return composed(this, other, CriteriaBuilder::or);
 	}
 
 	/**

--- a/src/main/java/org/springframework/data/jpa/domain/SpecificationComposition.java
+++ b/src/main/java/org/springframework/data/jpa/domain/SpecificationComposition.java
@@ -29,6 +29,7 @@ import org.springframework.lang.Nullable;
  *
  * @author Sebastian Staudt
  * @author Oliver Gierke
+ * @author Jens Schauder
  * @see Specification
  * @since 2.2
  */
@@ -38,7 +39,6 @@ class SpecificationComposition {
 		Predicate combine(CriteriaBuilder builder, @Nullable Predicate lhs, @Nullable Predicate rhs);
 	}
 
-	@Nullable
 	static <T> Specification<T> composed(@Nullable Specification<T> lhs, @Nullable Specification<T> rhs,
 			Combiner combiner) {
 
@@ -55,7 +55,8 @@ class SpecificationComposition {
 		};
 	}
 
-	private static <T> Predicate toPredicate(Specification<T> specification, Root<T> root, CriteriaQuery<?> query,
+	@Nullable
+	private static <T> Predicate toPredicate(@Nullable Specification<T> specification, Root<T> root, CriteriaQuery<?> query,
 			CriteriaBuilder builder) {
 		return specification == null ? null : specification.toPredicate(root, query, builder);
 	}


### PR DESCRIPTION
This allows for easier usage as a fluent API without warnings from the IDE or in the case of Kotlin compiler errors.

https://jira.spring.io/browse/DATAJPA-1622