### PR TITLE
Update all references to the issue tracker.

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -136,18 +136,18 @@ If you are just starting out with Spring, try one of the https://spring.io/guide
 * If you are upgrading, check out the https://docs.spring.io/spring-data/jpa/docs/current/changelog.txt[changelog] for "`new and noteworthy`" features.
 * Ask a question - we monitor https://stackoverflow.com[stackoverflow.com] for questions tagged with https://stackoverflow.com/tags/spring-data[`spring-data-jpa`].
 You can also chat with the community on https://gitter.im/spring-projects/spring-data[Gitter].
-* Report bugs with Spring Data JPA at https://jira.spring.io/browse/DATAJPA[jira.spring.io/browse/DATAJPA].
+* Report bugs with Spring Data JPA in the https://github.com/spring-projects/spring-data-jpa/issues[GitHub issue tracker].
 
 == Reporting Issues
 
-Spring Data uses JIRA as issue tracking system to record bugs and feature requests. If you want to raise an issue, please follow the recommendations below:
+Spring Data uses GitHub as issue tracking system to record bugs and feature requests. If you want to raise an issue, please follow the recommendations below:
 
 * Before you log a bug, please search the
-https://jira.spring.io/browse/DATAJPA[issue tracker] to see if someone has already reported the problem.
-* If the issue doesn’t already exist, https://jira.spring.io/browse/DATAJPA[create a new issue].
-* Please provide as much information as possible with the issue report, we like to know the version of Spring Data that you are using and JVM version.
-* If you need to paste code, or include a stack trace use JIRA `{code}…{code}` escapes before and after your text.
-* If possible try to create a test-case or project that replicates the issue. Attach a link to your code or a compressed file containing your code.
+https://github.com/spring-projects/spring-data-jpa/issues[issue tracker] to see if someone has already reported the problem.
+* If the issue doesn’t exist already, https://github.com/spring-projects/spring-data-jpa/issues[create a new issue].
+* Please provide as much information as possible with the issue report, we like to know the version of Spring Data that you are using and JVM version, complete stack traces and any relevant configuration information.
+* If you need to paste code, or include a stack trace format it as code using triple backtick.
+* If possible try to create a test-case or project that replicates the issue. Attach a link to your code or a compressed file containing your code. Use an in-memory datatabase if possible or set the database up using https://github.com/testcontainers[Testcontainers].
 
 == Building from Source
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-jpa</artifactId>
-	<version>2.5.0-SNAPSHOT</version>
+	<version>2.5.0-gh-2127-SNAPSHOT</version>
 
 	<name>Spring Data JPA</name>
 	<description>Spring Data module for JPA repositories.</description>

--- a/src/main/asciidoc/preface.adoc
+++ b/src/main/asciidoc/preface.adoc
@@ -7,7 +7,7 @@ Spring Data JPA provides repository support for the Java Persistence API (JPA). 
 === Project Metadata
 
 * Version control: https://github.com/spring-projects/spring-data-jpa
-* Bugtracker: https://jira.spring.io/browse/DATAJPA
+* Bugtracker: https://github.com/spring-projects/spring-data-jpa/issues
 * Release repository: https://repo.spring.io/libs-release
 * Milestone repository: https://repo.spring.io/libs-milestone
 * Snapshot repository: https://repo.spring.io/libs-snapshot

--- a/src/main/java/org/springframework/data/jpa/provider/PersistenceProvider.java
+++ b/src/main/java/org/springframework/data/jpa/provider/PersistenceProvider.java
@@ -52,7 +52,7 @@ public enum PersistenceProvider implements QueryExtractor, ProxyIdAccessor {
 	 * Since Hibernate 4.3 the location of the HibernateEntityManager moved to the org.hibernate.jpa package. In order to
 	 * support both locations we interpret both classnames as a Hibernate {@code PersistenceProvider}.
 	 *
-	 * @see <a href="https://jira.spring.io/browse/DATAJPA-444">DATAJPA-444</a>
+	 * @see <a href="https://github.com/spring-projects/spring-data-jpa/issues/846">DATAJPA-444</a>
 	 */
 	HIBERNATE(//
 			Collections.singletonList(HIBERNATE_ENTITY_MANAGER_INTERFACE), //

--- a/src/main/java/org/springframework/data/jpa/repository/config/AuditingBeanDefinitionParser.java
+++ b/src/main/java/org/springframework/data/jpa/repository/config/AuditingBeanDefinitionParser.java
@@ -81,7 +81,7 @@ public class AuditingBeanDefinitionParser implements BeanDefinitionParser {
 	/**
 	 * Copied code of SpringConfiguredBeanDefinitionParser until this class gets public.
 	 *
-	 * @see <a href="https://jira.springframework.org/browse/SPR-7340">SPR-7340</a>
+	 * @see <a href="https://github.com/spring-projects/spring-framework/issues/11999">SPR-7340</a>
 	 * @author Juergen Hoeller
 	 */
 	private static class SpringConfiguredBeanDefinitionParser implements BeanDefinitionParser {

--- a/src/main/java/org/springframework/data/jpa/support/MergingPersistenceUnitManager.java
+++ b/src/main/java/org/springframework/data/jpa/support/MergingPersistenceUnitManager.java
@@ -30,7 +30,7 @@ import org.springframework.orm.jpa.persistenceunit.MutablePersistenceUnitInfo;
  * {@code persistence.xml} files into one. This is necessary to allow the declaration of entities in seperate modules.
  *
  * @author Oliver Gierke
- * @link https://jira.springframework.org/browse/SPR-2598
+ * @link https://github.com/spring-projects/spring-framework/issues/7287
  */
 public class MergingPersistenceUnitManager extends DefaultPersistenceUnitManager {
 


### PR DESCRIPTION
All references to the issue tracker of Spring projects now lead directly to GitHub.

Closes #2127.