### PR TITLE
DATAJPA-872 - Allow for duplicate hints.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-jpa</artifactId>
-	<version>2.4.0-SNAPSHOT</version>
+	<version>2.4.0.DATAJPA-872</version>
 
 	<name>Spring Data JPA</name>
 	<description>Spring Data module for JPA repositories.</description>

--- a/src/main/java/org/springframework/data/jpa/repository/query/AbstractJpaQuery.java
+++ b/src/main/java/org/springframework/data/jpa/repository/query/AbstractJpaQuery.java
@@ -41,6 +41,7 @@ import org.springframework.data.jpa.repository.query.JpaQueryExecution.Procedure
 import org.springframework.data.jpa.repository.query.JpaQueryExecution.SingleEntityExecution;
 import org.springframework.data.jpa.repository.query.JpaQueryExecution.SlicedExecution;
 import org.springframework.data.jpa.repository.query.JpaQueryExecution.StreamExecution;
+import org.springframework.data.jpa.repository.support.QueryHintValue;
 import org.springframework.data.jpa.util.JpaMetamodel;
 import org.springframework.data.repository.query.RepositoryQuery;
 import org.springframework.data.repository.query.ResultProcessor;
@@ -239,11 +240,11 @@ public abstract class AbstractJpaQuery implements RepositoryQuery {
 		JpaEntityGraph entityGraph = method.getEntityGraph();
 
 		if (entityGraph != null) {
-			Map<String, Object> hints = Jpa21Utils.tryGetFetchGraphHints(em, method.getEntityGraph(),
+			List<QueryHintValue> hints = Jpa21Utils.tryGetFetchGraphHints(em, method.getEntityGraph(),
 					getQueryMethod().getEntityInformation().getJavaType());
 
-			for (Map.Entry<String, Object> hint : hints.entrySet()) {
-				query.setHint(hint.getKey(), hint.getValue());
+			for (QueryHintValue hint : hints) {
+				query.setHint(hint.name, hint.value);
 			}
 		}
 

--- a/src/main/java/org/springframework/data/jpa/repository/query/AbstractJpaQuery.java
+++ b/src/main/java/org/springframework/data/jpa/repository/query/AbstractJpaQuery.java
@@ -42,6 +42,7 @@ import org.springframework.data.jpa.repository.query.JpaQueryExecution.SingleEnt
 import org.springframework.data.jpa.repository.query.JpaQueryExecution.SlicedExecution;
 import org.springframework.data.jpa.repository.query.JpaQueryExecution.StreamExecution;
 import org.springframework.data.jpa.repository.support.QueryHintValue;
+import org.springframework.data.jpa.repository.support.SimpleQueryHints;
 import org.springframework.data.jpa.util.JpaMetamodel;
 import org.springframework.data.repository.query.RepositoryQuery;
 import org.springframework.data.repository.query.ResultProcessor;
@@ -240,12 +241,10 @@ public abstract class AbstractJpaQuery implements RepositoryQuery {
 		JpaEntityGraph entityGraph = method.getEntityGraph();
 
 		if (entityGraph != null) {
-			List<QueryHintValue> hints = Jpa21Utils.tryGetFetchGraphHints(em, method.getEntityGraph(),
+			SimpleQueryHints hints = Jpa21Utils.getFetchGraphHint(em, method.getEntityGraph(),
 					getQueryMethod().getEntityInformation().getJavaType());
 
-			for (QueryHintValue hint : hints) {
-				query.setHint(hint.name, hint.value);
-			}
+			hints.forEach(query::setHint);
 		}
 
 		return query;

--- a/src/main/java/org/springframework/data/jpa/repository/query/Jpa21Utils.java
+++ b/src/main/java/org/springframework/data/jpa/repository/query/Jpa21Utils.java
@@ -28,6 +28,7 @@ import javax.persistence.Query;
 import javax.persistence.Subgraph;
 
 import org.springframework.data.jpa.repository.support.QueryHintValue;
+import org.springframework.data.jpa.repository.support.SimpleQueryHints;
 import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
 import org.springframework.util.ClassUtils;
@@ -64,29 +65,23 @@ public class Jpa21Utils {
 		// prevent instantiation
 	}
 
-	/**
-	 * Returns a {@link Map} with hints for a JPA 2.1 fetch-graph or load-graph if running under JPA 2.1.
-	 *
-	 * @param em must not be {@literal null}.
-	 * @param entityGraph can be {@literal null}.
-	 * @param entityType must not be {@literal null}.
-	 * @return a {@code Map} with the hints or an empty {@code Map} if no hints were found.
-	 * @since 1.8
-	 */
-	public static List<QueryHintValue> tryGetFetchGraphHints(EntityManager em, @Nullable JpaEntityGraph entityGraph,
+	public static SimpleQueryHints getFetchGraphHint(EntityManager em, @Nullable JpaEntityGraph entityGraph,
 			Class<?> entityType) {
 
+		SimpleQueryHints result = new SimpleQueryHints();
+
 		if (entityGraph == null) {
-			return Collections.emptyList();
+			return result;
 		}
 
 		EntityGraph<?> graph = tryGetFetchGraph(em, entityGraph, entityType);
 
 		if (graph == null) {
-			return Collections.emptyList();
+			return result;
 		}
 
-		return Collections.singletonList(new QueryHintValue(entityGraph.getType().getKey(), graph));
+		result.add(entityGraph.getType().getKey(), graph);
+		return result;
 	}
 
 	/**

--- a/src/main/java/org/springframework/data/jpa/repository/query/Jpa21Utils.java
+++ b/src/main/java/org/springframework/data/jpa/repository/query/Jpa21Utils.java
@@ -27,6 +27,7 @@ import javax.persistence.EntityManager;
 import javax.persistence.Query;
 import javax.persistence.Subgraph;
 
+import org.springframework.data.jpa.repository.support.QueryHintValue;
 import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
 import org.springframework.util.ClassUtils;
@@ -41,6 +42,7 @@ import org.springframework.util.StringUtils;
  * @author Oliver Gierke
  * @author Christoph Strobl
  * @author Mark Paluch
+ * @author Jens Schauder
  * @since 1.6
  */
 public class Jpa21Utils {
@@ -71,20 +73,20 @@ public class Jpa21Utils {
 	 * @return a {@code Map} with the hints or an empty {@code Map} if no hints were found.
 	 * @since 1.8
 	 */
-	public static Map<String, Object> tryGetFetchGraphHints(EntityManager em, @Nullable JpaEntityGraph entityGraph,
+	public static List<QueryHintValue> tryGetFetchGraphHints(EntityManager em, @Nullable JpaEntityGraph entityGraph,
 			Class<?> entityType) {
 
 		if (entityGraph == null) {
-			return Collections.emptyMap();
+			return Collections.emptyList();
 		}
 
 		EntityGraph<?> graph = tryGetFetchGraph(em, entityGraph, entityType);
 
 		if (graph == null) {
-			return Collections.emptyMap();
+			return Collections.emptyList();
 		}
 
-		return Collections.<String, Object> singletonMap(entityGraph.getType().getKey(), graph);
+		return Collections.singletonList(new QueryHintValue(entityGraph.getType().getKey(), graph));
 	}
 
 	/**

--- a/src/main/java/org/springframework/data/jpa/repository/support/CrudMethodMetadata.java
+++ b/src/main/java/org/springframework/data/jpa/repository/support/CrudMethodMetadata.java
@@ -16,6 +16,9 @@
 package org.springframework.data.jpa.repository.support;
 
 import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
@@ -48,8 +51,26 @@ public interface CrudMethodMetadata {
 	 * Returns all query hints to be applied to queries executed for the CRUD method.
 	 *
 	 * @return
+	 * @deprecated use {@link #getQueryHintList()} instead.
 	 */
+	@Deprecated
 	Map<String, Object> getQueryHints();
+
+	/**
+	 * Returns all query hints in a list to be applied to queries executed for the CRUD method.
+	 * 
+	 * @return
+	 * @since 2.4
+	 */
+	default List<QueryHintValue> getQueryHintList() {
+
+		List<QueryHintValue> queryHints = new ArrayList<>();
+		for (Map.Entry<String, Object> hint : getQueryHints().entrySet()) {
+			queryHints.add(new QueryHintValue(hint.getKey(), hint.getValue()));
+		}
+
+		return Collections.unmodifiableList(queryHints);
+	}
 
 	/**
 	 * Returns all query hints to be applied to count queries executed for the CRUD method. The default implementation
@@ -57,9 +78,27 @@ public interface CrudMethodMetadata {
 	 *
 	 * @return
 	 * @since 2.2
+	 * @Deprecated use {@link #getQueryHintListForCount()} instead.
 	 */
+	@Deprecated
 	default Map<String, Object> getQueryHintsForCount() {
 		return getQueryHints();
+	}
+
+	/**
+	 * Returns all query hints in a list to be applied to queries executed for the CRUD method.
+	 * 
+	 * @return
+	 * @since 2.4
+	 */
+	default List<QueryHintValue> getQueryHintListForCount() {
+
+		List<QueryHintValue> queryHints = new ArrayList<>();
+		for (Map.Entry<String, Object> hint : getQueryHintsForCount().entrySet()) {
+			queryHints.add(new QueryHintValue(hint.getKey(), hint.getValue()));
+		}
+
+		return Collections.unmodifiableList(queryHints);
 	}
 
 	/**

--- a/src/main/java/org/springframework/data/jpa/repository/support/CrudMethodMetadata.java
+++ b/src/main/java/org/springframework/data/jpa/repository/support/CrudMethodMetadata.java
@@ -21,6 +21,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.function.BiConsumer;
 
 import javax.persistence.LockModeType;
 
@@ -48,13 +49,12 @@ public interface CrudMethodMetadata {
 	LockModeType getLockModeType();
 
 	/**
-	 * Returns all query hints to be applied to queries executed for the CRUD method.
-	 *
+	 * Returns all query hints in a list to be applied to queries executed for the CRUD method.
+	 * 
 	 * @return
-	 * @deprecated use {@link #getQueryHintList()} instead.
+	 * @since 2.4
 	 */
-	@Deprecated
-	Map<String, Object> getQueryHints();
+	SimpleQueryHints getQueryHints();
 
 	/**
 	 * Returns all query hints in a list to be applied to queries executed for the CRUD method.
@@ -62,44 +62,7 @@ public interface CrudMethodMetadata {
 	 * @return
 	 * @since 2.4
 	 */
-	default List<QueryHintValue> getQueryHintList() {
-
-		List<QueryHintValue> queryHints = new ArrayList<>();
-		for (Map.Entry<String, Object> hint : getQueryHints().entrySet()) {
-			queryHints.add(new QueryHintValue(hint.getKey(), hint.getValue()));
-		}
-
-		return Collections.unmodifiableList(queryHints);
-	}
-
-	/**
-	 * Returns all query hints to be applied to count queries executed for the CRUD method. The default implementation
-	 * just delegates to {@link #getQueryHints()}.
-	 *
-	 * @return
-	 * @since 2.2
-	 * @Deprecated use {@link #getQueryHintListForCount()} instead.
-	 */
-	@Deprecated
-	default Map<String, Object> getQueryHintsForCount() {
-		return getQueryHints();
-	}
-
-	/**
-	 * Returns all query hints in a list to be applied to queries executed for the CRUD method.
-	 * 
-	 * @return
-	 * @since 2.4
-	 */
-	default List<QueryHintValue> getQueryHintListForCount() {
-
-		List<QueryHintValue> queryHints = new ArrayList<>();
-		for (Map.Entry<String, Object> hint : getQueryHintsForCount().entrySet()) {
-			queryHints.add(new QueryHintValue(hint.getKey(), hint.getValue()));
-		}
-
-		return Collections.unmodifiableList(queryHints);
-	}
+	SimpleQueryHints getQueryHintsForCount();
 
 	/**
 	 * Returns the {@link EntityGraph} to be used.

--- a/src/main/java/org/springframework/data/jpa/repository/support/CrudMethodMetadataPostProcessor.java
+++ b/src/main/java/org/springframework/data/jpa/repository/support/CrudMethodMetadataPostProcessor.java
@@ -16,12 +16,8 @@
 package org.springframework.data.jpa.repository.support;
 
 import java.lang.reflect.Method;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
@@ -195,8 +191,8 @@ class CrudMethodMetadataPostProcessor implements RepositoryProxyPostProcessor, B
 	private static class DefaultCrudMethodMetadata implements CrudMethodMetadata {
 
 		private final @Nullable LockModeType lockModeType;
-		private final List<QueryHintValue> queryHints;
-		private final List<QueryHintValue> queryHintsForCount;
+		private final SimpleQueryHints queryHints;
+		private final SimpleQueryHints queryHintsForCount;
 		private final Optional<EntityGraph> entityGraph;
 		private final Method method;
 
@@ -227,25 +223,26 @@ class CrudMethodMetadataPostProcessor implements RepositoryProxyPostProcessor, B
 			return annotation == null ? null : (LockModeType) AnnotationUtils.getValue(annotation);
 		}
 
-		private static List<QueryHintValue> findQueryHints(Method method, Predicate<QueryHints> annotationFilter) {
+		private static SimpleQueryHints findQueryHints(Method method, Predicate<QueryHints> annotationFilter) {
 
-			List<QueryHintValue> queryHints = new ArrayList<>();
+			SimpleQueryHints queryHints = new SimpleQueryHints();
+
 			QueryHints queryHintsAnnotation = AnnotatedElementUtils.findMergedAnnotation(method, QueryHints.class);
 
 			if (queryHintsAnnotation != null && annotationFilter.test(queryHintsAnnotation)) {
 
 				for (QueryHint hint : queryHintsAnnotation.value()) {
-					queryHints.add(new QueryHintValue(hint.name(), hint.value()));
+					queryHints.add(hint.name(), hint.value());
 				}
 			}
 
 			QueryHint queryHintAnnotation = AnnotationUtils.findAnnotation(method, QueryHint.class);
 
 			if (queryHintAnnotation != null) {
-				queryHints.add(new QueryHintValue(queryHintAnnotation.name(), queryHintAnnotation.value()));
+				queryHints.add(queryHintAnnotation.name(), queryHintAnnotation.value());
 			}
 
-			return Collections.unmodifiableList(queryHints);
+			return queryHints;
 		}
 
 		/*
@@ -258,43 +255,13 @@ class CrudMethodMetadataPostProcessor implements RepositoryProxyPostProcessor, B
 			return lockModeType;
 		}
 
-		/*
-		 * (non-Javadoc)
-		 * @see org.springframework.data.jpa.repository.support.CrudMethodMetadata#getQueryHints()
-		 */
 		@Override
-		public Map<String, Object> getQueryHints() {
-
-			Map<String, Object> hints = new HashMap<>();
-
-			for (QueryHintValue hint : queryHints) {
-				hints.put(hint.name, hint.value);
-			}
-			return Collections.unmodifiableMap(hints);
-		}
-
-		@Override
-		public List<QueryHintValue> getQueryHintList() {
+		public SimpleQueryHints getQueryHints() {
 			return queryHints;
 		}
 
-		/*
-		 * (non-Javadoc)
-		 * @see org.springframework.data.jpa.repository.support.CrudMethodMetadata#getQueryHintsForCount()
-		 */
 		@Override
-		public Map<String, Object> getQueryHintsForCount() {
-
-			Map<String, Object> hints = new HashMap<>();
-
-			for (QueryHintValue hint : queryHintsForCount) {
-				hints.put(hint.name, hint.value);
-			}
-			return Collections.unmodifiableMap(hints);
-		}
-
-		@Override
-		public List<QueryHintValue> getQueryHintListForCount() {
+		public SimpleQueryHints getQueryHintsForCount() {
 			return queryHintsForCount;
 		}
 

--- a/src/main/java/org/springframework/data/jpa/repository/support/DefaultQueryHints.java
+++ b/src/main/java/org/springframework/data/jpa/repository/support/DefaultQueryHints.java
@@ -15,11 +15,10 @@
  */
 package org.springframework.data.jpa.repository.support;
 
+import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.Iterator;
-import java.util.Map;
-import java.util.Map.Entry;
+import java.util.List;
 import java.util.Optional;
 
 import javax.persistence.EntityManager;
@@ -102,8 +101,8 @@ class DefaultQueryHints implements QueryHints {
 	 * @see java.lang.Iterable#iterator()
 	 */
 	@Override
-	public Iterator<Entry<String, Object>> iterator() {
-		return asMap().entrySet().iterator();
+	public Iterator<QueryHintValue> iterator() {
+		return asList().iterator();
 	}
 
 	/*
@@ -111,27 +110,27 @@ class DefaultQueryHints implements QueryHints {
 	 * @see org.springframework.data.jpa.repository.support.QueryHints#asMap()
 	 */
 	@Override
-	public Map<String, Object> asMap() {
+	public List<QueryHintValue> asList() {
 
-		Map<String, Object> hints = new HashMap<>();
+		List<QueryHintValue> hints = new ArrayList<>();
 
 		if (forCounts) {
-			hints.putAll(metadata.getQueryHintsForCount());
+			hints.addAll(metadata.getQueryHintListForCount());
 		} else {
-			hints.putAll(metadata.getQueryHints());
+			hints.addAll(metadata.getQueryHintList());
 		}
 
-		hints.putAll(getFetchGraphs());
+		hints.addAll(getFetchGraphs());
 
 		return hints;
 	}
 
-	private Map<String, Object> getFetchGraphs() {
+	private List<QueryHintValue> getFetchGraphs() {
 
 		return Optionals
 				.mapIfAllPresent(entityManager, metadata.getEntityGraph(),
 						(em, graph) -> Jpa21Utils.tryGetFetchGraphHints(em, getEntityGraph(graph), information.getJavaType()))
-				.orElse(Collections.emptyMap());
+				.orElse(Collections.emptyList());
 	}
 
 	private JpaEntityGraph getEntityGraph(EntityGraph entityGraph) {

--- a/src/main/java/org/springframework/data/jpa/repository/support/QueryHintValue.java
+++ b/src/main/java/org/springframework/data/jpa/repository/support/QueryHintValue.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.jpa.repository.support;
+
+import java.util.Objects;
+
+import org.springframework.util.Assert;
+
+/**
+ * Value object carrying a query hint consisting of a name/key and a value.
+ * 
+ * @author Jens Schauder
+ * @since 2.4
+ */
+public class QueryHintValue {
+
+	public final String name;
+	public final Object value;
+
+	public QueryHintValue(String name, Object value) {
+
+		Assert.notNull(name, "Name must not be null.");
+		Assert.notNull(value, "Value must not be null.");
+
+		this.name = name;
+		this.value = value;
+	}
+
+	@Override
+	public String toString() {
+		return "QueryHintValue{" + "name='" + name + '\'' + ", value='" + value + '\'' + '}';
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o)
+			return true;
+		if (o == null || getClass() != o.getClass())
+			return false;
+		QueryHintValue that = (QueryHintValue) o;
+		return name.equals(that.name) && value.equals(that.value);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(name, value);
+	}
+}

--- a/src/main/java/org/springframework/data/jpa/repository/support/QueryHints.java
+++ b/src/main/java/org/springframework/data/jpa/repository/support/QueryHints.java
@@ -15,22 +15,21 @@
  */
 package org.springframework.data.jpa.repository.support;
 
-import java.util.Collections;
-import java.util.Iterator;
-import java.util.List;
+import java.util.function.BiConsumer;
 
 import javax.persistence.EntityManager;
 
 /**
- * QueryHints provides access to query hints defined via {@link CrudMethodMetadata#getQueryHintList()} by default
- * excluding JPA {@link javax.persistence.EntityGraph}.
+ * QueryHints provides access to query hints defined via {@link CrudMethodMetadata#getQueryHints()} QueryHintList()} by
+ * default excluding JPA {@link javax.persistence.EntityGraph}. The object allows to switch between query hints for
+ * count queries with or without fetch graph hints.
  *
  * @author Christoph Strobl
  * @author Oliver Gierke
  * @author Jens Schauder
  * @since 2.0
  */
-interface QueryHints extends Iterable<QueryHintValue> {
+interface QueryHints {
 
 	/**
 	 * Creates and returns a new {@link QueryHints} instance including {@link javax.persistence.EntityGraph}.
@@ -50,12 +49,12 @@ interface QueryHints extends Iterable<QueryHintValue> {
 	QueryHints forCounts();
 
 	/**
-	 * Get the query hints as a {@link List}.
+	 * Passes each query hint to the consumer. Query hint keys might appear more than once.
 	 *
-	 * @return never {@literal null}.
+	 * @param consumer to process query hints consisting of a key and a value.
 	 * @since 2.4
 	 */
-	List<QueryHintValue> asList();
+	void forEach(BiConsumer<String, Object> consumer);
 
 	/**
 	 * Null object implementation of {@link QueryHints}.
@@ -63,27 +62,9 @@ interface QueryHints extends Iterable<QueryHintValue> {
 	 * @author Oliver Gierke
 	 * @since 2.0
 	 */
-	static enum NoHints implements QueryHints {
+	enum NoHints implements QueryHints {
 
 		INSTANCE;
-
-		/*
-		 * (non-Javadoc)
-		 * @see org.springframework.data.jpa.repository.support.QueryHints#asMap()
-		 */
-		@Override
-		public List<QueryHintValue> asList() {
-			return Collections.emptyList();
-		}
-
-		/*
-		 * (non-Javadoc)
-		 * @see java.lang.Iterable#iterator()
-		 */
-		@Override
-		public Iterator<QueryHintValue> iterator() {
-			return Collections.emptyIterator();
-		}
 
 		/*
 		 * (non-Javadoc)
@@ -102,5 +83,8 @@ interface QueryHints extends Iterable<QueryHintValue> {
 		public QueryHints forCounts() {
 			return this;
 		}
+
+		@Override
+		public void forEach(BiConsumer<String, Object> consumer) {}
 	}
 }

--- a/src/main/java/org/springframework/data/jpa/repository/support/QueryHints.java
+++ b/src/main/java/org/springframework/data/jpa/repository/support/QueryHints.java
@@ -17,21 +17,20 @@ package org.springframework.data.jpa.repository.support;
 
 import java.util.Collections;
 import java.util.Iterator;
-import java.util.Map;
-import java.util.Map.Entry;
+import java.util.List;
 
 import javax.persistence.EntityManager;
 
 /**
- * QueryHints provides access to query hints defined via {@link CrudMethodMetadata#getQueryHints()} by default excluding
- * JPA {@link javax.persistence.EntityGraph}.
+ * QueryHints provides access to query hints defined via {@link CrudMethodMetadata#getQueryHintList()} by default
+ * excluding JPA {@link javax.persistence.EntityGraph}.
  *
  * @author Christoph Strobl
  * @author Oliver Gierke
  * @author Jens Schauder
  * @since 2.0
  */
-interface QueryHints extends Iterable<Entry<String, Object>> {
+interface QueryHints extends Iterable<QueryHintValue> {
 
 	/**
 	 * Creates and returns a new {@link QueryHints} instance including {@link javax.persistence.EntityGraph}.
@@ -51,11 +50,12 @@ interface QueryHints extends Iterable<Entry<String, Object>> {
 	QueryHints forCounts();
 
 	/**
-	 * Get the query hints as a {@link Map}.
+	 * Get the query hints as a {@link List}.
 	 *
 	 * @return never {@literal null}.
+	 * @since 2.4
 	 */
-	Map<String, Object> asMap();
+	List<QueryHintValue> asList();
 
 	/**
 	 * Null object implementation of {@link QueryHints}.
@@ -72,8 +72,8 @@ interface QueryHints extends Iterable<Entry<String, Object>> {
 		 * @see org.springframework.data.jpa.repository.support.QueryHints#asMap()
 		 */
 		@Override
-		public Map<String, Object> asMap() {
-			return Collections.emptyMap();
+		public List<QueryHintValue> asList() {
+			return Collections.emptyList();
 		}
 
 		/*
@@ -81,7 +81,7 @@ interface QueryHints extends Iterable<Entry<String, Object>> {
 		 * @see java.lang.Iterable#iterator()
 		 */
 		@Override
-		public Iterator<Entry<String, Object>> iterator() {
+		public Iterator<QueryHintValue> iterator() {
 			return Collections.emptyIterator();
 		}
 

--- a/src/main/java/org/springframework/data/jpa/repository/support/QuerydslJpaPredicateExecutor.java
+++ b/src/main/java/org/springframework/data/jpa/repository/support/QuerydslJpaPredicateExecutor.java
@@ -16,7 +16,6 @@
 package org.springframework.data.jpa.repository.support;
 
 import java.util.List;
-import java.util.Map.Entry;
 import java.util.Optional;
 
 import javax.persistence.EntityManager;
@@ -245,8 +244,8 @@ public class QuerydslJpaPredicateExecutor<T> implements QuerydslPredicateExecuto
 			query = query.where(predicate);
 		}
 
-		for (Entry<String, Object> hint : hints) {
-			query.setHint(hint.getKey(), hint.getValue());
+		for (QueryHintValue hint : hints) {
+			query.setHint(hint.name, hint.value);
 		}
 
 		return query;

--- a/src/main/java/org/springframework/data/jpa/repository/support/QuerydslJpaPredicateExecutor.java
+++ b/src/main/java/org/springframework/data/jpa/repository/support/QuerydslJpaPredicateExecutor.java
@@ -244,9 +244,7 @@ public class QuerydslJpaPredicateExecutor<T> implements QuerydslPredicateExecuto
 			query = query.where(predicate);
 		}
 
-		for (QueryHintValue hint : hints) {
-			query.setHint(hint.name, hint.value);
-		}
+		hints.forEach(query::setHint);
 
 		return query;
 	}

--- a/src/main/java/org/springframework/data/jpa/repository/support/QuerydslJpaRepository.java
+++ b/src/main/java/org/springframework/data/jpa/repository/support/QuerydslJpaRepository.java
@@ -220,9 +220,7 @@ public class QuerydslJpaRepository<T, ID extends Serializable> extends SimpleJpa
 			query = query.where(predicate);
 		}
 
-		for (QueryHintValue hint : hints) {
-			query.setHint(hint.name, hint.value);
-		}
+		hints.forEach(query::setHint);
 
 		return query;
 	}

--- a/src/main/java/org/springframework/data/jpa/repository/support/QuerydslJpaRepository.java
+++ b/src/main/java/org/springframework/data/jpa/repository/support/QuerydslJpaRepository.java
@@ -17,7 +17,6 @@ package org.springframework.data.jpa.repository.support;
 
 import java.io.Serializable;
 import java.util.List;
-import java.util.Map.Entry;
 import java.util.Optional;
 
 import javax.persistence.EntityManager;
@@ -48,7 +47,6 @@ import com.querydsl.jpa.impl.AbstractJPAQuery;
  * {@link QuerydslPredicateExecutor}.
  *
  * @deprecated Instead of this class use {@link QuerydslJpaPredicateExecutor}
- *
  * @author Oliver Gierke
  * @author Thomas Darimont
  * @author Mark Paluch
@@ -222,8 +220,8 @@ public class QuerydslJpaRepository<T, ID extends Serializable> extends SimpleJpa
 			query = query.where(predicate);
 		}
 
-		for (Entry<String, Object> hint : hints) {
-			query.setHint(hint.getKey(), hint.getValue());
+		for (QueryHintValue hint : hints) {
+			query.setHint(hint.name, hint.value);
 		}
 
 		return query;

--- a/src/main/java/org/springframework/data/jpa/repository/support/SimpleJpaRepository.java
+++ b/src/main/java/org/springframework/data/jpa/repository/support/SimpleJpaRepository.java
@@ -277,9 +277,7 @@ public class SimpleJpaRepository<T, ID> implements JpaRepositoryImplementation<T
 		LockModeType type = metadata.getLockModeType();
 
 		Map<String, Object> hints = new HashMap<>();
-		for (QueryHintValue hint : getQueryHints().withFetchGraphs(em)) {
-			hints.put(hint.name, hint.value);
-		}
+		getQueryHints().withFetchGraphs(em).forEach(hints::put);
 
 		return Optional.ofNullable(type == null ? em.find(domainType, id, hints) : em.find(domainType, id, type, hints));
 	}
@@ -788,10 +786,7 @@ public class SimpleJpaRepository<T, ID> implements JpaRepositoryImplementation<T
 	}
 
 	private void applyQueryHints(Query query) {
-
-		for (QueryHintValue hint : getQueryHints().withFetchGraphs(em)) {
-			query.setHint(hint.name, hint.value);
-		}
+		getQueryHints().withFetchGraphs(em).forEach(query::setHint);
 	}
 
 	/**

--- a/src/main/java/org/springframework/data/jpa/repository/support/SimpleJpaRepository.java
+++ b/src/main/java/org/springframework/data/jpa/repository/support/SimpleJpaRepository.java
@@ -20,9 +20,9 @@ import static org.springframework.data.jpa.repository.query.QueryUtils.*;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Map.Entry;
 import java.util.Optional;
 
 import javax.persistence.EntityManager;
@@ -276,7 +276,10 @@ public class SimpleJpaRepository<T, ID> implements JpaRepositoryImplementation<T
 
 		LockModeType type = metadata.getLockModeType();
 
-		Map<String, Object> hints = getQueryHints().withFetchGraphs(em).asMap();
+		Map<String, Object> hints = new HashMap<>();
+		for (QueryHintValue hint : getQueryHints().withFetchGraphs(em)) {
+			hints.put(hint.name, hint.value);
+		}
 
 		return Optional.ofNullable(type == null ? em.find(domainType, id, hints) : em.find(domainType, id, type, hints));
 	}
@@ -786,8 +789,8 @@ public class SimpleJpaRepository<T, ID> implements JpaRepositoryImplementation<T
 
 	private void applyQueryHints(Query query) {
 
-		for (Entry<String, Object> hint : getQueryHints().withFetchGraphs(em)) {
-			query.setHint(hint.getKey(), hint.getValue());
+		for (QueryHintValue hint : getQueryHints().withFetchGraphs(em)) {
+			query.setHint(hint.name, hint.value);
 		}
 	}
 

--- a/src/main/java/org/springframework/data/jpa/repository/support/SimpleQueryHints.java
+++ b/src/main/java/org/springframework/data/jpa/repository/support/SimpleQueryHints.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.jpa.repository.support;
+
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+
+import java.util.List;
+import java.util.Map;
+import java.util.function.BiConsumer;
+
+/**
+ * Just the values of QueryHints, without the Option to switch between count/ fetchGraph hints.
+ *
+ * @author Jens Schauder
+ * @since 2.4
+ * @see QueryHints
+ */
+public class SimpleQueryHints {
+
+	MultiValueMap<String, Object> values = new LinkedMultiValueMap<>();
+
+
+	public void add(String name, Object value) {
+		values.add(name, value);
+	}
+
+	public void forEach(BiConsumer<String, Object> consumer) {
+
+		for (Map.Entry<String, List<Object>> entry : values.entrySet()) {
+
+			for (Object value : entry.getValue()) {
+				consumer.accept(entry.getKey(), value);
+			}
+		}
+	}
+
+	public void addAll(SimpleQueryHints hints) {
+		hints.forEach(this::add);
+	}
+}

--- a/src/test/java/org/springframework/data/jpa/repository/support/DefaultQueryHintsTest.java
+++ b/src/test/java/org/springframework/data/jpa/repository/support/DefaultQueryHintsTest.java
@@ -18,8 +18,8 @@ package org.springframework.data.jpa.repository.support;
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
-import java.util.HashMap;
-import java.util.Map;
+import java.util.ArrayList;
+import java.util.List;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -46,9 +46,11 @@ public class DefaultQueryHintsTest {
 
 		QueryHints hints = DefaultQueryHints.of(information, metadata);
 
-		assertThat(hints.asMap()) //
-				.extracting("name1", "name2", "n1", "n2") //
-				.containsExactly("value1", "value2", null, null);
+		assertThat(hints.asList()) //
+				.containsExactly( //
+						new QueryHintValue("name1", "value1"), //
+						new QueryHintValue("name2", "value2") //
+				);
 	}
 
 	@Test // DATAJPA-1156
@@ -56,26 +58,28 @@ public class DefaultQueryHintsTest {
 
 		QueryHints hints = DefaultQueryHints.of(information, metadata).forCounts();
 
-		assertThat(hints.asMap()) //
-				.extracting("name1", "name2", "n1", "n2") //
-				.containsExactly(null, null, "1", "2");
+		assertThat(hints.asList()) //
+				.containsExactly( //
+						new QueryHintValue("n1", "1"), //
+						new QueryHintValue("n2", "2") //
+				);
 	}
 
 	private void setupMainHints() {
 
-		Map<String, Object> mainHintMap = new HashMap<>();
-		mainHintMap.put("name1", "value1");
-		mainHintMap.put("name2", "value2");
+		List<QueryHintValue> mainHints = new ArrayList<>();
+		mainHints.add(new QueryHintValue("name1", "value1"));
+		mainHints.add(new QueryHintValue("name2", "value2"));
 
-		when(metadata.getQueryHints()).thenReturn(mainHintMap);
+		when(metadata.getQueryHintList()).thenReturn(mainHints);
 	}
 
 	private void setUpCountHints() {
 
-		Map<String, Object> countHintMap = new HashMap<>();
-		countHintMap.put("n1", "1");
-		countHintMap.put("n2", "2");
+		List<QueryHintValue> countHints = new ArrayList<>();
+		countHints.add(new QueryHintValue("n1", "1"));
+		countHints.add(new QueryHintValue("n2", "2"));
 
-		when(metadata.getQueryHintsForCount()).thenReturn(countHintMap);
+		when(metadata.getQueryHintListForCount()).thenReturn(countHints);
 	}
 }

--- a/src/test/java/org/springframework/data/jpa/repository/support/DefaultQueryHintsTest.java
+++ b/src/test/java/org/springframework/data/jpa/repository/support/DefaultQueryHintsTest.java
@@ -19,7 +19,9 @@ import static org.assertj.core.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -46,10 +48,13 @@ public class DefaultQueryHintsTest {
 
 		QueryHints hints = DefaultQueryHints.of(information, metadata);
 
-		assertThat(hints.asList()) //
-				.containsExactly( //
-						new QueryHintValue("name1", "value1"), //
-						new QueryHintValue("name2", "value2") //
+		Map<String, Object> collectedHints=new HashMap<>();
+		hints.forEach(collectedHints::put);
+
+		assertThat(collectedHints) //
+				.contains( //
+						entry("name1", "value1"), //
+						entry("name2", "value2") //
 				);
 	}
 
@@ -58,28 +63,31 @@ public class DefaultQueryHintsTest {
 
 		QueryHints hints = DefaultQueryHints.of(information, metadata).forCounts();
 
-		assertThat(hints.asList()) //
-				.containsExactly( //
-						new QueryHintValue("n1", "1"), //
-						new QueryHintValue("n2", "2") //
+		Map<String, Object> collectedHints=new HashMap<>();
+		hints.forEach(collectedHints::put);
+
+		assertThat(collectedHints) //
+				.contains( //
+						entry("n1", "1"), //
+						entry("n2", "2") //
 				);
 	}
 
 	private void setupMainHints() {
 
-		List<QueryHintValue> mainHints = new ArrayList<>();
-		mainHints.add(new QueryHintValue("name1", "value1"));
-		mainHints.add(new QueryHintValue("name2", "value2"));
+		SimpleQueryHints mainHints = new SimpleQueryHints();
+		mainHints.add("name1", "value1");
+		mainHints.add("name2", "value2");
 
-		when(metadata.getQueryHintList()).thenReturn(mainHints);
+		when(metadata.getQueryHints()).thenReturn(mainHints);
 	}
 
 	private void setUpCountHints() {
 
-		List<QueryHintValue> countHints = new ArrayList<>();
-		countHints.add(new QueryHintValue("n1", "1"));
-		countHints.add(new QueryHintValue("n2", "2"));
+		SimpleQueryHints countHints = new SimpleQueryHints();
+		countHints.add("n1", "1");
+		countHints.add("n2", "2");
 
-		when(metadata.getQueryHintListForCount()).thenReturn(countHints);
+		when(metadata.getQueryHintsForCount()).thenReturn(countHints);
 	}
 }

--- a/src/test/java/org/springframework/data/jpa/repository/support/SimpleJpaRepositoryUnitTests.java
+++ b/src/test/java/org/springframework/data/jpa/repository/support/SimpleJpaRepositoryUnitTests.java
@@ -76,6 +76,10 @@ public class SimpleJpaRepositoryUnitTests {
 		when(em.createQuery(criteriaQuery)).thenReturn(query);
 		when(em.createQuery(countCriteriaQuery)).thenReturn(countQuery);
 
+		SimpleQueryHints hints = new SimpleQueryHints();
+		when(metadata.getQueryHints()).thenReturn(hints);
+		when(metadata.getQueryHintsForCount()).thenReturn(hints);
+
 		repo = new SimpleJpaRepository<User, Integer>(information, em);
 		repo.setRepositoryMethodMetadata(metadata);
 	}

--- a/src/test/java/org/springframework/data/jpa/repository/support/SimpleQueryHintsUnitTests.java
+++ b/src/test/java/org/springframework/data/jpa/repository/support/SimpleQueryHintsUnitTests.java
@@ -1,0 +1,69 @@
+package org.springframework.data.jpa.repository.support;/*
+																												* Copyright 2020 the original author or authors.
+																												*
+																												* Licensed under the Apache License, Version 2.0 (the "License");
+																												* you may not use this file except in compliance with the License.
+																												* You may obtain a copy of the License at
+																												*
+																												*      https://www.apache.org/licenses/LICENSE-2.0
+																												*
+																												* Unless required by applicable law or agreed to in writing, software
+																												* distributed under the License is distributed on an "AS IS" BASIS,
+																												* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+																												* See the License for the specific language governing permissions and
+																												* limitations under the License.
+																												*/
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.assertj.core.api.Assertions;
+import org.junit.Test;
+import org.springframework.data.util.Pair;
+
+public class SimpleQueryHintsUnitTests {
+
+	@Test
+	public void emptyQueryHint() {
+		new SimpleQueryHints().forEach((k, v) -> Assertions.fail("Empty SimpleQueryHints shouldn't contain a value"));
+	}
+
+	@Test
+	public void queryHint() {
+
+		SimpleQueryHints hints = new SimpleQueryHints();
+		hints.add("key", "value");
+		hints.add("key", "other value");
+		hints.add("other key", "another value");
+
+		List calls = new ArrayList();
+		hints.forEach((k, v) -> calls.add(Pair.of(k, v)));
+
+		assertThat(calls).containsExactlyInAnyOrder(Pair.of("key", "value"), Pair.of("key", "other value"),
+				Pair.of("other key", "another value"));
+	}
+
+	@Test
+	public void addingQueryHints() {
+
+		SimpleQueryHints hints = new SimpleQueryHints();
+		hints.add("key", "value");
+		hints.add("key", "other value");
+		hints.add("other key", "another value");
+
+		SimpleQueryHints additionalHints = new SimpleQueryHints();
+		additionalHints.add("key", "23");
+		additionalHints.add("another key", "42");
+
+		hints.addAll(additionalHints);
+
+		List calls = new ArrayList();
+		hints.forEach((k, v) -> calls.add(Pair.of(k, v)));
+
+		assertThat(calls).containsExactlyInAnyOrder(Pair.of("key", "value"), Pair.of("key", "other value"),Pair.of("key", "23"),
+				Pair.of("other key", "another value"), Pair.of("another key", "42"));
+	}
+
+}


### PR DESCRIPTION
Some JPA implementations allow to have multiple hints for the same key/name.
The former implementation did not support that since it stored hints as Maps.

With this change they are now stored as lists and duplicates are passed on to the JPA implementation.

How the implementation deals with such a situation depends on that implementation.

Issue: DATAJPA-872