### PR TITLE
DATAJPA-1663 - Removes superfluous method from PersistenceProvider.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-jpa</artifactId>
-	<version>2.3.0.BUILD-SNAPSHOT</version>
+	<version>2.3.0.DATAJPA-1663-SNAPSHOT</version>
 
 	<name>Spring Data JPA</name>
 	<description>Spring Data module for JPA repositories.</description>

--- a/src/main/java/org/springframework/data/jpa/provider/PersistenceProvider.java
+++ b/src/main/java/org/springframework/data/jpa/provider/PersistenceProvider.java
@@ -18,7 +18,6 @@ package org.springframework.data.jpa.provider;
 import static org.springframework.data.jpa.provider.JpaClassUtils.*;
 import static org.springframework.data.jpa.provider.PersistenceProvider.Constants.*;
 
-import java.util.Collection;
 import java.util.Collections;
 import java.util.NoSuchElementException;
 
@@ -96,16 +95,6 @@ public enum PersistenceProvider implements QueryExtractor, ProxyIdAccessor {
 
 		/*
 		 * (non-Javadoc)
-		 * @see org.springframework.data.jpa.provider.PersistenceProvider#potentiallyConvertEmptyCollection(java.util.Collection)
-		 */
-		@Nullable
-		@Override
-		public <T> Collection<T> potentiallyConvertEmptyCollection(@Nullable Collection<T> collection) {
-			return collection == null || collection.isEmpty() ? null : collection;
-		}
-
-		/*
-		 * (non-Javadoc)
 		 * @see org.springframework.data.jpa.provider.PersistenceProvider#executeQueryWithResultStream(javax.persistence.Query)
 		 */
 		@Override
@@ -142,16 +131,6 @@ public enum PersistenceProvider implements QueryExtractor, ProxyIdAccessor {
 		@Override
 		public Object getIdentifierFrom(Object entity) {
 			return null;
-		}
-
-		/*
-		 * (non-Javadoc)
-		 * @see org.springframework.data.jpa.provider.PersistenceProvider#potentiallyConvertEmptyCollection(java.util.Collection)
-		 */
-		@Nullable
-		@Override
-		public <T> Collection<T> potentiallyConvertEmptyCollection(@Nullable Collection<T> collection) {
-			return collection == null || collection.isEmpty() ? null : collection;
 		}
 
 		/*
@@ -209,7 +188,8 @@ public enum PersistenceProvider implements QueryExtractor, ProxyIdAccessor {
 	};
 
 	static ConcurrentReferenceHashMap<Class<?>, PersistenceProvider> CACHE = new ConcurrentReferenceHashMap<>();
-
+	private final Iterable<String> entityManagerClassNames;
+	private final Iterable<String> metamodelClassNames;
 	/**
 	 * Creates a new {@link PersistenceProvider}.
 	 *
@@ -222,9 +202,6 @@ public enum PersistenceProvider implements QueryExtractor, ProxyIdAccessor {
 		this.entityManagerClassNames = entityManagerClassNames;
 		this.metamodelClassNames = metamodelClassNames;
 	}
-
-	private final Iterable<String> entityManagerClassNames;
-	private final Iterable<String> metamodelClassNames;
 
 	/**
 	 * Caches the given {@link PersistenceProvider} for the given source type.
@@ -312,19 +289,6 @@ public enum PersistenceProvider implements QueryExtractor, ProxyIdAccessor {
 	@Override
 	public boolean canExtractQuery() {
 		return true;
-	}
-
-	/**
-	 * Potentially converts an empty collection to the appropriate representation of this {@link PersistenceProvider},
-	 * since some JPA providers cannot correctly handle empty collections.
-	 *
-	 * @see <a href="https://jira.spring.io/browse/DATAJPA-606">DATAJPA-606</a>
-	 * @param collection The collection to be converted. May be {@code null}.
-	 * @return a potentially converted collection. May be {@code null}.
-	 */
-	@Nullable
-	public <T> Collection<T> potentiallyConvertEmptyCollection(@Nullable Collection<T> collection) {
-		return collection;
 	}
 
 	/**

--- a/src/main/java/org/springframework/data/jpa/repository/query/JpaQueryLookupStrategy.java
+++ b/src/main/java/org/springframework/data/jpa/repository/query/JpaQueryLookupStrategy.java
@@ -19,7 +19,6 @@ import java.lang.reflect.Method;
 
 import javax.persistence.EntityManager;
 
-import org.springframework.data.jpa.provider.PersistenceProvider;
 import org.springframework.data.jpa.provider.QueryExtractor;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.projection.ProjectionFactory;
@@ -95,20 +94,19 @@ public final class JpaQueryLookupStrategy {
 	 */
 	private static class CreateQueryLookupStrategy extends AbstractQueryLookupStrategy {
 
-		private final PersistenceProvider persistenceProvider;
 		private final EscapeCharacter escape;
 
 		public CreateQueryLookupStrategy(EntityManager em, QueryExtractor extractor, EscapeCharacter escape,
 				JpaQueryMethodFactory queryMethodFactory) {
 
 			super(em, extractor, queryMethodFactory);
-			this.persistenceProvider = PersistenceProvider.fromEntityManager(em);
+
 			this.escape = escape;
 		}
 
 		@Override
 		protected RepositoryQuery resolveQuery(JpaQueryMethod method, EntityManager em, NamedQueries namedQueries) {
-			return new PartTreeJpaQuery(method, em, persistenceProvider, escape);
+			return new PartTreeJpaQuery(method, em, escape);
 		}
 	}
 
@@ -118,6 +116,7 @@ public final class JpaQueryLookupStrategy {
 	 *
 	 * @author Oliver Gierke
 	 * @author Thomas Darimont
+	 * @author Jens Schauder
 	 */
 	private static class DeclaredQueryLookupStrategy extends AbstractQueryLookupStrategy {
 

--- a/src/main/java/org/springframework/data/jpa/repository/query/ParameterMetadataProvider.java
+++ b/src/main/java/org/springframework/data/jpa/repository/query/ParameterMetadataProvider.java
@@ -57,22 +57,19 @@ class ParameterMetadataProvider {
 	private final Iterator<? extends Parameter> parameters;
 	private final List<ParameterMetadata<?>> expressions;
 	private final @Nullable Iterator<Object> bindableParameterValues;
-	private final PersistenceProvider persistenceProvider;
 	private final EscapeCharacter escape;
 
 	/**
 	 * Creates a new {@link ParameterMetadataProvider} from the given {@link CriteriaBuilder} and
-	 * {@link ParametersParameterAccessor} with support for parameter value customizations via {@link PersistenceProvider}
-	 * .
+	 * {@link ParametersParameterAccessor}.
 	 *
 	 * @param builder must not be {@literal null}.
 	 * @param accessor must not be {@literal null}.
-	 * @param provider must not be {@literal null}.
-	 * @param escape
+	 * @param escape must not be {@literal null}.
 	 */
 	public ParameterMetadataProvider(CriteriaBuilder builder, ParametersParameterAccessor accessor,
-			PersistenceProvider provider, EscapeCharacter escape) {
-		this(builder, accessor.iterator(), accessor.getParameters(), provider, escape);
+			EscapeCharacter escape) {
+		this(builder, accessor.iterator(), accessor.getParameters(), escape);
 	}
 
 	/**
@@ -81,37 +78,32 @@ class ParameterMetadataProvider {
 	 *
 	 * @param builder must not be {@literal null}.
 	 * @param parameters must not be {@literal null}.
-	 * @param provider must not be {@literal null}.
-	 * @param escape
+	 * @param escape must not be {@literal null}.
 	 */
-	public ParameterMetadataProvider(CriteriaBuilder builder, Parameters<?, ?> parameters, PersistenceProvider provider,
-			EscapeCharacter escape) {
-		this(builder, null, parameters, provider, escape);
+	public ParameterMetadataProvider(CriteriaBuilder builder, Parameters<?, ?> parameters, EscapeCharacter escape) {
+		this(builder, null, parameters, escape);
 	}
 
 	/**
 	 * Creates a new {@link ParameterMetadataProvider} from the given {@link CriteriaBuilder} an {@link Iterable} of all
-	 * bindable parameter values, and {@link Parameters} with support for parameter value customizations via
-	 * {@link PersistenceProvider}.
+	 * bindable parameter values, and {@link Parameters}.
 	 *
 	 * @param builder must not be {@literal null}.
 	 * @param bindableParameterValues may be {@literal null}.
 	 * @param parameters must not be {@literal null}.
-	 * @param provider must not be {@literal null}.
-	 * @param escape
+	 * @param escape must not be {@literal null}.
 	 */
 	private ParameterMetadataProvider(CriteriaBuilder builder, @Nullable Iterator<Object> bindableParameterValues,
-			Parameters<?, ?> parameters, PersistenceProvider provider, EscapeCharacter escape) {
+			Parameters<?, ?> parameters, EscapeCharacter escape) {
 
 		Assert.notNull(builder, "CriteriaBuilder must not be null!");
 		Assert.notNull(parameters, "Parameters must not be null!");
-		Assert.notNull(provider, "PesistenceProvider must not be null!");
+		Assert.notNull(escape, "EscapeCharacter must not be null!");
 
 		this.builder = builder;
 		this.parameters = parameters.getBindableParameters().iterator();
 		this.expressions = new ArrayList<>();
 		this.bindableParameterValues = bindableParameterValues;
-		this.persistenceProvider = provider;
 		this.escape = escape;
 	}
 
@@ -140,7 +132,7 @@ class ParameterMetadataProvider {
 	 * Builds a new {@link ParameterMetadata} of the given {@link Part} and type. Forwards the underlying
 	 * {@link Parameters} as well.
 	 *
-	 * @param <T> is the type parameter of the returend {@link ParameterMetadata}.
+	 * @param <T> is the type parameter of the returned {@link ParameterMetadata}.
 	 * @param type must not be {@literal null}.
 	 * @return ParameterMetadata for the next parameter.
 	 */
@@ -180,7 +172,7 @@ class ParameterMetadataProvider {
 
 		Object value = bindableParameterValues == null ? ParameterMetadata.PLACEHOLDER : bindableParameterValues.next();
 
-		ParameterMetadata<T> metadata = new ParameterMetadata<>(expression, part, value, persistenceProvider, escape);
+		ParameterMetadata<T> metadata = new ParameterMetadata<>(expression, part, value, escape);
 		expressions.add(metadata);
 
 		return metadata;
@@ -202,7 +194,6 @@ class ParameterMetadataProvider {
 
 		private final Type type;
 		private final ParameterExpression<T> expression;
-		private final PersistenceProvider persistenceProvider;
 		private final EscapeCharacter escape;
 		private final boolean ignoreCase;
 
@@ -210,10 +201,9 @@ class ParameterMetadataProvider {
 		 * Creates a new {@link ParameterMetadata}.
 		 */
 		public ParameterMetadata(ParameterExpression<T> expression, Part part, @Nullable Object value,
-				PersistenceProvider provider, EscapeCharacter escape) {
+				EscapeCharacter escape) {
 
 			this.expression = expression;
-			this.persistenceProvider = provider;
 			this.type = value == null && Type.SIMPLE_PROPERTY.equals(part.getType()) ? Type.IS_NULL : part.getType();
 			this.ignoreCase = IgnoreCaseType.ALWAYS.equals(part.shouldIgnoreCase());
 			this.escape = escape;
@@ -263,7 +253,7 @@ class ParameterMetadataProvider {
 			}
 
 			return Collection.class.isAssignableFrom(expressionType) //
-					? persistenceProvider.potentiallyConvertEmptyCollection(upperIfIgnoreCase(ignoreCase, toCollection(value))) //
+					? upperIfIgnoreCase(ignoreCase, toCollection(value)) //
 					: value;
 		}
 
@@ -283,11 +273,15 @@ class ParameterMetadataProvider {
 			}
 
 			if (value instanceof Collection) {
-				return (Collection<?>) value;
+
+				Collection<?> collection = (Collection<?>) value;
+				return collection.isEmpty() ? null : collection;
 			}
 
 			if (ObjectUtils.isArray(value)) {
-				return Arrays.asList(ObjectUtils.toObjectArray(value));
+
+				List<Object> collection = Arrays.asList(ObjectUtils.toObjectArray(value));
+				return collection.isEmpty() ? null : collection;
 			}
 
 			return Collections.singleton(value);

--- a/src/test/java/org/springframework/data/jpa/repository/query/JpaCountQueryCreatorIntegrationTests.java
+++ b/src/test/java/org/springframework/data/jpa/repository/query/JpaCountQueryCreatorIntegrationTests.java
@@ -60,7 +60,7 @@ public class JpaCountQueryCreatorIntegrationTests {
 
 		PartTree tree = new PartTree("findDistinctByRolesIn", User.class);
 		ParameterMetadataProvider metadataProvider = new ParameterMetadataProvider(entityManager.getCriteriaBuilder(),
-				queryMethod.getParameters(), provider, EscapeCharacter.DEFAULT);
+				queryMethod.getParameters(), EscapeCharacter.DEFAULT);
 
 		JpaCountQueryCreator creator = new JpaCountQueryCreator(tree, queryMethod.getResultProcessor().getReturnedType(),
 				entityManager.getCriteriaBuilder(), metadataProvider);

--- a/src/test/java/org/springframework/data/jpa/repository/query/ParameterExpressionProviderTests.java
+++ b/src/test/java/org/springframework/data/jpa/repository/query/ParameterExpressionProviderTests.java
@@ -27,7 +27,6 @@ import javax.persistence.criteria.ParameterExpression;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.data.jpa.domain.sample.User;
-import org.springframework.data.jpa.provider.PersistenceProvider;
 import org.springframework.data.repository.query.DefaultParameters;
 import org.springframework.data.repository.query.Parameters;
 import org.springframework.data.repository.query.ParametersParameterAccessor;
@@ -57,10 +56,9 @@ public class ParameterExpressionProviderTests {
 		Part part = new Part("IdGreaterThan", User.class);
 
 		CriteriaBuilder builder = em.getCriteriaBuilder();
-		PersistenceProvider persistenceProvider = PersistenceProvider.fromEntityManager(em);
-		ParameterMetadataProvider provider = new ParameterMetadataProvider(builder, accessor, persistenceProvider,
-				EscapeCharacter.DEFAULT);
+		ParameterMetadataProvider provider = new ParameterMetadataProvider(builder, accessor, EscapeCharacter.DEFAULT);
 		ParameterExpression<? extends Comparable> expression = provider.next(part, Comparable.class).getExpression();
+
 		assertThat(expression.getParameterType()).isEqualTo(int.class);
 	}
 

--- a/src/test/java/org/springframework/data/jpa/repository/query/ParameterMetadataProviderIntegrationTests.java
+++ b/src/test/java/org/springframework/data/jpa/repository/query/ParameterMetadataProviderIntegrationTests.java
@@ -26,7 +26,6 @@ import javax.persistence.PersistenceContext;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.data.jpa.domain.sample.User;
-import org.springframework.data.jpa.provider.PersistenceProvider;
 import org.springframework.data.jpa.repository.query.ParameterMetadataProvider.ParameterMetadata;
 import org.springframework.data.repository.query.Param;
 import org.springframework.data.repository.query.Parameters;
@@ -80,8 +79,7 @@ public class ParameterMetadataProviderIntegrationTests {
 		JpaParameters parameters = new JpaParameters(method);
 		simulateDiscoveredParametername(parameters);
 
-		return new ParameterMetadataProvider(em.getCriteriaBuilder(), parameters,
-				PersistenceProvider.fromEntityManager(em), EscapeCharacter.DEFAULT);
+		return new ParameterMetadataProvider(em.getCriteriaBuilder(), parameters, EscapeCharacter.DEFAULT);
 	}
 
 	@SuppressWarnings({ "unchecked", "ConstantConditions" })

--- a/src/test/java/org/springframework/data/jpa/repository/query/ParameterMetadataProviderUnitTests.java
+++ b/src/test/java/org/springframework/data/jpa/repository/query/ParameterMetadataProviderUnitTests.java
@@ -23,7 +23,6 @@ import java.util.Collections;
 import javax.persistence.criteria.CriteriaBuilder;
 
 import org.junit.Test;
-import org.springframework.data.jpa.provider.PersistenceProvider;
 import org.springframework.data.repository.query.Parameters;
 import org.springframework.data.repository.query.parser.Part;
 
@@ -37,18 +36,17 @@ public class ParameterMetadataProviderUnitTests {
 	@Test // DATAJPA-863
 	public void errorMessageMentionesParametersWhenParametersAreExhausted() {
 
-		PersistenceProvider persistenceProvider = mock(PersistenceProvider.class);
 		CriteriaBuilder builder = mock(CriteriaBuilder.class);
 
 		Parameters<?, ?> parameters = mock(Parameters.class, RETURNS_DEEP_STUBS);
 		when(parameters.getBindableParameters().iterator()).thenReturn(Collections.emptyListIterator());
 
 		ParameterMetadataProvider metadataProvider = new ParameterMetadataProvider(builder, parameters,
-				persistenceProvider, EscapeCharacter.DEFAULT);
+				EscapeCharacter.DEFAULT);
 
 		assertThatExceptionOfType(RuntimeException.class) //
 				.isThrownBy(() -> metadataProvider.next(mock(Part.class))) //
-                .withMessageContaining("parameter");
+				.withMessageContaining("parameter");
 	}
 
 }

--- a/src/test/java/org/springframework/data/jpa/repository/query/PartTreeJpaQueryIntegrationTests.java
+++ b/src/test/java/org/springframework/data/jpa/repository/query/PartTreeJpaQueryIntegrationTests.java
@@ -82,7 +82,7 @@ public class PartTreeJpaQueryIntegrationTests {
 	public void test() throws Exception {
 
 		JpaQueryMethod queryMethod = getQueryMethod("findByFirstname", String.class, Pageable.class);
-		PartTreeJpaQuery jpaQuery = new PartTreeJpaQuery(queryMethod, entityManager, provider);
+		PartTreeJpaQuery jpaQuery = new PartTreeJpaQuery(queryMethod, entityManager);
 
 		jpaQuery.createQuery(getAccessor(queryMethod, new Object[] { "Matthews", PageRequest.of(0, 1) }));
 		jpaQuery.createQuery((getAccessor(queryMethod, new Object[] { "Matthews", PageRequest.of(0, 1) })));
@@ -106,7 +106,7 @@ public class PartTreeJpaQueryIntegrationTests {
 	public void recreatesQueryIfNullValueIsGiven() throws Exception {
 
 		JpaQueryMethod queryMethod = getQueryMethod("findByFirstname", String.class, Pageable.class);
-		PartTreeJpaQuery jpaQuery = new PartTreeJpaQuery(queryMethod, entityManager, provider);
+		PartTreeJpaQuery jpaQuery = new PartTreeJpaQuery(queryMethod, entityManager);
 
 		Query query = jpaQuery.createQuery((getAccessor(queryMethod, new Object[] { "Matthews", PageRequest.of(0, 1) })));
 
@@ -121,7 +121,7 @@ public class PartTreeJpaQueryIntegrationTests {
 	public void shouldLimitExistsProjectionQueries() throws Exception {
 
 		JpaQueryMethod queryMethod = getQueryMethod("existsByFirstname", String.class);
-		PartTreeJpaQuery jpaQuery = new PartTreeJpaQuery(queryMethod, entityManager, provider);
+		PartTreeJpaQuery jpaQuery = new PartTreeJpaQuery(queryMethod, entityManager);
 
 		Query query = jpaQuery.createQuery((getAccessor(queryMethod, new Object[] { "Matthews" })));
 
@@ -132,7 +132,7 @@ public class PartTreeJpaQueryIntegrationTests {
 	public void shouldSelectAliasedIdForExistsProjectionQueries() throws Exception {
 
 		JpaQueryMethod queryMethod = getQueryMethod("existsByFirstname", String.class);
-		PartTreeJpaQuery jpaQuery = new PartTreeJpaQuery(queryMethod, entityManager, provider);
+		PartTreeJpaQuery jpaQuery = new PartTreeJpaQuery(queryMethod, entityManager);
 
 		Query query = jpaQuery.createQuery((getAccessor(queryMethod, new Object[] { "Matthews" })));
 
@@ -143,7 +143,7 @@ public class PartTreeJpaQueryIntegrationTests {
 	public void isEmptyCollection() throws Exception {
 
 		JpaQueryMethod queryMethod = getQueryMethod("findByRolesIsEmpty");
-		PartTreeJpaQuery jpaQuery = new PartTreeJpaQuery(queryMethod, entityManager, provider);
+		PartTreeJpaQuery jpaQuery = new PartTreeJpaQuery(queryMethod, entityManager);
 
 		Query query = jpaQuery.createQuery((getAccessor(queryMethod, new Object[] {})));
 
@@ -154,7 +154,7 @@ public class PartTreeJpaQueryIntegrationTests {
 	public void isNotEmptyCollection() throws Exception {
 
 		JpaQueryMethod queryMethod = getQueryMethod("findByRolesIsNotEmpty");
-		PartTreeJpaQuery jpaQuery = new PartTreeJpaQuery(queryMethod, entityManager, provider);
+		PartTreeJpaQuery jpaQuery = new PartTreeJpaQuery(queryMethod, entityManager);
 
 		Query query = jpaQuery.createQuery((getAccessor(queryMethod, new Object[] {})));
 
@@ -165,7 +165,7 @@ public class PartTreeJpaQueryIntegrationTests {
 	public void rejectsIsEmptyOnNonCollectionProperty() throws Exception {
 
 		JpaQueryMethod method = getQueryMethod("findByFirstnameIsEmpty");
-		AbstractJpaQuery jpaQuery = new PartTreeJpaQuery(method, entityManager, provider);
+		AbstractJpaQuery jpaQuery = new PartTreeJpaQuery(method, entityManager);
 
 		jpaQuery.createQuery((getAccessor(method, new Object[] { "Oliver" })));
 	}
@@ -176,7 +176,7 @@ public class PartTreeJpaQueryIntegrationTests {
 		JpaQueryMethod method = getQueryMethod("findByIdIn", Integer.class);
 
 		assertThatExceptionOfType(RuntimeException.class) //
-				.isThrownBy(() -> new PartTreeJpaQuery(method, entityManager, provider)) //
+				.isThrownBy(() -> new PartTreeJpaQuery(method, entityManager)) //
 				.withMessageContaining("findByIdIn") //
 				.withMessageContaining(" IN ") //
 				.withMessageContaining("Collection") //
@@ -189,7 +189,7 @@ public class PartTreeJpaQueryIntegrationTests {
 		JpaQueryMethod method = getQueryMethod("findById", Collection.class);
 
 		assertThatExceptionOfType(RuntimeException.class) //
-				.isThrownBy(() -> new PartTreeJpaQuery(method, entityManager, provider)) //
+				.isThrownBy(() -> new PartTreeJpaQuery(method, entityManager)) //
 				.withMessageContaining("findById") //
 				.withMessageContaining(" SIMPLE_PROPERTY ") //
 				.withMessageContaining(" scalar ") //
@@ -201,7 +201,7 @@ public class PartTreeJpaQueryIntegrationTests {
 
 		JpaQueryMethod method = getQueryMethod("findByFirstnameIn", Iterable.class);
 
-		new PartTreeJpaQuery(method, entityManager, provider);
+		new PartTreeJpaQuery(method, entityManager);
 
 		assertThat(method).isNotNull();
 	}
@@ -212,7 +212,7 @@ public class PartTreeJpaQueryIntegrationTests {
 		JpaQueryMethod method = getQueryMethod("findByFirstname");
 
 		assertThatExceptionOfType(IllegalArgumentException.class) //
-				.isThrownBy(() -> new PartTreeJpaQuery(method, entityManager, provider)) //
+				.isThrownBy(() -> new PartTreeJpaQuery(method, entityManager)) //
 				.withMessageContaining("findByFirstname") // the method being analyzed
 				.withMessageContaining(" firstname ") // the property we are looking for
 				.withMessageContaining("UserRepository"); // the repository
@@ -224,7 +224,7 @@ public class PartTreeJpaQueryIntegrationTests {
 		JpaQueryMethod method = getQueryMethod("findByNoSuchProperty", String.class);
 
 		assertThatExceptionOfType(IllegalArgumentException.class) //
-				.isThrownBy(() -> new PartTreeJpaQuery(method, entityManager, provider)) //
+				.isThrownBy(() -> new PartTreeJpaQuery(method, entityManager)) //
 				.withMessageContaining("findByNoSuchProperty") // the method being analyzed
 				.withMessageContaining(" noSuchProperty ") // the property we are looking for
 				.withMessageContaining("UserRepository"); // the repository
@@ -239,8 +239,7 @@ public class PartTreeJpaQueryIntegrationTests {
 		}
 
 		JpaQueryMethod queryMethod = getQueryMethod(methodName, parameterTypes);
-		PartTreeJpaQuery jpaQuery = new PartTreeJpaQuery(queryMethod, entityManager,
-				PersistenceProvider.fromEntityManager(entityManager));
+		PartTreeJpaQuery jpaQuery = new PartTreeJpaQuery(queryMethod, entityManager);
 		jpaQuery.createQuery((getAccessor(queryMethod, values)));
 	}
 


### PR DESCRIPTION
`PersistenceProvider.potentiallyConvertEmptyCollection(…)` is no longer necessary.
The single relevant implementation got inlined in the single usage location.
This in turn made a bunch of PersistenceProvider passing around superfluous which in turn get removed as well.

https://jira.spring.io/browse/DATAJPA-1663