### PR TITLE
DATAJPA-1813 - Removes dependency to joda.time

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -191,13 +191,6 @@
 		</dependency>
 
 		<dependency>
-			<groupId>joda-time</groupId>
-			<artifactId>joda-time</artifactId>
-			<version>${jodatime}</version>
-			<optional>true</optional>
-		</dependency>
-
-		<dependency>
 			<groupId>org.threeten</groupId>
 			<artifactId>threetenbp</artifactId>
 			<version>${threetenbp}</version>

--- a/src/test/java/org/springframework/data/jpa/repository/support/QuerydslJpaPredicateExecutorUnitTests.java
+++ b/src/test/java/org/springframework/data/jpa/repository/support/QuerydslJpaPredicateExecutorUnitTests.java
@@ -17,12 +17,13 @@ package org.springframework.data.jpa.repository.support;
 
 import static org.assertj.core.api.Assertions.*;
 
+import java.sql.Date;
 import java.util.List;
 
 import javax.persistence.EntityManager;
 import javax.persistence.PersistenceContext;
 
-import org.joda.time.LocalDate;
+import java.time.LocalDate;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -249,9 +250,9 @@ class QuerydslJpaPredicateExecutorUnitTests {
 	@Test // DATAJPA-566, DATAJPA-635
 	void shouldSupportSortByOperatorWithDateExpressions() {
 
-		carter.setDateOfBirth(new LocalDate(2000, 2, 1).toDate());
-		dave.setDateOfBirth(new LocalDate(2000, 1, 1).toDate());
-		oliver.setDateOfBirth(new LocalDate(2003, 5, 1).toDate());
+		carter.setDateOfBirth(Date.valueOf(LocalDate.of(2000, 2, 1)));
+		dave.setDateOfBirth(Date.valueOf(LocalDate.of(2000, 1, 1)));
+		oliver.setDateOfBirth(Date.valueOf(LocalDate.of(2003, 5, 1)));
 
 		List<User> users = predicateExecutor.findAll(QUser.user.dateOfBirth.yearMonth().asc());
 

--- a/src/test/java/org/springframework/data/jpa/repository/support/QuerydslJpaRepositoryTests.java
+++ b/src/test/java/org/springframework/data/jpa/repository/support/QuerydslJpaRepositoryTests.java
@@ -17,12 +17,13 @@ package org.springframework.data.jpa.repository.support;
 
 import static org.assertj.core.api.Assertions.*;
 
+import java.sql.Date;
 import java.util.List;
 
 import javax.persistence.EntityManager;
 import javax.persistence.PersistenceContext;
 
-import org.joda.time.LocalDate;
+import java.time.LocalDate;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -257,9 +258,9 @@ class QuerydslJpaRepositoryTests {
 	@Test // DATAJPA-566, DATAJPA-635
 	void shouldSupportSortByOperatorWithDateExpressions() {
 
-		carter.setDateOfBirth(new LocalDate(2000, 2, 1).toDate());
-		dave.setDateOfBirth(new LocalDate(2000, 1, 1).toDate());
-		oliver.setDateOfBirth(new LocalDate(2003, 5, 1).toDate());
+		carter.setDateOfBirth(Date.valueOf(LocalDate.of(2000, 2, 1)));
+		dave.setDateOfBirth(Date.valueOf(LocalDate.of(2000, 1, 1)));
+		oliver.setDateOfBirth(Date.valueOf(LocalDate.of(2003, 5, 1)));
 
 		List<User> users = repository.findAll(QUser.user.dateOfBirth.yearMonth().asc());
 

--- a/template.mf
+++ b/template.mf
@@ -16,7 +16,6 @@ Import-Template:
  org.aspectj.*;version="${aspectj:[=.=.=,+1.0.0)}";resolution:=optional,
  org.eclipse.persistence.*;version="${eclipselink:[=.=.=,+1.0.0)}";resolution:=optional,
  org.hibernate.*;version="[3.6.10,4.4.0)";resolution:=optional,
- org.joda.time.*;version="${jodatime:[=.=.=,+1.0.0)}";resolution:=optional,
  org.slf4j.*;version="${slf4j:[=.=.=,+1.0.0)}",
  org.springframework.*;version="${spring:[=.=.=.=,+1.1.0)}",
  org.springframework.beans.factory.aspectj;version="${spring:[=.=.=.=,+1.1.0)}";resolution:=optional,


### PR DESCRIPTION
The last remaining usages in a test are replaced with a java.time equivalent.


