### PR TITLE
Improve wording on transactional methods inherited from `SimpleJpaRepository` and repository fragments

### DIFF
--- a/src/main/asciidoc/jpa.adoc
+++ b/src/main/asciidoc/jpa.adoc
@@ -869,7 +869,7 @@ include::query-by-example.adoc[leveloffset=+1]
 [[transactions]]
 == Transactionality
 
-By default, CRUD methods on repository instances are transactional. For read operations, the transaction configuration `readOnly` flag is set to `true`.  All others are configured with a plain `@Transactional` so that default transaction configuration applies. For details, see JavaDoc of link:$$https://docs.spring.io/spring-data/data-jpa/docs/current/api/index.html?org/springframework/data/jpa/repository/support/SimpleJpaRepository.html$$[`SimpleJpaRepository`]. If you need to tweak transaction configuration for one of the methods declared in a repository, redeclare the method in your repository interface, as follows:
+By default, CRUD methods (defined in link:$$https://docs.spring.io/spring-data/commons/docs/current/api/org/springframework/data/repository/CrudRepository.html$$[`CrudRepository`]) on repository instances are transactional. For read operations, the transaction configuration `readOnly` flag is set to `true`.  All others are configured with a plain `@Transactional` so that default transaction configuration applies. For details, see JavaDoc of link:$$https://docs.spring.io/spring-data/data-jpa/docs/current/api/index.html?org/springframework/data/jpa/repository/support/SimpleJpaRepository.html$$[`SimpleJpaRepository`]. If you need to tweak transaction configuration for one of the methods declared in a repository, redeclare the method in your repository interface, as follows:
 
 .Custom transaction configuration for CRUD
 ====


### PR DESCRIPTION
Transactionality documentation sectional may mislead about apply `@Transactional` for custom repository, which extends `JpaRepository` ([proof](https://stackoverflow.com/questions/39827054/spring-jpa-repository-transactionality)). 

Spring JPA JavaDoc may be clarified by this PR.

**Tests**:
I test
```java
public interface SecurityRepository extends JpaRepository<SecurityEntity, String> {
    Collection<SecurityEntity> findByIdStartingWith(String with);
}
```
method call with property
```
logging.level.org.springframework.transaction.interceptor = TRACE
```
When no `@Transactional` on class or method, transaction for custom method is not created
```
o.s.t.i.TransactionInterceptor           : No need to create transaction for [org.springframework.data.jpa.repository.support.SimpleJpaRepository.findByIdStartingWith]: This method is not transactional.
```
With annotation on class or method level transaction is created
```
o.s.t.i.TransactionInterceptor           : Getting transaction for [org.springframework.data.jpa.repository.support.SimpleJpaRepository.findByIdStartingWith]
o.s.t.i.TransactionInterceptor           : Completing transaction for [org.springframework.data.jpa.repository.support.SimpleJpaRepository.findByIdStartingWith]
```