### PR TITLE
DATAJPA-1657 - @Procedure annotation doesn't work with cursors (NULL when using REF_CURSOR) and ResultSets that don't come from cursors

### DIFF
--- a/src/main/java/org/springframework/data/jpa/repository/query/JpaQueryExecution.java
+++ b/src/main/java/org/springframework/data/jpa/repository/query/JpaQueryExecution.java
@@ -300,6 +300,8 @@ public abstract class JpaQueryExecution {
 	 */
 	static class ProcedureExecution extends JpaQueryExecution {
 
+		private static final String NO_SURROUNDING_TRANSACTION = "You're trying to execute a @Procedure method without a surrounding transaction that keeps the connection open so that the ResultSet can actually be consumed. Make sure the consumer code uses @Transactional or any other way of declaring a (read-only) transaction.";
+
 		/*
 		 * (non-Javadoc)
 		 * @see org.springframework.data.jpa.repository.query.JpaQueryExecution#doExecute(org.springframework.data.jpa.repository.query.AbstractJpaQuery, java.lang.Object[])

--- a/src/main/java/org/springframework/data/jpa/repository/query/JpaQueryExecution.java
+++ b/src/main/java/org/springframework/data/jpa/repository/query/JpaQueryExecution.java
@@ -53,6 +53,7 @@ import org.springframework.util.ReflectionUtils;
  * @author Christoph Strobl
  * @author Nicolas Cirigliano
  * @author Jens Schauder
+ * @author Gabriel Basilio
  */
 public abstract class JpaQueryExecution {
 
@@ -313,7 +314,24 @@ public abstract class JpaQueryExecution {
 
 			StoredProcedureJpaQuery storedProcedureJpaQuery = (StoredProcedureJpaQuery) jpaQuery;
 			StoredProcedureQuery storedProcedure = storedProcedureJpaQuery.createQuery(accessor);
-			storedProcedure.execute();
+
+			boolean returnsResultSet = storedProcedure.execute();
+
+			if (returnsResultSet) {
+				if (!SurroundingTransactionDetectorMethodInterceptor.INSTANCE.isSurroundingTransactionActive())
+					throw new InvalidDataAccessApiUsageException(NO_SURROUNDING_TRANSACTION);
+
+				List<?> result = storedProcedure.getResultList();
+
+				if (!storedProcedureJpaQuery.getQueryMethod().isCollectionQuery()) {
+					if (result.isEmpty())
+						return null;
+					if (result.size() == 1)
+						return result.get(0);
+				}
+
+				return result;
+			}
 
 			return storedProcedureJpaQuery.extractOutputValue(storedProcedure);
 		}

--- a/src/main/java/org/springframework/data/jpa/repository/query/Procedure.java
+++ b/src/main/java/org/springframework/data/jpa/repository/query/Procedure.java
@@ -26,6 +26,7 @@ import java.lang.annotation.Target;
  * @author Thomas Darimont
  * @author Oliver Gierke
  * @author Christoph Strobl
+ * @author Gabriel Basilio
  * @since 1.6
  */
 @Target({ ElementType.METHOD, ElementType.ANNOTATION_TYPE })
@@ -51,4 +52,9 @@ public @interface Procedure {
 	 * The name of the outputParameter, defaults to {@code ""}.
 	 */
 	String outputParameterName() default "";
+
+	/**
+	 * Whether the procedure returns a Ref Cursor from the database {@code false}.
+	 */
+	boolean refCursor() default false;
 }

--- a/src/main/java/org/springframework/data/jpa/repository/query/ProcedureParameter.java
+++ b/src/main/java/org/springframework/data/jpa/repository/query/ProcedureParameter.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2014-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.data.jpa.repository.query;
+
+import org.springframework.lang.Nullable;
+
+import javax.persistence.ParameterMode;
+
+/**
+ * This class represents a Stored Procedure Parameter
+ * and an instance of the annotation {@link javax.persistence.StoredProcedureParameter}.
+ *
+ * @author Gabriel Basilio
+ */
+public class ProcedureParameter {
+
+	private final String name;
+	private final ParameterMode mode;
+	private final Class<?> type;
+
+	public ProcedureParameter(@Nullable String name, ParameterMode mode, Class<?> type) {
+		this.name = name;
+		this.mode = mode;
+		this.type = type;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public ParameterMode getMode() {
+		return mode;
+	}
+
+	public Class<?> getType() {
+		return type;
+	}
+}

--- a/src/test/java/org/springframework/data/jpa/repository/StoredProcedureIntegrationTests.java
+++ b/src/test/java/org/springframework/data/jpa/repository/StoredProcedureIntegrationTests.java
@@ -46,6 +46,7 @@ import org.springframework.transaction.annotation.Transactional;
  * @author Thomas Darimont
  * @author Oliver Gierke
  * @author Jens Schauder
+ * @author Gabriel Basilio
  * @see scripts/schema-stored-procedures.sql for procedure definitions.
  */
 @Transactional
@@ -53,7 +54,7 @@ import org.springframework.transaction.annotation.Transactional;
 @RunWith(SpringJUnit4ClassRunner.class)
 public class StoredProcedureIntegrationTests {
 
-	private static final String NOT_SUPPORTED = "Stored procedures with ResultSets are currently not supported for any JPA provider";
+	private static final String NOT_SUPPORTED = "Stored procedures with REF_CURSOR are currently not supported by HSQL dialect";
 
 	@PersistenceContext EntityManager em;
 	@Autowired DummyRepository repository;

--- a/src/test/java/org/springframework/data/jpa/repository/query/StoredProcedureAttributeSourceUnitTests.java
+++ b/src/test/java/org/springframework/data/jpa/repository/query/StoredProcedureAttributeSourceUnitTests.java
@@ -21,14 +21,17 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.springframework.core.annotation.AliasFor;
+import org.springframework.data.jpa.domain.sample.Dummy;
 import org.springframework.data.jpa.domain.sample.User;
 import org.springframework.data.repository.query.Param;
 import org.springframework.util.ReflectionUtils;
 
 import javax.persistence.EntityManager;
+import javax.persistence.ParameterMode;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.reflect.Method;
+import java.util.List;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.*;
@@ -43,6 +46,7 @@ import static org.mockito.Mockito.*;
  * @author Diego Diez
  * @author Jeff Sheets
  * @author Jens Schauder
+ * @author Gabriel Basilio
  * @since 1.6
  */
 @RunWith(MockitoJUnitRunner.class)
@@ -65,10 +69,11 @@ public class StoredProcedureAttributeSourceUnitTests {
 	public void shouldCreateStoredProcedureAttributesFromProcedureMethodWithImplicitProcedureName() {
 
 		StoredProcedureAttributes attr = creator.createFrom(method("plus1inout", Integer.class), entityMetadata);
-
+		ProcedureParameter outputParameter = attr.getOutputProcedureParameters().get(0);
 		assertThat(attr.getProcedureName()).isEqualTo("plus1inout");
-		assertThat(attr.getOutputParameterTypes().get(0)).isEqualTo(Integer.class);
-		assertThat(attr.getOutputParameterNames().get(0)).isEqualTo(StoredProcedureAttributes.SYNTHETIC_OUTPUT_PARAMETER_NAME);
+		assertThat(outputParameter.getMode()).isEqualTo(ParameterMode.OUT);
+		assertThat(outputParameter.getType()).isEqualTo(Integer.class);
+		assertThat(outputParameter.getName()).isEqualTo(StoredProcedureAttributes.SYNTHETIC_OUTPUT_PARAMETER_NAME);
 	}
 
 	@Test // DATAJPA-455
@@ -77,9 +82,11 @@ public class StoredProcedureAttributeSourceUnitTests {
 		StoredProcedureAttributes attr = creator.createFrom(method("explicitlyNamedPlus1inout", Integer.class),
 				entityMetadata);
 
+		ProcedureParameter outputParameter = attr.getOutputProcedureParameters().get(0);
 		assertThat(attr.getProcedureName()).isEqualTo("plus1inout");
-		assertThat(attr.getOutputParameterTypes().get(0)).isEqualTo(Integer.class);
-		assertThat(attr.getOutputParameterNames().get(0)).isEqualTo(StoredProcedureAttributes.SYNTHETIC_OUTPUT_PARAMETER_NAME);
+		assertThat(outputParameter.getMode()).isEqualTo(ParameterMode.OUT);
+		assertThat(outputParameter.getType()).isEqualTo(Integer.class);
+		assertThat(outputParameter.getName()).isEqualTo(StoredProcedureAttributes.SYNTHETIC_OUTPUT_PARAMETER_NAME);
 	}
 
 	@Test // DATAJPA-455
@@ -88,9 +95,11 @@ public class StoredProcedureAttributeSourceUnitTests {
 		StoredProcedureAttributes attr = creator.createFrom(method("explicitlyNamedPlus1inout", Integer.class),
 				entityMetadata);
 
+		ProcedureParameter outputParameter = attr.getOutputProcedureParameters().get(0);
 		assertThat(attr.getProcedureName()).isEqualTo("plus1inout");
-		assertThat(attr.getOutputParameterTypes().get(0)).isEqualTo(Integer.class);
-		assertThat(attr.getOutputParameterNames().get(0)).isEqualTo(StoredProcedureAttributes.SYNTHETIC_OUTPUT_PARAMETER_NAME);
+		assertThat(outputParameter.getMode()).isEqualTo(ParameterMode.OUT);
+		assertThat(outputParameter.getType()).isEqualTo(Integer.class);
+		assertThat(outputParameter.getName()).isEqualTo(StoredProcedureAttributes.SYNTHETIC_OUTPUT_PARAMETER_NAME);
 	}
 
 	@Test // DATAJPA-455
@@ -99,9 +108,11 @@ public class StoredProcedureAttributeSourceUnitTests {
 		StoredProcedureAttributes attr = creator
 				.createFrom(method("explicitPlus1inoutViaProcedureNameAlias", Integer.class), entityMetadata);
 
+		ProcedureParameter outputParameter = attr.getOutputProcedureParameters().get(0);
 		assertThat(attr.getProcedureName()).isEqualTo("plus1inout");
-		assertThat(attr.getOutputParameterTypes().get(0)).isEqualTo(Integer.class);
-		assertThat(attr.getOutputParameterNames().get(0)).isEqualTo(StoredProcedureAttributes.SYNTHETIC_OUTPUT_PARAMETER_NAME);
+		assertThat(outputParameter.getMode()).isEqualTo(ParameterMode.OUT);
+		assertThat(outputParameter.getType()).isEqualTo(Integer.class);
+		assertThat(outputParameter.getName()).isEqualTo(StoredProcedureAttributes.SYNTHETIC_OUTPUT_PARAMETER_NAME);
 	}
 
 	@Test // DATAJPA-1297
@@ -110,9 +121,11 @@ public class StoredProcedureAttributeSourceUnitTests {
 		StoredProcedureAttributes attr = creator.createFrom(
 				method("explicitPlus1inoutViaProcedureNameAliasAndOutputParameterName", Integer.class), entityMetadata);
 
+		ProcedureParameter outputParameter = attr.getOutputProcedureParameters().get(0);
 		assertThat(attr.getProcedureName()).isEqualTo("plus1inout");
-		assertThat(attr.getOutputParameterTypes().get(0)).isEqualTo(Integer.class);
-		assertThat(attr.getOutputParameterNames().get(0)).isEqualTo("res");
+		assertThat(outputParameter.getMode()).isEqualTo(ParameterMode.OUT);
+		assertThat(outputParameter.getType()).isEqualTo(Integer.class);
+		assertThat(outputParameter.getName()).isEqualTo("res");
 	}
 
 	@Test // DATAJPA-455
@@ -121,9 +134,11 @@ public class StoredProcedureAttributeSourceUnitTests {
 		StoredProcedureAttributes attr = creator
 				.createFrom(method("entityAnnotatedCustomNamedProcedurePlus1IO", Integer.class), entityMetadata);
 
+		ProcedureParameter outputParameter = attr.getOutputProcedureParameters().get(0);
 		assertThat(attr.getProcedureName()).isEqualTo("User.plus1IO");
-		assertThat(attr.getOutputParameterTypes().get(0)).isEqualTo(Integer.class);
-		assertThat(attr.getOutputParameterNames().get(0)).isEqualTo("res");
+		assertThat(outputParameter.getMode()).isEqualTo(ParameterMode.OUT);
+		assertThat(outputParameter.getType()).isEqualTo(Integer.class);
+		assertThat(outputParameter.getName()).isEqualTo("res");
 	}
 
 	@Test // DATAJPA-707
@@ -132,9 +147,11 @@ public class StoredProcedureAttributeSourceUnitTests {
 		StoredProcedureAttributes attr = creator
 				.createFrom(method("entityAnnotatedCustomNamedProcedureOutputParamNamePlus1IO", Integer.class), entityMetadata);
 
+		ProcedureParameter outputParameter = attr.getOutputProcedureParameters().get(0);
 		assertThat(attr.getProcedureName()).isEqualTo("User.plus1IO");
-		assertThat(attr.getOutputParameterTypes().get(0)).isEqualTo(Integer.class);
-		assertThat(attr.getOutputParameterNames().get(0)).isEqualTo("override");
+		assertThat(outputParameter.getMode()).isEqualTo(ParameterMode.OUT);
+		assertThat(outputParameter.getType()).isEqualTo(Integer.class);
+		assertThat(outputParameter.getName()).isEqualTo("override");
 	}
 
 	@Test // DATAJPA-707
@@ -143,11 +160,18 @@ public class StoredProcedureAttributeSourceUnitTests {
 		StoredProcedureAttributes attr = creator
 				.createFrom(method("entityAnnotatedCustomNamedProcedurePlus1IO2", Integer.class), entityMetadata);
 
+		ProcedureParameter firstOutputParameter = attr.getOutputProcedureParameters().get(0);
+		ProcedureParameter secondOutputParameter = attr.getOutputProcedureParameters().get(1);
+
 		assertThat(attr.getProcedureName()).isEqualTo("User.plus1IO2");
-		assertThat(attr.getOutputParameterTypes().get(0)).isEqualTo(Integer.class);
-		assertThat(attr.getOutputParameterNames().get(0)).isEqualTo("res");
-		assertThat(attr.getOutputParameterTypes().get(1)).isEqualTo(Integer.class);
-		assertThat(attr.getOutputParameterNames().get(1)).isEqualTo("res2");
+
+		assertThat(firstOutputParameter.getMode()).isEqualTo(ParameterMode.OUT);
+		assertThat(firstOutputParameter.getType()).isEqualTo(Integer.class);
+		assertThat(firstOutputParameter.getName()).isEqualTo("res");
+
+		assertThat(secondOutputParameter.getMode()).isEqualTo(ParameterMode.OUT);
+		assertThat(secondOutputParameter.getType()).isEqualTo(Integer.class);
+		assertThat(secondOutputParameter.getName()).isEqualTo("res2");
 	}
 
 	@Test // DATAJPA-455
@@ -155,9 +179,11 @@ public class StoredProcedureAttributeSourceUnitTests {
 
 		StoredProcedureAttributes attr = creator.createFrom(method("plus1", Integer.class), entityMetadata);
 
+		ProcedureParameter outputParameter = attr.getOutputProcedureParameters().get(0);
 		assertThat(attr.getProcedureName()).isEqualTo("User.plus1");
-		assertThat(attr.getOutputParameterTypes().get(0)).isEqualTo(Integer.class);
-		assertThat(attr.getOutputParameterNames().get(0)).isEqualTo("res");
+		assertThat(outputParameter.getMode()).isEqualTo(ParameterMode.OUT);
+		assertThat(outputParameter.getType()).isEqualTo(Integer.class);
+		assertThat(outputParameter.getName()).isEqualTo("res");
 	}
 
 	@Test // DATAJPA-871
@@ -166,9 +192,11 @@ public class StoredProcedureAttributeSourceUnitTests {
 		StoredProcedureAttributes attr = creator
 				.createFrom(method("plus1inoutWithComposedAnnotationOverridingProcedureName", Integer.class), entityMetadata);
 
+		ProcedureParameter outputParameter = attr.getOutputProcedureParameters().get(0);
 		assertThat(attr.getProcedureName()).isEqualTo("plus1inout");
-		assertThat(attr.getOutputParameterTypes().get(0)).isEqualTo(Integer.class);
-		assertThat(attr.getOutputParameterNames().get(0)).isEqualTo(StoredProcedureAttributes.SYNTHETIC_OUTPUT_PARAMETER_NAME);
+		assertThat(outputParameter.getMode()).isEqualTo(ParameterMode.OUT);
+		assertThat(outputParameter.getType()).isEqualTo(Integer.class);
+		assertThat(outputParameter.getName()).isEqualTo(StoredProcedureAttributes.SYNTHETIC_OUTPUT_PARAMETER_NAME);
 	}
 
 	@Test // DATAJPA-871
@@ -177,9 +205,104 @@ public class StoredProcedureAttributeSourceUnitTests {
 		StoredProcedureAttributes attr = creator
 				.createFrom(method("plus1inoutWithComposedAnnotationOverridingName", Integer.class), entityMetadata);
 
+		ProcedureParameter outputParameter = attr.getOutputProcedureParameters().get(0);
 		assertThat(attr.getProcedureName()).isEqualTo("User.plus1");
-		assertThat(attr.getOutputParameterTypes().get(0)).isEqualTo(Integer.class);
-		assertThat(attr.getOutputParameterNames().get(0)).isEqualTo("res");
+		assertThat(outputParameter.getMode()).isEqualTo(ParameterMode.OUT);
+		assertThat(outputParameter.getType()).isEqualTo(Integer.class);
+		assertThat(outputParameter.getName()).isEqualTo("res");
+	}
+
+	@Test // DATAJPA-1657
+	public void testSingleEntityFrom1RowResultSetAndNoInput() {
+
+		StoredProcedureAttributes attr = creator
+				.createFrom(method("singleEntityFrom1RowResultSetAndNoInput"), entityMetadata);
+
+		ProcedureParameter outputParameter = attr.getOutputProcedureParameters().get(0);
+		assertThat(attr.getProcedureName()).isEqualTo("0_input_1_row_resultset");
+		assertThat(outputParameter.getMode()).isEqualTo(ParameterMode.OUT);
+		assertThat(outputParameter.getType()).isEqualTo(Dummy.class);
+		assertThat(outputParameter.getName()).isEqualTo(StoredProcedureAttributes.SYNTHETIC_OUTPUT_PARAMETER_NAME);
+	}
+
+	@Test // DATAJPA-1657
+	public void testSingleEntityFrom1RowResultSetWithInput() {
+
+		StoredProcedureAttributes attr = creator
+				.createFrom(method("singleEntityFrom1RowResultSetWithInput", Integer.class), entityMetadata);
+
+		ProcedureParameter outputParameter = attr.getOutputProcedureParameters().get(0);
+		assertThat(attr.getProcedureName()).isEqualTo("1_input_1_row_resultset");
+		assertThat(outputParameter.getMode()).isEqualTo(ParameterMode.OUT);
+		assertThat(outputParameter.getType()).isEqualTo(Dummy.class);
+		assertThat(outputParameter.getName()).isEqualTo(StoredProcedureAttributes.SYNTHETIC_OUTPUT_PARAMETER_NAME);
+	}
+
+
+	@Test // DATAJPA-1657
+	public void testEntityListFromResultSetWithNoInput() {
+
+		StoredProcedureAttributes attr = creator
+				.createFrom(method("entityListFromResultSetWithNoInput"), entityMetadata);
+
+		ProcedureParameter outputParameter = attr.getOutputProcedureParameters().get(0);
+		assertThat(attr.getProcedureName()).isEqualTo("0_input_1_resultset");
+		assertThat(outputParameter.getMode()).isEqualTo(ParameterMode.OUT);
+		assertThat(outputParameter.getType()).isEqualTo(List.class);
+		assertThat(outputParameter.getName()).isEqualTo(StoredProcedureAttributes.SYNTHETIC_OUTPUT_PARAMETER_NAME);
+	}
+
+	//
+	@Test // DATAJPA-1657
+	public void testEntityListFromResultSetWithInput() {
+
+		StoredProcedureAttributes attr = creator
+				.createFrom(method("entityListFromResultSetWithInput", Integer.class), entityMetadata);
+
+		ProcedureParameter outputParameter = attr.getOutputProcedureParameters().get(0);
+		assertThat(attr.getProcedureName()).isEqualTo("1_input_1_resultset");
+		assertThat(outputParameter.getMode()).isEqualTo(ParameterMode.OUT);
+		assertThat(outputParameter.getType()).isEqualTo(List.class);
+		assertThat(outputParameter.getName()).isEqualTo(StoredProcedureAttributes.SYNTHETIC_OUTPUT_PARAMETER_NAME);
+	}
+
+	@Test // DATAJPA-1657
+	public void testGenericObjectListFromResultSetWithInput() {
+
+		StoredProcedureAttributes attr = creator
+				.createFrom(method("genericObjectListFromResultSetWithInput", Integer.class), entityMetadata);
+
+		ProcedureParameter outputParameter = attr.getOutputProcedureParameters().get(0);
+		assertThat(attr.getProcedureName()).isEqualTo("1_input_1_resultset");
+		assertThat(outputParameter.getMode()).isEqualTo(ParameterMode.OUT);
+		assertThat(outputParameter.getType()).isEqualTo(List.class);
+		assertThat(outputParameter.getName()).isEqualTo(StoredProcedureAttributes.SYNTHETIC_OUTPUT_PARAMETER_NAME);
+	}
+
+	@Test // DATAJPA-1657
+	public void testEntityListFromResultSetWithInputAndNamedOutput() {
+
+		StoredProcedureAttributes attr = creator
+				.createFrom(method("entityListFromResultSetWithInputAndNamedOutput", Integer.class), entityMetadata);
+
+		ProcedureParameter outputParameter = attr.getOutputProcedureParameters().get(0);
+		assertThat(attr.getProcedureName()).isEqualTo("1_input_1_resultset");
+		assertThat(outputParameter.getMode()).isEqualTo(ParameterMode.OUT);
+		assertThat(outputParameter.getType()).isEqualTo(List.class);
+		assertThat(outputParameter.getName()).isEqualTo("dummies");
+	}
+
+	@Test // DATAJPA-1657
+	public void testEntityListFromResultSetWithInputAndNamedOutputAndCursor() {
+
+		StoredProcedureAttributes attr = creator
+				.createFrom(method("entityListFromResultSetWithInputAndNamedOutputAndCursor", Integer.class), entityMetadata);
+
+		ProcedureParameter outputParameter = attr.getOutputProcedureParameters().get(0);
+		assertThat(attr.getProcedureName()).isEqualTo("1_input_1_resultset");
+		assertThat(outputParameter.getMode()).isEqualTo(ParameterMode.REF_CURSOR);
+		assertThat(outputParameter.getType()).isEqualTo(List.class);
+		assertThat(outputParameter.getName()).isEqualTo("dummies");
 	}
 
 	private static Method method(String name, Class<?>... paramTypes) {
@@ -255,6 +378,34 @@ public class StoredProcedureAttributeSourceUnitTests {
 
 		@ComposedProcedureUsingAliasFor(emProcedureName = "User.plus1")
 		Integer plus1inoutWithComposedAnnotationOverridingName(Integer arg);
+
+		@Procedure("0_input_1_row_resultset")
+			// DATAJPA-1657
+		Dummy singleEntityFrom1RowResultSetAndNoInput();
+
+		@Procedure("1_input_1_row_resultset")
+			// DATAJPA-1657
+		Dummy singleEntityFrom1RowResultSetWithInput(Integer arg);
+
+		@Procedure("0_input_1_resultset")
+			// DATAJPA-1657
+		List<Dummy> entityListFromResultSetWithNoInput();
+
+		@Procedure("1_input_1_resultset")
+			// DATAJPA-1657
+		List<Dummy> entityListFromResultSetWithInput(Integer arg);
+
+		@Procedure("1_input_1_resultset")
+			// DATAJPA-1657
+		List<Object[]> genericObjectListFromResultSetWithInput(Integer arg);
+
+		@Procedure(value = "1_input_1_resultset", outputParameterName = "dummies")
+			// DATAJPA-1657
+		List<Dummy> entityListFromResultSetWithInputAndNamedOutput(Integer arg);
+
+		@Procedure(value = "1_input_1_resultset", outputParameterName = "dummies", refCursor = true)
+			// DATAJPA-1657
+		List<Dummy> entityListFromResultSetWithInputAndNamedOutputAndCursor(Integer arg);
 	}
 
 	@SuppressWarnings("unused")

--- a/src/test/java/org/springframework/data/jpa/repository/query/StoredProcedureAttributesUnitTests.java
+++ b/src/test/java/org/springframework/data/jpa/repository/query/StoredProcedureAttributesUnitTests.java
@@ -20,6 +20,8 @@ import static org.springframework.data.jpa.repository.query.StoredProcedureAttri
 
 import org.junit.Test;
 
+import javax.persistence.ParameterMode;
+
 /**
  * Unit tests for {@link StoredProcedureAttributes}.
  *
@@ -31,7 +33,8 @@ public class StoredProcedureAttributesUnitTests {
 	@Test // DATAJPA-681
 	public void usesSyntheticOutputParameterNameForAdhocProcedureWithoutOutputName() {
 
-		StoredProcedureAttributes attributes = new StoredProcedureAttributes("procedure", null, Long.class);
-		assertThat(attributes.getOutputParameterNames().get(0)).isEqualTo(SYNTHETIC_OUTPUT_PARAMETER_NAME);
+		ProcedureParameter outputParameter = new ProcedureParameter(null, ParameterMode.OUT, Long.class);
+		StoredProcedureAttributes attributes = new StoredProcedureAttributes("procedure", outputParameter);
+		assertThat(attributes.getOutputProcedureParameters().get(0).getName()).isEqualTo(SYNTHETIC_OUTPUT_PARAMETER_NAME);
 	}
 }


### PR DESCRIPTION
- [ x ] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [ x ] There is a ticket in the bug tracker for the project in our [JIRA](https://jira.spring.io/projects/DATAJPA/issues/DATAJPA-1657).
- [ x ] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [ x] You submit test cases (unit or integration tests) that back your changes.
- [ x ] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).

Objectives:

- Make it possible to return ResultSets from @Procedure without using REF_CURSOR

- Make it possible to return ResultSets from @Procedure using REF_CURSOR

- Remove the need to use @NamedStoredProcedureQuery in your entities to return cursors. We should be able to return it with a simple @Procedure annotation

Details:

I made a change so you can call procedures that return ResultSets using the @Procedure annotation. I tested this in [this secondary project](https://github.com/GabrielBB/spring-data-jpa-procedure-tests) with MySQL, Postgres, Oracle and SQL Server databases

What did I do to make it work for any of those 4 databases? I added a new parameter called "refCursor" to express that the procedure in your database is using a REF_CURSOR. Here is an Example that would work with Oracle:

```java
@Procedure("my_procedure",  refCursor = true)
List<Entity> myProcedure(Integer input);
```

However if you're using MySQL or SQL Server, you don't need that parameter. This will work:

```java
@Procedure("my_procedure")
List<Entity> myProcedure(Integer input);
```

You can also return a single Entity from your procedure. For Example:

```java
@Procedure("my_procedure")
Entity myProcedure();
```

One more... You can also return a list of generic objects. For example:

```java
@Procedure("my_procedure")
List<Object[]> myProcedure();
```

Nothing else is needed to call your procedure with ResultSets. I made sure you don't have to use Hibernate's @Namedstoredprocedurequery in your entities, making them dirty. I also made sure you can still return regular output parameters. This still works:

```java
@Procedure("my_procedure")
Integer myProcedure();
```

I predict if you are intending to return a ResultSet using this logic: If the method annotated with @Procedure has a Collection return type or if it's not a collection but it is an entity. This works 100% of the time because OUT parameters are never returned in collections (List<Object>) but in arrays (Object[]) and also OUT parameters will never return an Entity. However when the refCursor attribute is set to true, this logic is obviously not needed because the user is explicitly saying that he is intending to return a ResultSet from the database using a cursor. That logic is only for procedures that return resultsets without cursors, for example, when using MySQL.

I could pass a boolean all around the code saying if the procedure will return a resulset so at the end, in the JPAQueryExecution class, I can know if I should call getResultList() or read output parameter values, but my condition is based instead on the [javax/persistence/StoredProcedureQuery.execute](https://docs.oracle.com/javaee/7/api/javax/persistence/StoredProcedureQuery.html#execute--) return value:

> boolean execute()
> Return true if the first result corresponds to a result set, and false if it is an update count or if there are no results other than through INOUT and OUT parameters, if any.

To return ResultSets the code calling the @Procedure method needs to have an active transaction. I re-used some logic I found to check if no transaction is active, if not, then I throw [InvalidDataAccessApiUsageException](https://docs.spring.io/spring/docs/current/javadoc-api/org/springframework/dao/InvalidDataAccessApiUsageException.html)

I added 6 unit tests in spring-data-jpa covering the following cases:

```java
        @Procedure("0_input_1_row_resultset")
        Dummy singleEntityFromResultSetAndNoInput();

        @Procedure("1_input_1_row_resultset")
        Dummy singleEntityFrom1RowResultSetWithInput(Integer arg);

        @Procedure("0_input_1_resultset")
        List<Dummy> entityListFrom1RowResultSetWithNoInput();

        @Procedure("1_input_1_resultset")
        List<Dummy> entityListFrom1RowResultSetWithInput(Integer arg);

        @Procedure(value = "1_input_1_resultset", outputParameterName = "dummies")
        List<Dummy> entityListFrom1RowResultSetWithInputAndNamedOutput(Integer arg);

        @Procedure(value = "1_input_1_resultset", outputParameterName = "dummies", refCursor = true)
        List<Dummy> entityListFrom1RowResultSetWithInputAndNamedOutputAndCursor(Integer arg);

```

However, spring-data-jpa uses [HSQL](http://hsqldb.org/) for the integration tests and the HSQL [Dialect for Hibernate](https://docs.jboss.org/hibernate/orm/3.5/javadocs/org/hibernate/dialect/HSQLDialect.html) doesn't support returning REF_CURSORs so there's no way to make integration tests for this. That's why I made [another project](https://github.com/GabrielBB/spring-data-jpa-procedure-tests) to test this with MySQL, Oracle, Postgres and SQL Server dockerized databases. All the tests passed! ResultSets with or without REF_CURSORs are working perfectly. 

I  found this text somewhere in the spring-data-jpa code that justifies not supporting REF_CURSORs:

> Stored procedures with ResultSets are currently not supported for any
> JPA Provider

That is not true. Hibernate works with it (maybe the support was added after that comment) and all the major database dialects support it (I mentioned 4 databases that I tested with, maybe there are more). That's why i changed that comment to: 

> Stored procedures with REF_CURSOR are currently not supported by the HSQL dialect