### PR TITLE
DATAJPA-1198 - Consistently avoid toLower(…) translation in Querydsl case-insensitive ORDER BY translation for non-String properties

### DIFF
--- a/src/main/java/org/springframework/data/jpa/repository/support/Querydsl.java
+++ b/src/main/java/org/springframework/data/jpa/repository/support/Querydsl.java
@@ -235,7 +235,7 @@ public class Querydsl {
 
 		while (path != null) {
 
-			sortPropertyExpression = !path.hasNext() && order.isIgnoreCase() //
+			sortPropertyExpression = !path.hasNext() && order.isIgnoreCase() && String.class == path.getType() //
 					? Expressions.stringPath((Path<?>) sortPropertyExpression, path.getSegment()).lower() //
 					: Expressions.path(path.getType(), (Path<?>) sortPropertyExpression, path.getSegment());
 

--- a/src/main/java/org/springframework/data/jpa/repository/support/Querydsl.java
+++ b/src/main/java/org/springframework/data/jpa/repository/support/Querydsl.java
@@ -47,6 +47,7 @@ import com.querydsl.jpa.impl.JPAQuery;
  * @author Thomas Darimont
  * @author Mark Paluch
  * @author Christoph Strobl
+ * @author Marcus Voltolim
  */
 public class Querydsl {
 


### PR DESCRIPTION
Add condition to add lower in order by only String type

<!--

Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
Make sure that:

-->

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] There is a ticket in the bug tracker for the project in our [JIRA](https://jira.spring.io/browse/DATAJPA).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).

