### PR TITLE
JPA is now Jakarta Persistence API

### DIFF
--- a/src/main/asciidoc/glossary.adoc
+++ b/src/main/asciidoc/glossary.adoc
@@ -16,6 +16,6 @@ EclipseLink :: Object relational mapper implementing JPA - link:$$https://www.ec
 
 Hibernate :: Object relational mapper implementing JPA - link:$$https://hibernate.org/$$[https://hibernate.org/]
 
-JPA :: Java Persistence API
+JPA :: Jakarta Persistence API
 
 Spring :: Java application framework - link:$$https://projects.spring.io/spring-framework$$[https://projects.spring.io/spring-framework]

--- a/src/main/asciidoc/preface.adoc
+++ b/src/main/asciidoc/preface.adoc
@@ -1,7 +1,7 @@
 [[preface]]
 == Preface
 
-Spring Data JPA provides repository support for the Java Persistence API (JPA). It eases development of applications that need to access JPA data sources.
+Spring Data JPA provides repository support for the Jakarta Persistence API (JPA). It eases development of applications that need to access JPA data sources.
 
 [[project]]
 === Project Metadata


### PR DESCRIPTION
JPA is now Jakarta Persistence API.

This trivial fix changes two lines in the documentation from Java Persistence API to Jakarta Persistence API
