### PR TITLE
DATAJPA-1664 - Typo errors in documentation of @EntityGraph.

### DIFF
--- a/src/main/java/org/springframework/data/jpa/repository/EntityGraph.java
+++ b/src/main/java/org/springframework/data/jpa/repository/EntityGraph.java
@@ -25,12 +25,15 @@ import org.springframework.data.jpa.repository.query.JpaQueryMethod;
 
 /**
  * Annotation to configure the JPA 2.1 {@link javax.persistence.EntityGraph}s that should be used on repository methods.
- * Since 1.9 we support the definition of dynamic {@link EntityGraph}s by allowing to customize the fetch-graph via via
+ * Since 1.9 we support the definition of dynamic {@link EntityGraph}s by allowing to customize the fetch-graph via
  * {@link #attributePaths()} ad-hoc fetch-graph configuration.
+ * 
+ * If {@link #attributePaths()} are specified then we ignore the entity-graph name {@link #value()} and treat this 
+ * {@link EntityGraph} as dynamic.
  *
- * @author Christoph Strobl If {@link #attributePaths()} are specified then we ignore the entity-graph name
- *         {@link #value()} and treat this {@link EntityGraph} as dynamic.
+ * @author Christoph Strobl
  * @author Thomas Darimont
+ * @author Oerd Cukalla
  * @since 1.6
  */
 @Retention(RetentionPolicy.RUNTIME)


### PR DESCRIPTION
Fixed typos in javadoc of `org.springframework.data.jpa.repository.EntityGraph` interface.

Related tickets: DATAJPA-1664.

<!--

Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
Make sure that:

-->

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] There is a ticket in the bug tracker for the project in our [JIRA](https://jira.spring.io/browse/DATAJPA).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [ ] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).

