### PR TITLE
DATAJPA-1649 Ensure repository declares correct ID type.

### DIFF
--- a/src/test/java/org/springframework/data/jpa/repository/cdi/QualifiedCustomizedUserRepository.java
+++ b/src/test/java/org/springframework/data/jpa/repository/cdi/QualifiedCustomizedUserRepository.java
@@ -22,7 +22,7 @@ import org.springframework.data.repository.Repository;
  * @author Mark Paluch
  */
 @UserDB
-public interface QualifiedCustomizedUserRepository extends Repository<User, Long>,
+public interface QualifiedCustomizedUserRepository extends Repository<User, Integer>,
 		QualifiedCustomizedUserRepositoryCustom, QualifiedFragment {
 
 }

--- a/src/test/java/org/springframework/data/jpa/repository/query/JpaCountQueryCreatorIntegrationTests.java
+++ b/src/test/java/org/springframework/data/jpa/repository/query/JpaCountQueryCreatorIntegrationTests.java
@@ -70,7 +70,7 @@ public class JpaCountQueryCreatorIntegrationTests {
 		assertThat(HibernateUtils.getHibernateQuery(query)).startsWith("select distinct count(distinct");
 	}
 
-	interface SomeRepository extends Repository<User, Long> {
+	interface SomeRepository extends Repository<User, Integer> {
 		void findDistinctByRolesIn(List<Role> roles);
 	}
 }

--- a/src/test/java/org/springframework/data/jpa/repository/query/JpaQueryLookupStrategyUnitTests.java
+++ b/src/test/java/org/springframework/data/jpa/repository/query/JpaQueryLookupStrategyUnitTests.java
@@ -102,7 +102,7 @@ public class JpaQueryLookupStrategyUnitTests {
 				.withMessageContaining(method.toString());
 	}
 
