### PR TITLE
DATAJPA-1635 - Removed superfluous logic from evaluation of count query.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-jpa</artifactId>
-	<version>2.3.0.BUILD-SNAPSHOT</version>
+	<version>2.3.0.DATAJPA-1635-SNAPSHOT</version>
 
 	<name>Spring Data JPA</name>
 	<description>Spring Data module for JPA repositories.</description>

--- a/src/main/java/org/springframework/data/jpa/repository/query/JpaQueryExecution.java
+++ b/src/main/java/org/springframework/data/jpa/repository/query/JpaQueryExecution.java
@@ -180,8 +180,8 @@ public abstract class JpaQueryExecution {
 
 		private long count(AbstractJpaQuery repositoryQuery, JpaParametersParameterAccessor accessor) {
 
-			List<?> totals = repositoryQuery.createCountQuery(accessor).getResultList();
-			return (totals.size() == 1 ? CONVERSION_SERVICE.convert(totals.get(0), Long.class) : totals.size());
+			return CONVERSION_SERVICE.convert(repositoryQuery.createCountQuery(accessor).getSingleResult(), Long.class);
+
 		}
 	}
 

--- a/src/test/java/org/springframework/data/jpa/repository/query/JpaQueryExecutionUnitTests.java
+++ b/src/test/java/org/springframework/data/jpa/repository/query/JpaQueryExecutionUnitTests.java
@@ -33,7 +33,6 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
-
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.query.JpaQueryExecution.ModifyingExecution;
@@ -147,14 +146,14 @@ public class JpaQueryExecutionUnitTests {
 		JpaParameters parameters = new JpaParameters(getClass().getMethod("sampleMethod", Pageable.class));
 		when(jpaQuery.createCountQuery(Mockito.any())).thenReturn(countQuery);
 		when(jpaQuery.createQuery(Mockito.any())).thenReturn(query);
-		when(countQuery.getResultList()).thenReturn(Arrays.asList(20L));
+		when(countQuery.getSingleResult()).thenReturn(20L);
 
 		PagedExecution execution = new PagedExecution();
 		execution.doExecute(jpaQuery,
 				new JpaParametersParameterAccessor(parameters, new Object[] { PageRequest.of(2, 10) }));
 
 		verify(query).getResultList();
-		verify(countQuery).getResultList();
+		verify(countQuery).getSingleResult();
 	}
 
 	@Test // DATAJPA-477, DATAJPA-912
@@ -207,8 +206,8 @@ public class JpaQueryExecutionUnitTests {
 		JpaParameters parameters = new JpaParameters(getClass().getMethod("sampleMethod", Pageable.class));
 		when(jpaQuery.createQuery(Mockito.any())).thenReturn(query);
 		when(query.getResultList()).thenReturn(Collections.emptyList());
-		when(jpaQuery.createCountQuery(Mockito.any())).thenReturn(query);
-		when(countQuery.getResultList()).thenReturn(Arrays.asList(20L));
+		when(jpaQuery.createCountQuery(Mockito.any())).thenReturn(countQuery);
+		when(countQuery.getSingleResult()).thenReturn(20L);
 
 		PagedExecution execution = new PagedExecution();
 		execution.doExecute(jpaQuery,
@@ -224,8 +223,8 @@ public class JpaQueryExecutionUnitTests {
 		JpaParameters parameters = new JpaParameters(getClass().getMethod("sampleMethod", Pageable.class));
 		when(jpaQuery.createQuery(Mockito.any())).thenReturn(query);
 		when(query.getResultList()).thenReturn(Arrays.asList(new Object(), new Object(), new Object(), new Object()));
-		when(jpaQuery.createCountQuery(Mockito.any())).thenReturn(query);
-		when(countQuery.getResultList()).thenReturn(Arrays.asList(20L));
+		when(jpaQuery.createCountQuery(Mockito.any())).thenReturn(countQuery);
+		when(countQuery.getSingleResult()).thenReturn(20L);
 
 		PagedExecution execution = new PagedExecution();
 		execution.doExecute(jpaQuery,


### PR DESCRIPTION
The logic existed only for handling a scenario that was only created by bogus unit tests.
A count query must never return anything but a single result.

https://jira.spring.io/browse/DATAJPA-1635