### PR TITLE
Adding Github Continuous Integration

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -1,0 +1,18 @@
+#author Gabriel Basilio
+name: Java CI
+
+on: [push]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up JDK 1.8
+      uses: actions/setup-java@v1
+      with:
+        java-version: 1.8
+    - name: Build with Maven
+      run: mvn test


### PR DESCRIPTION
Adding Github Actions Maven Workflow. This will make it easier for the owners and contributors to quickly check if pull requests are passing the maven tests. Its' free. Why not

You can see that the CI works here: https://github.com/GabrielBB/spring-data-jpa/runs/421046996