### PR TITLE
DATAJPA-1647 - Removes broken caching of ParameterBinder.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-jpa</artifactId>
-	<version>2.3.0.BUILD-SNAPSHOT</version>
+	<version>2.3.0.DATAJPA-1647-SNAPSHOT</version>
 
 	<name>Spring Data JPA</name>
 	<description>Spring Data module for JPA repositories.</description>

--- a/src/main/java/org/springframework/data/jpa/repository/query/PartTreeJpaQuery.java
+++ b/src/main/java/org/springframework/data/jpa/repository/query/PartTreeJpaQuery.java
@@ -16,8 +16,6 @@
 package org.springframework.data.jpa.repository.query;
 
 import java.util.List;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
 
 import javax.persistence.EntityManager;
 import javax.persistence.Query;
@@ -211,7 +209,6 @@ public class PartTreeJpaQuery extends AbstractJpaQuery {
 		private final @Nullable CriteriaQuery<?> cachedCriteriaQuery;
 		private final @Nullable ParameterBinder cachedParameterBinder;
 		private final PersistenceProvider persistenceProvider;
-		private final Map<List<ParameterMetadata<?>>, ParameterBinder> binderCache = new ConcurrentHashMap<>();
 		private final QueryParameterSetter.QueryMetadataCache metadataCache = new QueryParameterSetter.QueryMetadataCache();
 
 		QueryPreparer(PersistenceProvider persistenceProvider, boolean recreateQueries) {
@@ -335,8 +332,7 @@ public class PartTreeJpaQuery extends AbstractJpaQuery {
 		}
 
 		private ParameterBinder getBinder(List<ParameterMetadata<?>> expressions) {
-			return this.binderCache.computeIfAbsent(expressions,
-					key -> ParameterBinderFactory.createCriteriaBinder(parameters, key));
+			return ParameterBinderFactory.createCriteriaBinder(parameters, expressions);
 		}
 
 		private Sort getDynamicSort(JpaParametersParameterAccessor accessor) {


### PR DESCRIPTION
The caching was broken because ParameterMetadata used for the key lacked a proper equals and hashCode implementation.
Also it references the EntityManager and itself gets referenced in the ParameterBinder and therefore can't safely be cached.

https://jira.spring.io/browse/DATAJPA-1647