### PR TITLE
EntityManagerBeanDefinitionRegistrarPostProcessor should set primary flag on EntityManager bean definitions

### DIFF
--- a/src/main/java/org/springframework/data/jpa/repository/support/EntityManagerBeanDefinitionRegistrarPostProcessor.java
+++ b/src/main/java/org/springframework/data/jpa/repository/support/EntityManagerBeanDefinitionRegistrarPostProcessor.java
@@ -43,6 +43,7 @@ import org.springframework.orm.jpa.SharedEntityManagerCreator;
  * {@link EntityManagerFactory} instances.
  *
  * @author Oliver Gierke
+ * @author Réda Housni Alaoui
  */
 public class EntityManagerBeanDefinitionRegistrarPostProcessor implements BeanFactoryPostProcessor, Ordered {
 
@@ -85,6 +86,7 @@ public class EntityManagerBeanDefinitionRegistrarPostProcessor implements BeanFa
 
 			AbstractBeanDefinition emBeanDefinition = builder.getRawBeanDefinition();
 
+			emBeanDefinition.setPrimary(definition.getBeanDefinition().isPrimary());
 			emBeanDefinition.addQualifier(new AutowireCandidateQualifier(Qualifier.class, definition.getBeanName()));
 			emBeanDefinition.setScope(definition.getBeanDefinition().getScope());
 			emBeanDefinition.setSource(definition.getBeanDefinition().getSource());

--- a/src/test/java/org/springframework/data/jpa/repository/support/EntityManagerBeanDefinitionRegistrarPostProcessorIntegrationTests.java
+++ b/src/test/java/org/springframework/data/jpa/repository/support/EntityManagerBeanDefinitionRegistrarPostProcessorIntegrationTests.java
@@ -35,6 +35,7 @@ import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.ComponentScan.Filter;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.ImportResource;
+import org.springframework.context.annotation.Primary;
 import org.springframework.orm.jpa.JpaVendorAdapter;
 import org.springframework.orm.jpa.LocalContainerEntityManagerFactoryBean;
 import org.springframework.stereotype.Component;
@@ -46,6 +47,7 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
  *
  * @author Oliver Gierke
  * @author Jens Schauder
+ * @author Réda Housni Alaoui
  */
 @ExtendWith(SpringExtension.class)
 @ContextConfiguration
@@ -57,7 +59,8 @@ public class EntityManagerBeanDefinitionRegistrarPostProcessorIntegrationTests {
 	void injectsEntityManagerIntoConstructors() {
 
 		assertThat(target).isNotNull();
-		assertThat(target.em).isNotNull();
+		assertThat(target.firstEm).isNotNull();
+		assertThat(target.primaryEm).isNotNull();
 	}
 
 	/**
@@ -104,16 +107,24 @@ public class EntityManagerBeanDefinitionRegistrarPostProcessorIntegrationTests {
 		LocalContainerEntityManagerFactoryBean secondEmf() {
 			return emf();
 		}
+
+		@Primary
+		@Bean
+		LocalContainerEntityManagerFactoryBean thirdEmf() {
+			return emf();
+		}
 	}
 
 	@TestComponent
 	static class EntityManagerInjectionTarget {
 
-		private final EntityManager em;
+		private final EntityManager firstEm;
+		private final EntityManager primaryEm;
 
 		@Autowired
-		public EntityManagerInjectionTarget(@Qualifier("firstEmf") EntityManager em) {
-			this.em = em;
+		public EntityManagerInjectionTarget(@Qualifier("firstEmf") EntityManager firstEm, EntityManager primaryEm) {
+			this.firstEm = firstEm;
+			this.primaryEm = primaryEm;
 		}
 	}
 }


### PR DESCRIPTION
Fix #2288

- [X] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [X] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [X] You submit test cases (unit or integration tests) that back your changes.
- [X] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
