### PR TITLE
DATAJPA-1651 - Collection/varargs utility methods for composing Specifications

### DIFF
--- a/src/main/java/org/springframework/data/jpa/domain/Specification.java
+++ b/src/main/java/org/springframework/data/jpa/domain/Specification.java
@@ -18,6 +18,8 @@ package org.springframework.data.jpa.domain;
 import static org.springframework.data.jpa.domain.SpecificationComposition.*;
 
 import java.io.Serializable;
+import java.util.Arrays;
+import java.util.stream.StreamSupport;
 
 import javax.persistence.criteria.CriteriaBuilder;
 import javax.persistence.criteria.CriteriaQuery;
@@ -34,6 +36,7 @@ import org.springframework.lang.Nullable;
  * @author Krzysztof Rzymkowski
  * @author Sebastian Staudt
  * @author Mark Paluch
+ * @author Daniel Shuy
  */
 public interface Specification<T> extends Serializable {
 
@@ -102,4 +105,46 @@ public interface Specification<T> extends Serializable {
 	 */
 	@Nullable
 	Predicate toPredicate(Root<T> root, CriteriaQuery<?> query, CriteriaBuilder criteriaBuilder);
+
+	/**
+	 * Applies an AND operation to all the given {@link Specification}s.
+	 *
+	 * @param specifications The {@link Specification}s to compose. Can contain {@code null}s.
+	 * @return The conjunction of the specifications
+	 * @see #and(Specification)
+	 */
+	static <T> Specification<T> allOf(Iterable<Specification<T>> specifications) {
+
+		return StreamSupport.stream(specifications.spliterator(), false) //
+				.reduce(Specification.where(null), Specification::and);
+	}
+
+	/**
+	 * @see #allOf(Iterable)
+	 */
+	@SafeVarargs
+	static <T> Specification<T> allOf(Specification<T>... specifications) {
+		return allOf(Arrays.asList(specifications));
+	}
+
+	/**
+	 * Applies an OR operation to all the given {@link Specification}s.
+	 *
+	 * @param specifications The {@link Specification}s to compose. Can contain {@code null}s.
+	 * @return The disjunction of the specifications
+	 * @see #or(Specification)
+	 */
+	static <T> Specification<T> anyOf(Iterable<Specification<T>> specifications) {
+
+		return StreamSupport.stream(specifications.spliterator(), false) //
+				.reduce(Specification.where(null), Specification::or);
+	}
+
+	/**
+	 * @see #anyOf(Iterable)
+	 */
+	@SafeVarargs
+	static <T> Specification<T> anyOf(Specification<T>... specifications) {
+		return anyOf(Arrays.asList(specifications));
+	}
 }

--- a/src/test/java/org/springframework/data/jpa/domain/SpecificationUnitTests.java
+++ b/src/test/java/org/springframework/data/jpa/domain/SpecificationUnitTests.java
@@ -40,6 +40,7 @@ import org.mockito.junit.MockitoJUnitRunner;
  * @author Thomas Darimont
  * @author Sebastian Staudt
  * @author Jens Schauder
+ * @author Daniel Shuy
  */
 @SuppressWarnings("serial")
 @RunWith(MockitoJUnitRunner.class)
@@ -111,6 +112,42 @@ public class SpecificationUnitTests implements Serializable {
 
 		assertThat(specification).isNotNull();
 		assertThat(specification.toPredicate(root, query, builder)).isEqualTo(predicate);
+	}
+
+	@Test // DATAJPA-1651
+	public void allOfConcatenatesNull() {
+
+		Specification<Object> specification = Specification.allOf(null, spec, null);
+
+		assertThat(specification).isNotNull();
+		assertThat(specification.toPredicate(root, query, builder)).isEqualTo(predicate);
+	}
+
+	@Test // DATAJPA-1651
+	public void anyOfConcatenatesNull() {
+
+		Specification<Object> specification = Specification.anyOf(null, spec, null);
+
+		assertThat(specification).isNotNull();
+		assertThat(specification.toPredicate(root, query, builder)).isEqualTo(predicate);
+	}
+
+	@Test // DATAJPA-1651
+	public void emptyAllOfReturnsEmptySpecification() {
+
+		Specification<Object> specification = Specification.allOf();
+
+		assertThat(specification).isNotNull();
+		assertThat(specification.toPredicate(root, query, builder)).isNull();
+	}
+
+	@Test // DATAJPA-1651
+	public void emptyAnyOfReturnsEmptySpecification() {
+
+		Specification<Object> specification = Specification.anyOf();
+
+		assertThat(specification).isNotNull();
+		assertThat(specification.toPredicate(root, query, builder)).isNull();
 	}
 
 	@Test // DATAJPA-523


### PR DESCRIPTION
Currently, when handling multiple conditional `Specification`s, the code looks something like:
```java
Specification<User> specification = Specification.where(null);
if (nameFilter != null && !nameFilter.isEmpty()) {
  specification = specification.and(specifications.hasName(nameFilter));
}
if (typeFilter != null) {
  specification = specification.and(specifications.hasType(typeFilter));
}
if (archivedFilter != null) {
  specification = specification.and(specifications.isArchived(archived));
}
if (searchPattern != null && !searchPattern.isEmpty()) {
  specification = specification.and(
    specifications.nameLike(searchPattern).or(
      specifications.addressLike(searchPattern)));
}

return repository.findAll(specification);
```

This approach has the following disadvantages:
- It is quite verbose
- Some IDEs will emit potential `NullPointerException` warnings on the `Specification#and(Specification)` calls (because `Specification#where(Specification)` is `@Nullable`)
- It forces us to mutate the specification variable
- Can get very confusing/messy when nesting multiple AND/OR operations

This PR adds 4 utility methods, `Specification#allOf(Collection)`, `Specification#allOf(Specification...)`, `Specification#anyOf(Collection)`, `Specification#anyOf(Specification...)`, which is inspired by Querydsl's [ExpressionUtils#allOf(Collection)](http://www.querydsl.com/static/querydsl/4.1.4/apidocs/com/querydsl/core/types/ExpressionUtils.html#allOf-java.util.Collection-), [ExpressionUtils#allOf(Predicate...)](http://www.querydsl.com/static/querydsl/4.1.4/apidocs/com/querydsl/core/types/ExpressionUtils.html#allOf-com.querydsl.core.types.Predicate...-), [ExpressionUtils#anyOf(Collection)](http://www.querydsl.com/static/querydsl/4.1.4/apidocs/com/querydsl/core/types/ExpressionUtils.html#anyOf-java.util.Collection-), [ExpressionUtils#anyOf(Predicate...)](http://www.querydsl.com/static/querydsl/4.1.4/apidocs/com/querydsl/core/types/ExpressionUtils.html#anyOf-com.querydsl.core.types.Predicate...-).

This will allow for better structured code when handling multiple conditional `Specification`s, eg. the same example above can be replaced with:
```java
var specification = Specification.allOf(
    nameFilter != null && !nameFilter.isEmpty() ? specifications.hasName(nameFilter) : null,
    typeFilter != null ? specifications.hasType(typeFilter) : null,
    archivedFilter != null ? specifications.isArchived(archivedFilter) : null),
    searchPattern != null && !searchPattern.isEmpty() ? Specification.anyOf(
        specifications.nameLike(searchPattern),
        specifications.addressLike(searchPattern));

return repository.findAll(specification);
```
 

<!--

Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
Make sure that:

-->

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] There is a ticket in the bug tracker for the project in our [JIRA](https://jira.spring.io/browse/DATAJPA).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).

