### PR TITLE
Fix raw use of JpaSpecificationExecutor in docs

### DIFF
--- a/src/main/asciidoc/jpa.adoc
+++ b/src/main/asciidoc/jpa.adoc
@@ -789,7 +789,7 @@ Spring Data JPA takes the concept of a specification from Eric Evans' book, "`Do
 
 [source, java]
 ----
-public interface CustomerRepository extends CrudRepository<Customer, Long>, JpaSpecificationExecutor {
+public interface CustomerRepository extends CrudRepository<Customer, Long>, JpaSpecificationExecutor<Customer> {
  …
 }
 ----


### PR DESCRIPTION
I noticed that the parameterized class `JpaSpecificationExecutor` was being used without a type being specified. This commit that.

<!--

Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
Make sure that:

-->

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [ ] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [ ] You submit test cases (unit or integration tests) that back your changes.
- [ ] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
