### PR TITLE
Add JpaRepository.getById for consistency, deprecated JpaRepository.getOne

### DIFF
--- a/src/main/java/org/springframework/data/jpa/repository/JpaRepository.java
+++ b/src/main/java/org/springframework/data/jpa/repository/JpaRepository.java
@@ -31,6 +31,7 @@ import org.springframework.data.repository.query.QueryByExampleExecutor;
  * @author Oliver Gierke
  * @author Christoph Strobl
  * @author Mark Paluch
+ * @author Jesse Wouters
  */
 @NoRepositoryBean
 public interface JpaRepository<T, ID> extends PagingAndSortingRepository<T, ID>, QueryByExampleExecutor<T> {
@@ -121,8 +122,22 @@ public interface JpaRepository<T, ID> extends PagingAndSortingRepository<T, ID>,
 	 * @param id must not be {@literal null}.
 	 * @return a reference to the entity with the given identifier.
 	 * @see EntityManager#getReference(Class, Object) for details on when an exception is thrown.
+	 * @deprecated use {@link JpaRepository#getById(ID)} instead.
 	 */
+	@Deprecated
 	T getOne(ID id);
+
+	/**
+	 * Returns a reference to the entity with the given identifier. Depending on how the JPA persistence provider is
+	 * implemented this is very likely to always return an instance and throw an
+	 * {@link javax.persistence.EntityNotFoundException} on first access. Some of them will reject invalid identifiers
+	 * immediately.
+	 *
+	 * @param id must not be {@literal null}.
+	 * @return a reference to the entity with the given identifier.
+	 * @see EntityManager#getReference(Class, Object) for details on when an exception is thrown.
+	 */
+	T getById(ID id);
 
 	/*
 	 * (non-Javadoc)

--- a/src/main/java/org/springframework/data/jpa/repository/support/SimpleJpaRepository.java
+++ b/src/main/java/org/springframework/data/jpa/repository/support/SimpleJpaRepository.java
@@ -73,6 +73,7 @@ import org.springframework.util.Assert;
  * @author Jens Schauder
  * @author David Madden
  * @author Moritz Becker
+ * @author Jesse Wouters
  * @param <T> the type of the entity to handle
  * @param <ID> the type of the entity's identifier
  */
@@ -322,8 +323,20 @@ public class SimpleJpaRepository<T, ID> implements JpaRepositoryImplementation<T
 	 * (non-Javadoc)
 	 * @see org.springframework.data.jpa.repository.JpaRepository#getOne(java.io.Serializable)
 	 */
+	@Deprecated
 	@Override
 	public T getOne(ID id) {
+
+		Assert.notNull(id, ID_MUST_NOT_BE_NULL);
+		return em.getReference(getDomainClass(), id);
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.jpa.repository.JpaRepository#getById(java.io.Serializable)
+	 */
+	@Override
+	public T getById(ID id) {
 
 		Assert.notNull(id, ID_MUST_NOT_BE_NULL);
 		return em.getReference(getDomainClass(), id);

--- a/src/test/java/org/springframework/data/jpa/repository/AbstractPersistableIntegrationTests.java
+++ b/src/test/java/org/springframework/data/jpa/repository/AbstractPersistableIntegrationTests.java
@@ -25,6 +25,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.jpa.domain.AbstractPersistable;
 import org.springframework.data.jpa.domain.sample.CustomAbstractPersistable;
+import org.springframework.data.jpa.domain.sample.User;
 import org.springframework.data.jpa.repository.sample.CustomAbstractPersistableRepository;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
@@ -36,6 +37,7 @@ import org.springframework.transaction.annotation.Transactional;
  * @author Thomas Darimont
  * @author Oliver Gierke
  * @author Jens Schauder
+ * @author Jesse Wouters
  */
 @Transactional
 @ExtendWith(SpringExtension.class)
@@ -63,6 +65,18 @@ public class AbstractPersistableIntegrationTests {
 		em.clear();
 
 		CustomAbstractPersistable proxy = repository.getOne(entity.getId());
+
+		assertThat(proxy).isEqualTo(proxy);
+	}
+
+	@Test // DATAJPA-1377
+	void equalsWorksForProxiedEntitiesUsingGetById() {
+
+		CustomAbstractPersistable entity = repository.saveAndFlush(new CustomAbstractPersistable());
+
+		em.clear();
+
+		CustomAbstractPersistable proxy = repository.getById(entity.getId());
 
 		assertThat(proxy).isEqualTo(proxy);
 	}

--- a/src/test/java/org/springframework/data/jpa/repository/UserRepositoryTests.java
+++ b/src/test/java/org/springframework/data/jpa/repository/UserRepositoryTests.java
@@ -91,6 +91,7 @@ import com.google.common.base.Optional;
  * @author Kevin Peters
  * @author Jens Schauder
  * @author Andrey Kovalev
+ * @author Jesse Wouters
  */
 @ExtendWith(SpringExtension.class)
 @ContextConfiguration("classpath:application-context.xml")
@@ -984,6 +985,15 @@ public class UserRepositoryTests {
 		flushTestUsers();
 
 		User result = repository.getOne(firstUser.getId());
+		assertThat(result).isEqualTo(firstUser);
+	}
+
+	@Test // DATAJPA-1377
+	void looksUpEntityReferenceUsingGetById() {
+
+		flushTestUsers();
+
+		User result = repository.getById(firstUser.getId());
 		assertThat(result).isEqualTo(firstUser);
 	}
 


### PR DESCRIPTION

Also added two new tests where getById is used instead of getOne.

Closes #1697

<!--

Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
Make sure that:

-->

- [ ] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [ ] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [ ] You submit test cases (unit or integration tests) that back your changes.
- [ ] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