-	interface UserRepository extends Repository<User, Long> {
+	interface UserRepository extends Repository<User, Integer> {
 
 		@Query("something absurd")
 		User findByFoo(String foo);

--- a/src/test/java/org/springframework/data/jpa/repository/query/JpaQueryMethodUnitTests.java
+++ b/src/test/java/org/springframework/data/jpa/repository/query/JpaQueryMethodUnitTests.java
@@ -66,7 +66,6 @@ import org.springframework.data.repository.query.QueryMethod;
 @RunWith(MockitoJUnitRunner.class)
 public class JpaQueryMethodUnitTests {
 
-	static final Class<?> DOMAIN_CLASS = User.class;
 	static final String METHOD_NAME = "findByFirstname";
 
 	@Mock QueryExtractor extractor;
@@ -328,7 +327,7 @@ public class JpaQueryMethodUnitTests {
 		doReturn(User.class).when(metadata).getDomainType();
 		doReturn(User.class).when(metadata).getReturnedDomainClass((Method) any());
 
-		JpaQueryMethod method = new JpaQueryMethod(JpaRepositoryOverride.class.getMethod("findOne", Long.class), metadata,
+		JpaQueryMethod method = new JpaQueryMethod(JpaRepositoryOverride.class.getMethod("findOne", Integer.class), metadata,
 				factory, extractor);
 
 		assertThat(method.getEntityGraph()).isNotNull();
@@ -345,7 +344,7 @@ public class JpaQueryMethodUnitTests {
 		doReturn(User.class).when(metadata).getDomainType();
 		doReturn(User.class).when(metadata).getReturnedDomainClass((Method) any());
 
-		JpaQueryMethod method = new JpaQueryMethod(JpaRepositoryOverride.class.getMethod("getOneById", Long.class),
+		JpaQueryMethod method = new JpaQueryMethod(JpaRepositoryOverride.class.getMethod("getOneById", Integer.class),
 				metadata, factory, extractor);
 
 		assertThat(method.getEntityGraph()).isNotNull();
@@ -469,7 +468,7 @@ public class JpaQueryMethodUnitTests {
 	 *
 	 * @author Oliver Gierke
 	 */
-	static interface InvalidRepository extends Repository<User, Long> {
+	interface InvalidRepository extends Repository<User, Integer> {
 
 		// Invalid return type
 		User findByFirstname(String firstname, Pageable pageable);
@@ -500,7 +499,7 @@ public class JpaQueryMethodUnitTests {
 		List<User> findByAnnotatedQuery(@Param("param") String param);
 	}
 
-	static interface ValidRepository extends Repository<User, Long> {
+	interface ValidRepository extends Repository<User, Integer> {
 
 		@Query(value = "query", nativeQuery = true)
 		List<User> findByLastname(String lastname);
@@ -530,7 +529,7 @@ public class JpaQueryMethodUnitTests {
 		void withMetaAnnotationUsingAliasFor();
 	}
 
-	static interface JpaRepositoryOverride extends JpaRepository<User, Long> {
+	interface JpaRepositoryOverride extends JpaRepository<User, Integer> {
 
 		/**
 		 * DATAJPA-612
@@ -543,13 +542,13 @@ public class JpaQueryMethodUnitTests {
 		 * DATAJPA-689
 		 */
 		@EntityGraph("User.detail")
-		Optional<User> findOne(Long id);
+		Optional<User> findOne(Integer id);
 
 		/**
 		 * DATAJPA-696
 		 */
 		@EntityGraph
-		User getOneById(Long id);
+		User getOneById(Integer id);
 
 		@CustomComposedEntityGraphAnnotationWithAliasFor
 		User getOneWithCustomEntityGraphAnnotation();

--- a/src/test/java/org/springframework/data/jpa/repository/query/PartTreeJpaQueryIntegrationTests.java
+++ b/src/test/java/org/springframework/data/jpa/repository/query/PartTreeJpaQueryIntegrationTests.java
@@ -173,14 +173,14 @@ public class PartTreeJpaQueryIntegrationTests {
 	@Test // DATAJPA-1182
 	public void rejectsInPredicateWithNonIterableParameter() throws Exception {
 
-		JpaQueryMethod method = getQueryMethod("findByIdIn", Long.class);
+		JpaQueryMethod method = getQueryMethod("findByIdIn", Integer.class);
 
 		assertThatExceptionOfType(RuntimeException.class) //
 				.isThrownBy(() -> new PartTreeJpaQuery(method, entityManager, provider)) //
 				.withMessageContaining("findByIdIn") //
 				.withMessageContaining(" IN ") //
 				.withMessageContaining("Collection") //
-				.withMessageContaining("Long");
+				.withMessageContaining("Integer");
 	}
 
 	@Test // DATAJPA-1182
@@ -284,7 +284,7 @@ public class PartTreeJpaQueryIntegrationTests {
 	}
 
 	@SuppressWarnings("unused")
-	interface UserRepository extends Repository<User, Long> {
+	interface UserRepository extends Repository<User, Integer> {
 
 		Page<User> findByFirstname(String firstname, Pageable pageable);
 
@@ -303,10 +303,10 @@ public class PartTreeJpaQueryIntegrationTests {
 		List<User> findByFirstnameIsEmpty();
 
 		// should fail, since we can't compare scalar values to collections
-		List<User> findById(Collection<Long> ids);
+		List<User> findById(Collection<Integer> ids);
 
 		// should fail, since we can't do an IN on a scalar
-		List<User> findByIdIn(Long id);
+		List<User> findByIdIn(Integer id);
 
 		// should succeed
 		List<User> findByFirstnameIn(Iterable<String> id);

--- a/src/test/java/org/springframework/data/jpa/repository/sample/AuditableUserRepository.java
+++ b/src/test/java/org/springframework/data/jpa/repository/sample/AuditableUserRepository.java
@@ -28,7 +28,7 @@ import org.springframework.data.jpa.repository.Query;
  * @author Oliver Gierke
  * @author Thomas Darimont
  */
-public interface AuditableUserRepository extends JpaRepository<AuditableUser, Long> {
+public interface AuditableUserRepository extends JpaRepository<AuditableUser, Integer> {
 
 	/**
 	 * Returns all users with the given firstname.

--- a/src/test/java/org/springframework/data/jpa/repository/sample/DummyRepository.java
+++ b/src/test/java/org/springframework/data/jpa/repository/sample/DummyRepository.java
@@ -23,7 +23,7 @@ import org.springframework.data.repository.CrudRepository;
 import org.springframework.transaction.annotation.Transactional;
 
 @Transactional
-public interface DummyRepository extends CrudRepository<Dummy, Long> {
+public interface DummyRepository extends CrudRepository<Dummy, Integer> {
 
 	@Procedure("procedure_in1_out1")
 	Integer adHocProcedureWith1InputAnd1OutputParameter(Integer in);

--- a/src/test/java/org/springframework/data/jpa/repository/sample/RedeclaringRepositoryMethodsRepository.java
+++ b/src/test/java/org/springframework/data/jpa/repository/sample/RedeclaringRepositoryMethodsRepository.java
@@ -29,7 +29,7 @@ import org.springframework.data.repository.CrudRepository;
  *
  * @author Thomas Darimont
  */
-public interface RedeclaringRepositoryMethodsRepository extends CrudRepository<User, Long> {
+public interface RedeclaringRepositoryMethodsRepository extends CrudRepository<User, Integer> {
 
 	/**
 	 * Should not find any users at all.

--- a/src/test/java/org/springframework/data/jpa/repository/support/JpaEntityInformationSupportUnitTests.java
+++ b/src/test/java/org/springframework/data/jpa/repository/support/JpaEntityInformationSupportUnitTests.java
@@ -46,7 +46,7 @@ public class JpaEntityInformationSupportUnitTests {
 	@Test
 	public void usesSimpleClassNameIfNoEntityNameGiven() throws Exception {
 
-		JpaEntityInformation<User, Long> information = new DummyJpaEntityInformation<User, Long>(User.class);
+		JpaEntityInformation<User, Integer> information = new DummyJpaEntityInformation<>(User.class);
 		assertThat(information.getEntityName()).isEqualTo("User");
 
 		JpaEntityInformation<NamedUser, ?> second = new DummyJpaEntityInformation<NamedUser, Serializable>(NamedUser.class);

--- a/src/test/java/org/springframework/data/jpa/repository/support/SimpleJpaRepositoryUnitTests.java
+++ b/src/test/java/org/springframework/data/jpa/repository/support/SimpleJpaRepositoryUnitTests.java
@@ -57,7 +57,7 @@ public class SimpleJpaRepositoryUnitTests {
 	@Mock CriteriaQuery<Long> countCriteriaQuery;
 	@Mock TypedQuery<User> query;
 	@Mock TypedQuery<Long> countQuery;
-	@Mock JpaEntityInformation<User, Long> information;
+	@Mock JpaEntityInformation<User, Integer> information;
 	@Mock CrudMethodMetadata metadata;
 	@Mock EntityGraph<User> entityGraph;
 	@Mock org.springframework.data.jpa.repository.EntityGraph entityGraphAnnotation;


### PR DESCRIPTION
https://jira.spring.io/browse/DATAJPA-1649

It turned out that some of repositories in test module are declared with mismatching ID type, e. g. `UserRepository` and application context starts up correctly and repository works unless one calls `CrudRepository.findById()` method.