### PR TITLE
DATAJPA-1033 Support projections on methods that take a Specification

### DIFF
--- a/src/main/java/org/springframework/data/jpa/repository/JpaSpecificationExecutor.java
+++ b/src/main/java/org/springframework/data/jpa/repository/JpaSpecificationExecutor.java
@@ -29,6 +29,7 @@ import org.springframework.lang.Nullable;
  *
  * @author Oliver Gierke
  * @author Christoph Strobl
+ * @author Lorenzo Dee
  */
 public interface JpaSpecificationExecutor<T> {
 
@@ -42,12 +43,32 @@ public interface JpaSpecificationExecutor<T> {
 	Optional<T> findOne(@Nullable Specification<T> spec);
 
 	/**
+	 * Returns a projection of a single entity matching the given {@link Specification}, or
+	 * {@link Optional#empty()} if none found.
+	 *
+	 * @param spec can be {@literal null}.
+	 * @param projectionType must not be {@literal null}.
+	 * @return never {@literal null}.
+	 * @throws org.springframework.dao.IncorrectResultSizeDataAccessException if more than one entity found.
+	 */
+	<P> Optional<P> findOne(@Nullable Specification<T> spec, Class<P> projectionType);
+
+	/**
 	 * Returns all entities matching the given {@link Specification}.
 	 *
 	 * @param spec can be {@literal null}.
 	 * @return never {@literal null}.
 	 */
 	List<T> findAll(@Nullable Specification<T> spec);
+
+	/**
+	 * Returns projections of all entities matching the given {@link Specification}.
+	 *
+	 * @param spec can be {@literal null}.
+	 * @param projectionType must not be {@literal null}.
+	 * @return never {@literal null}.
+	 */
+	<P> List<P> findAll(@Nullable Specification<T> spec, Class<P> projectionType);
 
 	/**
 	 * Returns a {@link Page} of entities matching the given {@link Specification}.
@@ -59,6 +80,16 @@ public interface JpaSpecificationExecutor<T> {
 	Page<T> findAll(@Nullable Specification<T> spec, Pageable pageable);
 
 	/**
+	 * Returns a {@link Page} of projections matching the given {@link Specification}.
+	 *
+	 * @param spec can be {@literal null}.
+	 * @param pageable must not be {@literal null}.
+	 * @param projectionType must not be {@literal null}.
+	 * @return never {@literal null}.
+	 */
+	<P> Page<P> findAll(@Nullable Specification<T> spec, Pageable pageable, Class<P> projectionType);
+
+	/**
 	 * Returns all entities matching the given {@link Specification} and {@link Sort}.
 	 *
 	 * @param spec can be {@literal null}.
@@ -66,6 +97,16 @@ public interface JpaSpecificationExecutor<T> {
 	 * @return never {@literal null}.
 	 */
 	List<T> findAll(@Nullable Specification<T> spec, Sort sort);
+
+	/**
+	 * Returns projections of all entities matching the given {@link Specification} and {@link Sort}.
+	 *
+	 * @param spec can be {@literal null}.
+	 * @param sort must not be {@literal null}.
+	 * @param projectionType must not be {@literal null}.
+	 * @return never {@literal null}.
+	 */
+	<P> List<P> findAll(@Nullable Specification<T> spec, Sort sort, Class<P> projectionType);
 
 	/**
 	 * Returns the number of instances that the given {@link Specification} will return.

--- a/src/main/java/org/springframework/data/jpa/repository/query/AbstractJpaQuery.java
+++ b/src/main/java/org/springframework/data/jpa/repository/query/AbstractJpaQuery.java
@@ -15,23 +15,16 @@
  */
 package org.springframework.data.jpa.repository.query;
 
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
-import java.util.stream.Collectors;
 
 import javax.persistence.EntityManager;
 import javax.persistence.LockModeType;
 import javax.persistence.Query;
 import javax.persistence.QueryHint;
 import javax.persistence.Tuple;
-import javax.persistence.TupleElement;
 import javax.persistence.TypedQuery;
 
-import org.springframework.core.convert.converter.Converter;
 import org.springframework.data.jpa.provider.PersistenceProvider;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.query.JpaQueryExecution.CollectionExecution;
@@ -42,6 +35,7 @@ import org.springframework.data.jpa.repository.query.JpaQueryExecution.SingleEnt
 import org.springframework.data.jpa.repository.query.JpaQueryExecution.SlicedExecution;
 import org.springframework.data.jpa.repository.query.JpaQueryExecution.StreamExecution;
 import org.springframework.data.jpa.util.JpaMetamodel;
+import org.springframework.data.jpa.util.TupleConverter;
 import org.springframework.data.repository.query.RepositoryQuery;
 import org.springframework.data.repository.query.ResultProcessor;
 import org.springframework.data.repository.query.ReturnedType;
@@ -59,6 +53,7 @@ import org.springframework.util.Assert;
  * @author Nicolas Cirigliano
  * @author Jens Schauder
  * @author Сергей Цыпанов
+ * @author Lorenzo Dee
  */
 public abstract class AbstractJpaQuery implements RepositoryQuery {
 
@@ -154,7 +149,7 @@ public abstract class AbstractJpaQuery implements RepositoryQuery {
 		Object result = execution.execute(this, accessor);
 
 		ResultProcessor withDynamicProjection = method.getResultProcessor().withDynamicProjection(accessor);
-		return withDynamicProjection.processResult(result, new TupleConverter(withDynamicProjection.getReturnedType()));
+		return withDynamicProjection.processResult(result, new TupleConverter(withDynamicProjection.getReturnedType().getReturnedType()));
 	}
 
 	protected JpaQueryExecution getExecution() {
@@ -289,160 +284,4 @@ public abstract class AbstractJpaQuery implements RepositoryQuery {
 	 */
 	protected abstract Query doCreateCountQuery(JpaParametersParameterAccessor accessor);
 
-	static class TupleConverter implements Converter<Object, Object> {
-
-		private final ReturnedType type;
-
-		/**
-		 * Creates a new {@link TupleConverter} for the given {@link ReturnedType}.
-		 *
-		 * @param type must not be {@literal null}.
-		 */
-		public TupleConverter(ReturnedType type) {
-
-			Assert.notNull(type, "Returned type must not be null!");
-
-			this.type = type;
-		}
-
-		/*
-		 * (non-Javadoc)
-		 * @see org.springframework.core.convert.converter.Converter#convert(java.lang.Object)
-		 */
-		@Override
-		public Object convert(Object source) {
-
-			if (!(source instanceof Tuple)) {
-				return source;
-			}
-
-			Tuple tuple = (Tuple) source;
-			List<TupleElement<?>> elements = tuple.getElements();
-
-			if (elements.size() == 1) {
-
-				Object value = tuple.get(elements.get(0));
-
-				if (type.isInstance(value) || value == null) {
-					return value;
-				}
-			}
-
-			return new TupleBackedMap(tuple);
-		}
-
-		/**
-		 * A {@link Map} implementation which delegates all calls to a {@link Tuple}. Depending on the provided
-		 * {@link Tuple} implementation it might return the same value for various keys of which only one will appear in the
-		 * key/entry set.
-		 *
-		 * @author Jens Schauder
-		 */
-		private static class TupleBackedMap implements Map<String, Object> {
-
-			private static final String UNMODIFIABLE_MESSAGE = "A TupleBackedMap cannot be modified.";
-
-			private final Tuple tuple;
-
-			TupleBackedMap(Tuple tuple) {
-				this.tuple = tuple;
-			}
-
-			@Override
-			public int size() {
-				return tuple.getElements().size();
-			}
-
-			@Override
-			public boolean isEmpty() {
-				return tuple.getElements().isEmpty();
-			}
-
-			/**
-			 * If the key is not a {@code String} or not a key of the backing {@link Tuple} this returns {@code false}.
-			 * Otherwise this returns {@code true} even when the value from the backing {@code Tuple} is {@code null}.
-			 *
-			 * @param key the key for which to get the value from the map.
-			 * @return whether the key is an element of the backing tuple.
-			 */
-			@Override
-			public boolean containsKey(Object key) {
-
-				try {
-					tuple.get((String) key);
-					return true;
-				} catch (IllegalArgumentException e) {
-					return false;
-				}
-			}
-
-			@Override
-			public boolean containsValue(Object value) {
-				return Arrays.asList(tuple.toArray()).contains(value);
-			}
-
-			/**
-			 * If the key is not a {@code String} or not a key of the backing {@link Tuple} this returns {@code null}.
-			 * Otherwise the value from the backing {@code Tuple} is returned, which also might be {@code null}.
-			 *
-			 * @param key the key for which to get the value from the map.
-			 * @return the value of the backing {@link Tuple} for that key or {@code null}.
-			 */
-			@Override
-			@Nullable
-			public Object get(Object key) {
-
-				if (!(key instanceof String)) {
-					return null;
-				}
-
-				try {
-					return tuple.get((String) key);
-				} catch (IllegalArgumentException e) {
-					return null;
-				}
-			}
-
-			@Override
-			public Object put(String key, Object value) {
-				throw new UnsupportedOperationException(UNMODIFIABLE_MESSAGE);
-			}
-
-			@Override
-			public Object remove(Object key) {
-				throw new UnsupportedOperationException(UNMODIFIABLE_MESSAGE);
-			}
-
-			@Override
-			public void putAll(Map<? extends String, ?> m) {
-				throw new UnsupportedOperationException(UNMODIFIABLE_MESSAGE);
-			}
-
-			@Override
-			public void clear() {
-				throw new UnsupportedOperationException(UNMODIFIABLE_MESSAGE);
-			}
-
-			@Override
-			public Set<String> keySet() {
-
-				return tuple.getElements().stream() //
-						.map(TupleElement::getAlias) //
-						.collect(Collectors.toSet());
-			}
-
-			@Override
-			public Collection<Object> values() {
-				return Arrays.asList(tuple.toArray());
-			}
-
-			@Override
-			public Set<Entry<String, Object>> entrySet() {
-
-				return tuple.getElements().stream() //
-						.map(e -> new HashMap.SimpleEntry<String, Object>(e.getAlias(), tuple.get(e))) //
-						.collect(Collectors.toSet());
-			}
-		}
-	}
 }

--- a/src/main/java/org/springframework/data/jpa/repository/query/QueryUtils.java
+++ b/src/main/java/org/springframework/data/jpa/repository/query/QueryUtils.java
@@ -615,12 +615,12 @@ public abstract class QueryUtils {
 		}
 	}
 
-	static <T> Expression<T> toExpressionRecursively(From<?, ?> from, PropertyPath property) {
+	public static <T> Expression<T> toExpressionRecursively(From<?, ?> from, PropertyPath property) {
 		return toExpressionRecursively(from, property, false);
 	}
 
 	@SuppressWarnings("unchecked")
-	static <T> Expression<T> toExpressionRecursively(From<?, ?> from, PropertyPath property, boolean isForSelection) {
+	public static <T> Expression<T> toExpressionRecursively(From<?, ?> from, PropertyPath property, boolean isForSelection) {
 
 		Bindable<?> propertyPathModel;
 		Bindable<?> model = from.getModel();

--- a/src/main/java/org/springframework/data/jpa/repository/support/JpaRepositoryImplementation.java
+++ b/src/main/java/org/springframework/data/jpa/repository/support/JpaRepositoryImplementation.java
@@ -18,7 +18,9 @@ package org.springframework.data.jpa.repository.support;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.jpa.repository.query.EscapeCharacter;
+import org.springframework.data.projection.ProjectionFactory;
 import org.springframework.data.repository.NoRepositoryBean;
+import org.springframework.data.repository.core.RepositoryInformation;
 
 /**
  * SPI interface to be implemented by {@link JpaRepository} implementations.
@@ -26,6 +28,7 @@ import org.springframework.data.repository.NoRepositoryBean;
  * @author Oliver Gierke
  * @author Stefan Fussenegger
  * @author Jens Schauder
+ * @author Lorenzo Dee
  */
 @NoRepositoryBean
 public interface JpaRepositoryImplementation<T, ID> extends JpaRepository<T, ID>, JpaSpecificationExecutor<T> {
@@ -45,4 +48,18 @@ public interface JpaRepositoryImplementation<T, ID> extends JpaRepository<T, ID>
 	default void setEscapeCharacter(EscapeCharacter escapeCharacter) {
 
 	}
+
+	/**
+	 * Configures the {@link ProjectionFactory} to be used with the repository.
+	 *
+	 * @param projectionFactory must not be {@literal null}.
+	 */
+	void setProjectionFactory(ProjectionFactory projectionFactory);
+
+	/**
+	 * Configures the {@link RepositoryInformation} to be used with the repository.
+	 *
+	 * @param information must not be {@literal null}.
+	 */
+	void setRepositoryInformation(RepositoryInformation information);
 }

--- a/src/main/java/org/springframework/data/jpa/repository/support/SimpleJpaRepository.java
+++ b/src/main/java/org/springframework/data/jpa/repository/support/SimpleJpaRepository.java
@@ -17,19 +17,25 @@ package org.springframework.data.jpa.repository.support;
 
 import static org.springframework.data.jpa.repository.query.QueryUtils.*;
 
+import java.beans.PropertyDescriptor;
+import java.lang.reflect.Method;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
+import java.util.Set;
 
 import javax.persistence.EntityManager;
 import javax.persistence.LockModeType;
 import javax.persistence.NoResultException;
 import javax.persistence.Parameter;
 import javax.persistence.Query;
+import javax.persistence.Tuple;
 import javax.persistence.TypedQuery;
 import javax.persistence.criteria.CriteriaBuilder;
 import javax.persistence.criteria.CriteriaQuery;
@@ -38,6 +44,7 @@ import javax.persistence.criteria.ParameterExpression;
 import javax.persistence.criteria.Path;
 import javax.persistence.criteria.Predicate;
 import javax.persistence.criteria.Root;
+import javax.persistence.criteria.Selection;
 
 import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.data.domain.Example;
@@ -52,12 +59,26 @@ import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.query.EscapeCharacter;
 import org.springframework.data.jpa.repository.query.QueryUtils;
 import org.springframework.data.jpa.repository.support.QueryHints.NoHints;
+import org.springframework.data.jpa.util.TupleConverter;
+import org.springframework.data.mapping.PreferredConstructor;
+import org.springframework.data.mapping.PropertyPath;
+import org.springframework.data.mapping.model.PreferredConstructorDiscoverer;
+import org.springframework.data.projection.ProjectionFactory;
+import org.springframework.data.projection.ProjectionInformation;
+import org.springframework.data.repository.core.RepositoryInformation;
+import org.springframework.data.repository.query.ParameterAccessor;
+import org.springframework.data.repository.query.ParametersParameterAccessor;
+import org.springframework.data.repository.query.QueryMethod;
+import org.springframework.data.repository.query.ResultProcessor;
 import org.springframework.data.repository.support.PageableExecutionUtils;
+import org.springframework.data.util.Pair;
 import org.springframework.data.util.ProxyUtils;
 import org.springframework.lang.Nullable;
 import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.Assert;
+import org.springframework.util.ClassUtils;
+import org.springframework.util.ConcurrentReferenceHashMap;
 
 /**
  * Default implementation of the {@link org.springframework.data.repository.CrudRepository} interface. This will offer
@@ -72,6 +93,7 @@ import org.springframework.util.Assert;
  * @author Jens Schauder
  * @author David Madden
  * @author Moritz Becker
+ * @author Lorenzo Dee
  * @param <T> the type of the entity to handle
  * @param <ID> the type of the entity's identifier
  */
@@ -87,6 +109,13 @@ public class SimpleJpaRepository<T, ID> implements JpaRepositoryImplementation<T
 
 	private @Nullable CrudMethodMetadata metadata;
 	private EscapeCharacter escapeCharacter = EscapeCharacter.DEFAULT;
+
+	private @Nullable ProjectionFactory projectionFactory;
+	private @Nullable RepositoryInformation information;
+
+	private final Map<Method, QueryMethod> queriesCache = new ConcurrentReferenceHashMap<>(8);
+	private final Map<Pair<Method, Class<?>>, ParameterAccessor> accessorsCache = new ConcurrentReferenceHashMap<>(32);
+	private final Map<Pair<Method, Class<?>>, ResultProcessor> resultProcessorsCache = new ConcurrentReferenceHashMap<>(32);
 
 	private static <T> Collection<T> toCollection(Iterable<T> ts) {
 
@@ -141,6 +170,16 @@ public class SimpleJpaRepository<T, ID> implements JpaRepositoryImplementation<T
 	@Override
 	public void setEscapeCharacter(EscapeCharacter escapeCharacter) {
 		this.escapeCharacter = escapeCharacter;
+	}
+	
+	@Override
+	public void setProjectionFactory(ProjectionFactory projectionFactory) {
+		this.projectionFactory = projectionFactory;
+	}
+
+	@Override
+	public void setRepositoryInformation(RepositoryInformation information) {
+		this.information = information;
 	}
 
 	@Nullable
@@ -426,11 +465,42 @@ public class SimpleJpaRepository<T, ID> implements JpaRepositoryImplementation<T
 
 	/*
 	 * (non-Javadoc)
+	 * @see org.springframework.data.jpa.repository.JpaSpecificationExecutor#findOne(org.springframework.data.jpa.domain.Specification, java.lang.Class)
+	 */
+	@Override
+	public <P> Optional<P> findOne(@Nullable Specification<T> spec, Class<P> projectionType) {
+		/*
+		if (metadata == null || projectionFactory == null || information == null) {
+			// Should we fallback on to using domain class instead of projection type?
+			return (Optional<P>) findOne(spec);
+		}
+		*/
+		try {
+			Tuple result = getTupleQuery(
+					spec, getDomainClass(), Sort.unsorted(), projectionType).getSingleResult();
+			ResultProcessor resultProcessor = getResultProcessor(projectionType);
+			return Optional.of(resultProcessor.processResult(result, new TupleConverter(projectionType)));
+		} catch (NoResultException e) {
+			return Optional.empty();
+		}
+	}
+	
+	/*
+	 * (non-Javadoc)
 	 * @see org.springframework.data.jpa.repository.JpaSpecificationExecutor#findAll(org.springframework.data.jpa.domain.Specification)
 	 */
 	@Override
 	public List<T> findAll(@Nullable Specification<T> spec) {
 		return getQuery(spec, Sort.unsorted()).getResultList();
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.jpa.repository.JpaSpecificationExecutor#findAll(org.springframework.data.jpa.domain.Specification, java.lang.Class)
+	 */
+	@Override
+	public <P> List<P> findAll(@Nullable Specification<T> spec, Class<P> projectionType) {
+		return findAll(spec, Sort.unsorted(), projectionType);
 	}
 
 	/*
@@ -447,11 +517,38 @@ public class SimpleJpaRepository<T, ID> implements JpaRepositoryImplementation<T
 
 	/*
 	 * (non-Javadoc)
+	 * @see org.springframework.data.jpa.repository.JpaSpecificationExecutor#findAll(org.springframework.data.jpa.domain.Specification, org.springframework.data.domain.Pageable, java.lang.Class)
+	 */
+	@Override
+	public <P> Page<P> findAll(@Nullable Specification<T> spec, Pageable pageable, Class<P> projectionType) {
+
+		Sort sort = pageable.isPaged() ? pageable.getSort() : Sort.unsorted();
+		TypedQuery<Tuple> query = getTupleQuery(
+				spec, getDomainClass(), sort, projectionType);
+		return isUnpaged(pageable)
+				? new PageImpl<P>(getResultProcessor(projectionType).processResult(query.getResultList(), new TupleConverter(projectionType)))
+				: readPage(query, getDomainClass(), pageable, spec, projectionType);
+	}
+
+	/*
+	 * (non-Javadoc)
 	 * @see org.springframework.data.jpa.repository.JpaSpecificationExecutor#findAll(org.springframework.data.jpa.domain.Specification, org.springframework.data.domain.Sort)
 	 */
 	@Override
 	public List<T> findAll(@Nullable Specification<T> spec, Sort sort) {
 		return getQuery(spec, sort).getResultList();
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.jpa.repository.JpaSpecificationExecutor#findAll(org.springframework.data.jpa.domain.Specification, org.springframework.data.domain.Sort, java.lang.Class)
+	 */
+	@Override
+	public <P> List<P> findAll(@Nullable Specification<T> spec, Sort sort, Class<P> projectionType) {
+		List<Tuple> resultList = getTupleQuery(
+				spec, getDomainClass(), sort, projectionType).getResultList();
+		ResultProcessor resultProcessor = getResultProcessor(projectionType);
+		return resultProcessor.processResult(resultList, new TupleConverter(projectionType));
 	}
 
 	/*
@@ -639,6 +736,31 @@ public class SimpleJpaRepository<T, ID> implements JpaRepositoryImplementation<T
 	}
 
 	/**
+	 * Reads the given {@link TypedQuery} into a {@link Page} applying the given {@link Pageable} and
+	 * {@link Specification} and projection.
+	 *
+	 * @param query must not be {@literal null}.
+	 * @param domainClass must not be {@literal null}.
+	 * @param spec can be {@literal null}.
+	 * @param pageable can be {@literal null}.
+	 * @param projectionType must not be {@literal null}.
+	 * @return
+	 */
+	protected <S extends T, P> Page<P> readPage(TypedQuery<Tuple> query, final Class<S> domainClass, Pageable pageable,
+			@Nullable Specification<S> spec, Class<P> projectionType) {
+
+		if (pageable.isPaged()) {
+			query.setFirstResult((int) pageable.getOffset());
+			query.setMaxResults(pageable.getPageSize());
+		}
+		ResultProcessor resultProcessor = getResultProcessor(projectionType);
+		Page<Tuple> tuplesPage = PageableExecutionUtils.getPage(
+				query.getResultList(), pageable, () -> executeCountQuery(getCountQuery(spec, domainClass)));
+		// Page<Tuple> --> Page<P>
+		return resultProcessor.processResult(tuplesPage, new TupleConverter(projectionType));
+	}
+
+	/**
 	 * Creates a new {@link TypedQuery} from the given {@link Specification}.
 	 *
 	 * @param spec can be {@literal null}.
@@ -698,6 +820,91 @@ public class SimpleJpaRepository<T, ID> implements JpaRepositoryImplementation<T
 		}
 
 		return applyRepositoryMethodMetadata(em.createQuery(query));
+	}
+
+	/**
+	 * Creates a {@link TypedQuery} for the given {@link Specification}, {@link Sort}, and projection.
+	 *
+	 * @param spec can be {@literal null}.
+	 * @param domainClass must not be {@literal null}.
+	 * @param sort must not be {@literal null}.
+	 * @param projectionType must not be {@literal null}.
+	 * @return
+	 */
+	protected <S extends T, U> TypedQuery<Tuple> getTupleQuery(@Nullable Specification<S> spec, Class<S> domainClass, Sort sort, Class<U> projectionType) {
+
+		CriteriaBuilder builder = em.getCriteriaBuilder();
+		CriteriaQuery<Tuple> query = builder.createTupleQuery();
+
+		Root<S> root = applySpecificationToCriteria(spec, domainClass, query);
+		
+		ProjectionInformation projectionInformation = projectionFactory.getProjectionInformation(projectionType);
+		List<String> properties = null;
+		if (projectionType.isInterface()) {
+			properties = new ArrayList<>();
+			for (PropertyDescriptor descriptor : projectionInformation.getInputProperties()) {
+				if (!properties.contains(descriptor.getName())) {
+					properties.add(descriptor.getName());
+				}
+			}
+		}
+		else {
+			properties = detectConstructorParameterNames(projectionType);
+		}
+
+        List<Selection<?>> selections = new ArrayList<>();
+        for (String property : properties) {
+            PropertyPath path = PropertyPath.from(property, projectionType);
+            selections.add(toExpressionRecursively(root, path, true).alias(property));
+        }
+        query.multiselect(selections);
+
+		if (sort.isSorted()) {
+			query.orderBy(toOrders(sort, root, builder));
+		}
+
+		return applyRepositoryMethodMetadata(em.createQuery(query));
+	}
+
+	private List<String> detectConstructorParameterNames(Class<?> type) {
+
+		if (!isDto(type)) {
+			return Collections.emptyList();
+		}
+
+		PreferredConstructor<?, ?> constructor = PreferredConstructorDiscoverer.discover(type);
+
+		if (constructor == null) {
+			return Collections.emptyList();
+		}
+
+		List<String> properties = new ArrayList<>(constructor.getConstructor().getParameterCount());
+
+		for (PreferredConstructor.Parameter<Object, ?> parameter : constructor.getParameters()) {
+			properties.add(parameter.getName());
+		}
+
+		return properties;
+	}
+
+	private static final Set<Class<?>> VOID_TYPES = new HashSet<>(Arrays.asList(Void.class, void.class));
+
+	private boolean isDto(Class<?> type) {
+		return !Object.class.equals(type) && //
+				!type.isEnum() && //
+				!isDomainSubtype(type) && //
+				!isPrimitiveOrWrapper(type) && //
+				!Number.class.isAssignableFrom(type) && //
+				!VOID_TYPES.contains(type) && //
+				!type.getPackage().getName().startsWith("java.");
+	}
+
+	private boolean isDomainSubtype(Class<?> type) {
+		return getDomainClass().equals(type) && getDomainClass().isAssignableFrom(type);
+	}
+
+	private boolean isPrimitiveOrWrapper(Class<?> type) {
+		return ClassUtils.isPrimitiveOrWrapper(type);
 	}
 
 	/**
@@ -787,6 +994,27 @@ public class SimpleJpaRepository<T, ID> implements JpaRepositoryImplementation<T
 		for (Entry<String, Object> hint : getQueryHints().withFetchGraphs(em)) {
 			query.setHint(hint.getKey(), hint.getValue());
 		}
+	}
+
+	private <P> ResultProcessor getResultProcessor(Class<P> projectionType) {
+
+		Method method = metadata.getMethod();
+		QueryMethod queryMethod = queriesCache.computeIfAbsent(
+				method,
+				key -> new QueryMethod(method, information, projectionFactory));
+		int numberOfParameters = queryMethod.getParameters().getNumberOfParameters();
+		Object values[] = new Object[numberOfParameters];
+		ParameterAccessor accessor = accessorsCache.computeIfAbsent(
+				Pair.of(method, projectionType),
+				key -> new ParametersParameterAccessor(queryMethod.getParameters(), values) {
+						@Override
+						public Class<?> findDynamicProjection() {
+							return projectionType;
+						}
+				});
+		return resultProcessorsCache.computeIfAbsent(
+				Pair.of(method, projectionType),
+				key -> queryMethod.getResultProcessor().withDynamicProjection(accessor));
 	}
 
 	/**

--- a/src/main/java/org/springframework/data/jpa/util/TupleConverter.java
+++ b/src/main/java/org/springframework/data/jpa/util/TupleConverter.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2008-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.springframework.data.jpa.util;
 
 import java.util.Arrays;
@@ -17,158 +32,156 @@ import org.springframework.util.Assert;
 
 public class TupleConverter implements Converter<Object, Object> {
 
-    private final Class<?> type;
+	private final Class<?> type;
 
-    /**
-     * Creates a new {@link TupleConverter} for the given {@link Class}.
-     *
-     * @param type must not be {@literal null}.
-     */
-    public TupleConverter(Class<?> type) {
+	/**
+	 * Creates a new {@link TupleConverter} for the given {@link Class}.
+	 *
+	 * @param type must not be {@literal null}.
+	 */
+	public TupleConverter(Class<?> type) {
 
-        Assert.notNull(type, "Returned type must not be null!");
+		Assert.notNull(type, "Type must not be null!");
 
-        this.type = type;
-    }
+		this.type = type;
+	}
 
-    /*
-     * (non-Javadoc)
-     * @see org.springframework.core.convert.converter.Converter#convert(java.lang.Object)
-     */
-    @Override
-    public Object convert(Object source) {
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.core.convert.converter.Converter#convert(java.lang.Object)
+	 */
+	@Override
+	public Object convert(Object source) {
 
-        if (!(source instanceof Tuple)) {
-            return source;
-        }
+		if (!(source instanceof Tuple)) {
+			return source;
+		}
 
-        Tuple tuple = (Tuple) source;
-        List<TupleElement<?>> elements = tuple.getElements();
+		Tuple tuple = (Tuple) source;
+		List<TupleElement<?>> elements = tuple.getElements();
 
-        if (elements.size() == 1) {
+		if (elements.size() == 1) {
 
-            Object value = tuple.get(elements.get(0));
+			Object value = tuple.get(elements.get(0));
 
-            if (type.isInstance(value) || value == null) {
-                return value;
-            }
-        }
+			if (type.isInstance(value) || value == null) {
+				return value;
+			}
+		}
 
-        return new TupleBackedMap(tuple);
-    }
+		return new TupleBackedMap(tuple);
+	}
 
-    /**
-     * A {@link Map} implementation which delegates all calls to a {@link Tuple}. Depending on the provided
-     * {@link Tuple} implementation it might return the same value for various keys of which only one will appear in the
-     * key/entry set.
-     *
-     * @author Jens Schauder
-     */
-    private static class TupleBackedMap implements Map<String, Object> {
+	/**
+	 * A {@link Map} implementation which delegates all calls to a {@link Tuple}. Depending on the provided
+	 * {@link Tuple} implementation it might return the same value for various keys of which only one will appear in the
+	 * key/entry set.
+	 *
+	 * @author Jens Schauder
+	 */
+	private static class TupleBackedMap implements Map<String, Object> {
+		private static final String UNMODIFIABLE_MESSAGE = "A TupleBackedMap cannot be modified.";
 
-        private static final String UNMODIFIABLE_MESSAGE = "A TupleBackedMap cannot be modified.";
+		private final Tuple tuple;
 
-        private final Tuple tuple;
+		public TupleBackedMap(Tuple tuple) {
+			this.tuple = tuple;
+		}
 
-        TupleBackedMap(Tuple tuple) {
-            this.tuple = tuple;
-        }
+		@Override
+		public int size() {
+			return tuple.getElements().size();
+		}
 
-        @Override
-        public int size() {
-            return tuple.getElements().size();
-        }
+		@Override
+		public boolean isEmpty() {
+			return tuple.getElements().isEmpty();
+		}
 
-        @Override
-        public boolean isEmpty() {
-            return tuple.getElements().isEmpty();
-        }
+		/**
+		 * If the key is not a {@code String} or not a key of the backing {@link Tuple} this returns {@code false}.
+		 * Otherwise this returns {@code true} even when the value from the backing {@code Tuple} is {@code null}.
+		 *
+		 * @param key the key for which to get the value from the map.
+		 * @return whether the key is an element of the backing tuple.
+		 */
+		@Override
+		public boolean containsKey(Object key) {
 
-        /**
-         * If the key is not a {@code String} or not a key of the backing {@link Tuple} this returns {@code false}.
-         * Otherwise this returns {@code true} even when the value from the backing {@code Tuple} is {@code null}.
-         *
-         * @param key the key for which to get the value from the map.
-         * @return wether the key is an element of the backing tuple.
-         */
-        @Override
-        public boolean containsKey(Object key) {
+			try {
+				tuple.get((String) key);
+				return true;
+			} catch (IllegalArgumentException e) {
+				return false;
+			}
+		}
 
-            try {
-                tuple.get((String) key);
-                return true;
-            } catch (IllegalArgumentException e) {
-                return false;
-            }
-        }
+		@Override
+		public boolean containsValue(Object value) {
+			return Arrays.asList(tuple.toArray()).contains(value);
+		}
 
-        @Override
-        public boolean containsValue(Object value) {
-            return Arrays.asList(tuple.toArray()).contains(value);
-        }
+		/**
+		 * If the key is not a {@code String} or not a key of the backing {@link Tuple} this returns {@code null}.
+		 * Otherwise the value from the backing {@code Tuple} is returned, which also might be {@code null}.
+		 *
+		 * @param key the key for which to get the value from the map.
+		 * @return the value of the backing {@link Tuple} for that key or {@code null}.
+		 */
+		@Override
+		@Nullable
+		public Object get(Object key) {
 
-        /**
-         * If the key is not a {@code String} or not a key of the backing {@link Tuple} this returns {@code null}.
-         * Otherwise the value from the backing {@code Tuple} is returned, which also might be {@code null}.
-         *
-         * @param key the key for which to get the value from the map.
-         * @return the value of the backing {@link Tuple} for that key or {@code null}.
-         */
-        @Override
-        @Nullable
-        public Object get(Object key) {
+			if (!(key instanceof String)) {
+				return null;
+			}
 
-            if (!(key instanceof String)) {
-                return null;
-            }
+			try {
+				return tuple.get((String) key);
+			} catch (IllegalArgumentException e) {
+				return null;
+			}
+		}
 
-            try {
-                return tuple.get((String) key);
-            } catch (IllegalArgumentException e) {
-                return null;
-            }
-        }
+		@Override
+		public Object put(String key, Object value) {
+			throw new UnsupportedOperationException(UNMODIFIABLE_MESSAGE);
+		}
 
-        @Override
-        public Object put(String key, Object value) {
-            throw new UnsupportedOperationException(UNMODIFIABLE_MESSAGE);
-        }
+		@Override
+		public Object remove(Object key) {
+			throw new UnsupportedOperationException(UNMODIFIABLE_MESSAGE);
+		}
 
-        @Override
-        public Object remove(Object key) {
-            throw new UnsupportedOperationException(UNMODIFIABLE_MESSAGE);
-        }
+		@Override
+		public void putAll(Map<? extends String, ?> m) {
+			throw new UnsupportedOperationException(UNMODIFIABLE_MESSAGE);
+		}
 
-        @Override
-        public void putAll(Map<? extends String, ?> m) {
-            throw new UnsupportedOperationException(UNMODIFIABLE_MESSAGE);
-        }
+		@Override
+		public void clear() {
+			throw new UnsupportedOperationException(UNMODIFIABLE_MESSAGE);
+		}
 
-        @Override
-        public void clear() {
-            throw new UnsupportedOperationException(UNMODIFIABLE_MESSAGE);
-        }
+		@Override
+		public Set<String> keySet() {
 
-        @Override
-        public Set<String> keySet() {
+			return tuple.getElements().stream() //
+					.map(TupleElement::getAlias) //
+					.collect(Collectors.toSet());
+		}
 
-            return tuple.getElements().stream() //
-                    .map(TupleElement::getAlias) //
-                    .collect(Collectors.toSet());
-        }
+		@Override
+		public Collection<Object> values() {
+			return Arrays.asList(tuple.toArray());
+		}
 
-        @Override
-        public Collection<Object> values() {
-            return Arrays.asList(tuple.toArray());
-        }
+		@Override
+		public Set<Entry<String, Object>> entrySet() {
 
-        @Override
-        public Set<Entry<String, Object>> entrySet() {
-
-            return tuple.getElements().stream() //
-                    .map(e -> new HashMap.SimpleEntry<String, Object>(e.getAlias(), tuple.get(e))) //
-                    .collect(Collectors.toSet());
-        }
-    }
-
+			return tuple.getElements().stream() //
+					.map(e -> new HashMap.SimpleEntry<String, Object>(e.getAlias(), tuple.get(e))) //
+					.collect(Collectors.toSet());
+		}
+	}
 }

--- a/src/main/java/org/springframework/data/jpa/util/TupleConverter.java
+++ b/src/main/java/org/springframework/data/jpa/util/TupleConverter.java
@@ -1,0 +1,174 @@
+package org.springframework.data.jpa.util;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import javax.persistence.Tuple;
+import javax.persistence.TupleElement;
+
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.lang.Nullable;
+import org.springframework.util.Assert;
+
+public class TupleConverter implements Converter<Object, Object> {
+
+    private final Class<?> type;
+
+    /**
+     * Creates a new {@link TupleConverter} for the given {@link Class}.
+     *
+     * @param type must not be {@literal null}.
+     */
+    public TupleConverter(Class<?> type) {
+
+        Assert.notNull(type, "Returned type must not be null!");
+
+        this.type = type;
+    }
+
+    /*
+     * (non-Javadoc)
+     * @see org.springframework.core.convert.converter.Converter#convert(java.lang.Object)
+     */
+    @Override
+    public Object convert(Object source) {
+
+        if (!(source instanceof Tuple)) {
+            return source;
+        }
+
+        Tuple tuple = (Tuple) source;
+        List<TupleElement<?>> elements = tuple.getElements();
+
+        if (elements.size() == 1) {
+
+            Object value = tuple.get(elements.get(0));
+
+            if (type.isInstance(value) || value == null) {
+                return value;
+            }
+        }
+
+        return new TupleBackedMap(tuple);
+    }
+
+    /**
+     * A {@link Map} implementation which delegates all calls to a {@link Tuple}. Depending on the provided
+     * {@link Tuple} implementation it might return the same value for various keys of which only one will appear in the
+     * key/entry set.
+     *
+     * @author Jens Schauder
+     */
+    private static class TupleBackedMap implements Map<String, Object> {
+
+        private static final String UNMODIFIABLE_MESSAGE = "A TupleBackedMap cannot be modified.";
+
+        private final Tuple tuple;
+
+        TupleBackedMap(Tuple tuple) {
+            this.tuple = tuple;
+        }
+
+        @Override
+        public int size() {
+            return tuple.getElements().size();
+        }
+
+        @Override
+        public boolean isEmpty() {
+            return tuple.getElements().isEmpty();
+        }
+
+        /**
+         * If the key is not a {@code String} or not a key of the backing {@link Tuple} this returns {@code false}.
+         * Otherwise this returns {@code true} even when the value from the backing {@code Tuple} is {@code null}.
+         *
+         * @param key the key for which to get the value from the map.
+         * @return wether the key is an element of the backing tuple.
+         */
+        @Override
+        public boolean containsKey(Object key) {
+
+            try {
+                tuple.get((String) key);
+                return true;
+            } catch (IllegalArgumentException e) {
+                return false;
+            }
+        }
+
+        @Override
+        public boolean containsValue(Object value) {
+            return Arrays.asList(tuple.toArray()).contains(value);
+        }
+
+        /**
+         * If the key is not a {@code String} or not a key of the backing {@link Tuple} this returns {@code null}.
+         * Otherwise the value from the backing {@code Tuple} is returned, which also might be {@code null}.
+         *
+         * @param key the key for which to get the value from the map.
+         * @return the value of the backing {@link Tuple} for that key or {@code null}.
+         */
+        @Override
+        @Nullable
+        public Object get(Object key) {
+
+            if (!(key instanceof String)) {
+                return null;
+            }
+
+            try {
+                return tuple.get((String) key);
+            } catch (IllegalArgumentException e) {
+                return null;
+            }
+        }
+
+        @Override
+        public Object put(String key, Object value) {
+            throw new UnsupportedOperationException(UNMODIFIABLE_MESSAGE);
+        }
+
+        @Override
+        public Object remove(Object key) {
+            throw new UnsupportedOperationException(UNMODIFIABLE_MESSAGE);
+        }
+
+        @Override
+        public void putAll(Map<? extends String, ?> m) {
+            throw new UnsupportedOperationException(UNMODIFIABLE_MESSAGE);
+        }
+
+        @Override
+        public void clear() {
+            throw new UnsupportedOperationException(UNMODIFIABLE_MESSAGE);
+        }
+
+        @Override
+        public Set<String> keySet() {
+
+            return tuple.getElements().stream() //
+                    .map(TupleElement::getAlias) //
+                    .collect(Collectors.toSet());
+        }
+
+        @Override
+        public Collection<Object> values() {
+            return Arrays.asList(tuple.toArray());
+        }
+
+        @Override
+        public Set<Entry<String, Object>> entrySet() {
+
+            return tuple.getElements().stream() //
+                    .map(e -> new HashMap.SimpleEntry<String, Object>(e.getAlias(), tuple.get(e))) //
+                    .collect(Collectors.toSet());
+        }
+    }
+
+}

--- a/src/test/java/org/springframework/data/jpa/util/TupleConverterUnitTests.java
+++ b/src/test/java/org/springframework/data/jpa/util/TupleConverterUnitTests.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.springframework.data.jpa.repository.query;
+package org.springframework.data.jpa.util;
 
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.Mockito.*;
@@ -32,13 +32,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
-import org.springframework.data.jpa.repository.query.AbstractJpaQuery.TupleConverter;
-import org.springframework.data.projection.ProjectionFactory;
-import org.springframework.data.repository.CrudRepository;
-import org.springframework.data.repository.core.RepositoryMetadata;
-import org.springframework.data.repository.core.support.DefaultRepositoryMetadata;
-import org.springframework.data.repository.query.QueryMethod;
-import org.springframework.data.repository.query.ReturnedType;
 
 /**
  * Unit tests for {@link TupleConverter}.
@@ -52,21 +45,15 @@ public class TupleConverterUnitTests {
 
 	@Mock Tuple tuple;
 	@Mock TupleElement<String> element;
-	@Mock ProjectionFactory factory;
 
-	ReturnedType type;
+	Class<?> type;
 
 	@Before
 	public void setUp() throws Exception {
-
-		RepositoryMetadata metadata = new DefaultRepositoryMetadata(SampleRepository.class);
-		QueryMethod method = new QueryMethod(SampleRepository.class.getMethod("someMethod"), metadata, factory);
-
-		this.type = method.getResultProcessor().getReturnedType();
+		this.type = String.class;
 	}
 
 	@Test // DATAJPA-984
-	@SuppressWarnings("unchecked")
 	public void returnsSingleTupleElementIfItMatchesExpectedType() {
 
 		doReturn(Collections.singletonList(element)).when(tuple).getElements();
@@ -78,7 +65,6 @@ public class TupleConverterUnitTests {
 	}
 
 	@Test // DATAJPA-1024
-	@SuppressWarnings("unchecked")
 	public void returnsNullForSingleElementTupleWithNullValue() {
 
 		doReturn(Collections.singletonList(element)).when(tuple).getElements();
@@ -107,10 +93,6 @@ public class TupleConverterUnitTests {
 		softly.assertThat(map.get("oNe")).isEqualTo("one");
 
 		softly.assertAll();
-	}
-
-	interface SampleRepository extends CrudRepository<Object, Long> {
-		String someMethod();
 	}
 
 	@SuppressWarnings("unchecked")


### PR DESCRIPTION
Related [JIRA issue](https://jira.spring.io/browse/DATAJPA-1033).

The current state of this PR *does not yet* cover projections for `QuerydslJpaPredicateExecutor`. But it *does* support projections for methods that accept a `Specification`.

While this is still a work-in-progress, I'd appreciate feedback/help/suggestions from the community.

---

In a nutshell, the methods in `JpaSpecificationExecutor` were overloaded with one that accepts a project type.

```java
public interface JpaSpecificationExecutor<T> {

	Optional<T> findOne(@Nullable Specification<T> spec);

	<P> Optional<P> findOne(@Nullable Specification<T> spec, Class<P> projectionType);

	List<T> findAll(@Nullable Specification<T> spec);

	<P> List<P> findAll(@Nullable Specification<T> spec, Class<P> projectionType);

	Page<T> findAll(@Nullable Specification<T> spec, Pageable pageable);

	<P> Page<P> findAll(@Nullable Specification<T> spec, Pageable pageable, Class<P> projectionType);

	List<T> findAll(@Nullable Specification<T> spec, Sort sort);

	<P> List<P> findAll(@Nullable Specification<T> spec, Sort sort, Class<P> projectionType);

	long count(@Nullable Specification<T> spec);
}
```

---

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] There is a ticket in the bug tracker for the project in our [JIRA](https://jira.spring.io/browse/DATAJPA).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).

