### PR TITLE
DATAJPA-1652: Using || (pipes) along with named parameters in custom queries raises an exception

### DIFF
--- a/src/main/java/org/springframework/data/jpa/repository/query/QueryUtils.java
+++ b/src/main/java/org/springframework/data/jpa/repository/query/QueryUtils.java
@@ -79,6 +79,7 @@ import org.springframework.util.StringUtils;
  * @author Florian Lüdiger
  * @author Grégoire Druant
  * @author Mohammad Hewedy
+ * @author Andriy Redko
  */
 public abstract class QueryUtils {
 
@@ -90,7 +91,7 @@ public abstract class QueryUtils {
 	// Cc Control
 	// Cf Format
 	// Punct Punctuation
-	private static final String IDENTIFIER = "[._$#[\\P{Z}&&\\P{Cc}&&\\P{Cf}&&\\P{Punct}]]+";
+	private static final String IDENTIFIER = "[._$[\\P{Z}&&\\P{Cc}&&\\P{Cf}&&\\P{Punct}]]+";
 	static final String COLON_NO_DOUBLE_COLON = "(?<![:\\\\]):";
 	static final String IDENTIFIER_GROUP = String.format("(%s)", IDENTIFIER);
 

--- a/src/main/java/org/springframework/data/jpa/repository/query/QueryUtils.java
+++ b/src/main/java/org/springframework/data/jpa/repository/query/QueryUtils.java
@@ -89,8 +89,8 @@ public abstract class QueryUtils {
 	// Z Separator
 	// Cc Control
 	// Cf Format
-	// P Punctuation
-	private static final String IDENTIFIER = "[._[\\P{Z}&&\\P{Cc}&&\\P{Cf}&&\\P{P}]]+";
+	// Punct Punctuation
+	private static final String IDENTIFIER = "[._$#[\\P{Z}&&\\P{Cc}&&\\P{Cf}&&\\P{Punct}]]+";
 	static final String COLON_NO_DOUBLE_COLON = "(?<![:\\\\]):";
 	static final String IDENTIFIER_GROUP = String.format("(%s)", IDENTIFIER);
 

--- a/src/test/java/org/springframework/data/jpa/repository/query/StringQueryUnitTests.java
+++ b/src/test/java/org/springframework/data/jpa/repository/query/StringQueryUnitTests.java
@@ -37,6 +37,7 @@ import org.springframework.data.repository.query.parser.Part.Type;
  * @author Thomas Darimont
  * @author Jens Schauder
  * @author Nils Borrmann
+ * @author Andriy Redko
  */
 public class StringQueryUnitTests {
 
@@ -557,7 +558,7 @@ public class StringQueryUnitTests {
 	@Test // DATAJPA-1652
 	public void usingGreaterThanWithNamedParameter() {
 
-		String queryString = "SELECT u FROM User u WHERE :age<u.age";
+		String queryString = "SELECT u FROM User u WHERE :age>u.age";
 		StringQuery query = new StringQuery(queryString);
 
 		softly.assertThat(query.getQueryString()).isEqualTo(queryString);

--- a/src/test/java/org/springframework/data/jpa/repository/query/StringQueryUnitTests.java
+++ b/src/test/java/org/springframework/data/jpa/repository/query/StringQueryUnitTests.java
@@ -540,6 +540,34 @@ public class StringQueryUnitTests {
 		softly.assertAll();
 	}
 
+	@Test // DATAJPA-1652
+	public void usingPipesWithNamedParameter() {
+
+		String queryString = "SELECT u FROM User u WHERE u.lastname LIKE '%'||:name||'%'";
+		StringQuery query = new StringQuery(queryString);
+
+		softly.assertThat(query.getQueryString()).isEqualTo(queryString);
+		softly.assertThat(query.hasParameterBindings()).isTrue();
+		softly.assertThat(query.getParameterBindings()).hasSize(1);
+		softly.assertThat(query.getParameterBindings().get(0).getName()).isEqualTo("name");
+
+		softly.assertAll();
+	}
+
+	@Test // DATAJPA-1652
+	public void usingGreaterThanWithNamedParameter() {
+
+		String queryString = "SELECT u FROM User u WHERE :age<u.age";
+		StringQuery query = new StringQuery(queryString);
+
+		softly.assertThat(query.getQueryString()).isEqualTo(queryString);
+		softly.assertThat(query.hasParameterBindings()).isTrue();
+		softly.assertThat(query.getParameterBindings()).hasSize(1);
+		softly.assertThat(query.getParameterBindings().get(0).getName()).isEqualTo("age");
+
+		softly.assertAll();
+	}
+
 	public void checkNumberOfNamedParameters(String query, int expectedSize, String label) {
 
 		DeclaredQuery declaredQuery = DeclaredQuery.of(query);


### PR DESCRIPTION
<!--

Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
Make sure that:

-->

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] There is a ticket in the bug tracker for the project in our [JIRA](https://jira.spring.io/browse/DATAJPA).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).

Since the Lovelace release train, the usage of '||' along named parameters in custom queries ends up with `Caused by: org.hibernate.QueryException: Named parameter [..] not set` exception.  For example,

```
@Query(value = "SELECT u FROM User u WHERE u.lastname LIKE '%'||:name||'%'")
Page<User> findByNamedQueryWithLike(@Param("name") String name, Pageable page); 
```

It caused by the fact that the identifier pattern (declared in `QueryUtils`) has changed in Lovelace and above, instead of capturing 'name', it captures 'name||'.  The suggested fix is to exclude `|` from the identifier name pattern.

Fixes https://jira.spring.io/browse/DATAJPA-1652, could be also related to https://github.com/spring-projects/spring-framework/issues/22450 and https://github.com/spring-projects/spring-data-commons/pull/340. 

Thank you.