### PR TITLE
`JpaPersistentPropertyImpl` now considers super types association and target type.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -243,6 +243,14 @@
 			<version>${querydsl}</version>
 			<optional>true</optional>
 		</dependency>
+		
+		<!-- jMolecules -->
+		<dependency>
+			<groupId>org.jmolecules.integrations</groupId>
+			<artifactId>jmolecules-spring</artifactId>
+			<version>${jmolecules-integration}</version>
+			<scope>test</scope>
+		</dependency>
 
 		<!-- CDI -->
 		<!-- Dependency order required to build against CDI 1.0 and test with CDI 2.0 -->

--- a/src/main/java/org/springframework/data/jpa/mapping/JpaPersistentPropertyImpl.java
+++ b/src/main/java/org/springframework/data/jpa/mapping/JpaPersistentPropertyImpl.java
@@ -124,7 +124,7 @@ class JpaPersistentPropertyImpl extends AnnotationBasedPersistentProperty<JpaPer
 				: super.getActualType();
 	}
 
-	/* 
+	/*
 	 * (non-Javadoc)
 	 * @see org.springframework.data.mapping.PersistentProperty#getPersistentEntityTypes()
 	 */
@@ -208,7 +208,7 @@ class JpaPersistentPropertyImpl extends AnnotationBasedPersistentProperty<JpaPer
 		return updateable && super.isWritable();
 	}
 
-	/* 
+	/*
 	 * (non-Javadoc)
 	 * @see org.springframework.data.jpa.mapping.JpaPersistentProperty#isEmbeddable()
 	 */

--- a/src/main/java/org/springframework/data/jpa/mapping/JpaPersistentPropertyImpl.java
+++ b/src/main/java/org/springframework/data/jpa/mapping/JpaPersistentPropertyImpl.java
@@ -101,7 +101,8 @@ class JpaPersistentPropertyImpl extends AnnotationBasedPersistentProperty<JpaPer
 
 		Assert.notNull(metamodel, "Metamodel must not be null!");
 
-		this.isAssociation = Lazy.of(() -> ASSOCIATION_ANNOTATIONS.stream().anyMatch(this::isAnnotationPresent));
+		this.isAssociation = Lazy.of(() -> super.isAssociation() //
+				|| ASSOCIATION_ANNOTATIONS.stream().anyMatch(this::isAnnotationPresent));
 		this.usePropertyAccess = detectPropertyAccess();
 		this.associationTargetType = detectAssociationTargetType();
 		this.updateable = detectUpdatability();
@@ -117,7 +118,10 @@ class JpaPersistentPropertyImpl extends AnnotationBasedPersistentProperty<JpaPer
 	 */
 	@Override
 	public Class<?> getActualType() {
-		return associationTargetType != null ? associationTargetType.getType() : super.getActualType();
+
+		return associationTargetType != null //
+				? associationTargetType.getType() //
+				: super.getActualType();
 	}
 
 	/* 
@@ -211,6 +215,18 @@ class JpaPersistentPropertyImpl extends AnnotationBasedPersistentProperty<JpaPer
 	@Override
 	public boolean isEmbeddable() {
 		return isAnnotationPresent(Embedded.class) || hasActualTypeAnnotation(Embeddable.class);
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.mapping.model.AnnotationBasedPersistentProperty#getAssociationTargetType()
+	 */
+	@Override
+	public Class<?> getAssociationTargetType() {
+
+		return associationTargetType != null //
+				? associationTargetType.getType() //
+				: super.getAssociationTargetType();
 	}
 
 	/**

--- a/src/test/java/org/springframework/data/jpa/mapping/JpaPersistentPropertyImplUnitTests.java
+++ b/src/test/java/org/springframework/data/jpa/mapping/JpaPersistentPropertyImplUnitTests.java
@@ -170,6 +170,16 @@ public class JpaPersistentPropertyImplUnitTests {
 		assertThat(property.isAssociation()).isFalse();
 	}
 
+	@Test
+	void detectsJMoleculesAssociation() {
+
+		JpaPersistentEntityImpl<?> entity = context.getRequiredPersistentEntity(JMoleculesSample.class);
+		JpaPersistentProperty property = entity.getRequiredPersistentProperty("association");
+
+		assertThat(property.isAssociation()).isTrue();
+		assertThat(property.getAssociationTargetType()).isEqualTo(JMoleculesAggregate.class);
+	}
+
 	private JpaPersistentProperty getProperty(Class<?> ownerType, String propertyName) {
 
 		JpaPersistentEntity<?> entity = context.getRequiredPersistentEntity(ownerType);
@@ -293,4 +303,12 @@ public class JpaPersistentPropertyImplUnitTests {
 		@Column(updatable = false) String name;
 		String updatable;
 	}
+
+	// jMolecules
+
+	private static class JMoleculesSample {
+		Association<JMoleculesAggregate, Identifier> association;
+	}
+
+	private static interface JMoleculesAggregate extends AggregateRoot<JMoleculesAggregate, Identifier> {}
 }


### PR DESCRIPTION
The association target type detection in `JpaPersistenPropertyImpl` previously failed to honor the super class detected association target type as fallback. In fact, it didn't even override `….getAssociationTargetType()` at all to expose the target type declared on JPA specific annotations.

This is now in place and tested by verifying the `AbstractPersistentProperty` support for jMolecules' annotations still work in case no JPA specific customizations are applied.