### PR TITLE
#2234 Remove @Repository annotation from examples

### DIFF
--- a/src/main/asciidoc/jpa.adoc
+++ b/src/main/asciidoc/jpa.adoc
@@ -655,7 +655,6 @@ The following example shows how to reference a named entity graph on a repositor
 ====
 [source, java]
 ----
-@Repository
 public interface GroupRepository extends CrudRepository<GroupInfo, String> {
 
   @EntityGraph(value = "GroupInfo.detail", type = EntityGraphType.LOAD)
@@ -671,7 +670,6 @@ It is also possible to define ad hoc entity graphs by using `@EntityGraph`. The 
 ====
 [source, java]
 ----
-@Repository
 public interface GroupRepository extends CrudRepository<GroupInfo, String> {
 
   @EntityGraph(attributePaths = { "members" })


### PR DESCRIPTION
Remove the @Repository annotation from interfaces in the examples, since it is not necessary on Spring Data interfaces (and creates a warning log anyway).

<!--

Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
Make sure that:

-->

- [ X ] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [ ] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [ ] You submit test cases (unit or integration tests) that back your changes.
- [ ] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
