### PR TITLE
add protectedGetEntityManager method to JpaRepository.

### DIFF
--- a/src/main/java/org/springframework/data/jpa/repository/JpaRepository.java
+++ b/src/main/java/org/springframework/data/jpa/repository/JpaRepository.java
@@ -33,6 +33,7 @@ import org.springframework.data.repository.query.QueryByExampleExecutor;
  * @author Mark Paluch
  * @author Sander Krabbenborg
  * @author Jesse Wouters
+ * @author Evgeny Bokshitsky
  */
 @NoRepositoryBean
 public interface JpaRepository<T, ID> extends PagingAndSortingRepository<T, ID>, QueryByExampleExecutor<T> {
@@ -163,4 +164,11 @@ public interface JpaRepository<T, ID> extends PagingAndSortingRepository<T, ID>,
 	 */
 	@Override
 	<S extends T> List<S> findAll(Example<S> example, Sort sort);
+
+	/**
+	 * Method should not be called outside of repository.
+	 * Allows implement custom query logic using EntityManager without additional ${RepositoryName}Custom interface and ${RepositoryName}Impl class
+	 */
+	EntityManager protectedGetEntityManager();
+
 }

--- a/src/main/java/org/springframework/data/jpa/repository/support/SimpleJpaRepository.java
+++ b/src/main/java/org/springframework/data/jpa/repository/support/SimpleJpaRepository.java
@@ -562,6 +562,11 @@ public class SimpleJpaRepository<T, ID> implements JpaRepositoryImplementation<T
 				.getResultList();
 	}
 
+	@Override
+	public EntityManager protectedGetEntityManager() {
+		return em;
+	}
+
 	/*
 	 * (non-Javadoc)
 	 * @see org.springframework.data.repository.query.QueryByExampleExecutor#findAll(org.springframework.data.domain.Example, org.springframework.data.domain.Pageable)

--- a/src/test/java/org/springframework/data/jpa/repository/UserRepositoryTests.java
+++ b/src/test/java/org/springframework/data/jpa/repository/UserRepositoryTests.java
@@ -459,6 +459,13 @@ public class UserRepositoryTests {
 	}
 
 	@Test
+	void testExecutionOfMethodWithDefaultImplementation() {
+
+		flushTestUsers();
+		assertThat(repository.countWithLastname("Arrasz")).isEqualTo(1L);
+	}
+
+	@Test
 	void executesSpecificationCorrectly() {
 
 		flushTestUsers();

--- a/src/test/java/org/springframework/data/jpa/repository/sample/UserRepository.java
+++ b/src/test/java/org/springframework/data/jpa/repository/sample/UserRepository.java
@@ -166,6 +166,13 @@ public interface UserRepository
 	@Query("select count(u) from User u where u.firstname = ?1")
 	Long countWithFirstname(String firstname);
 
+	default Long countWithLastname(String lastname) {
+		return protectedGetEntityManager()
+				.createQuery("select count(u) from User u where u.lastname = :lastname", Long.class)
+				.setParameter("lastname", lastname)
+				.getSingleResult();
+	}
+
 	/**
 	 * Method where parameters will be applied by name. Note that the order of the parameters is then not crucial anymore.
 	 *


### PR DESCRIPTION
Hi,
(excuse me for my english :)

I am new spring-data user.

We use it for some services in our company and it works great.

But I found what if I want to have some customization of repository method and write it's body - I need to create extra classes (Impl and Custom) and put what logic there, separately from common repository logic.
(I mean this part: https://docs.spring.io/spring-data/jpa/docs/current/reference/html/#repositories.single-repository-behavior)

I was trying to avoid same separation using Java8 default Interface methods, and found what the only missing thing for 95% of logic is EntityManager, unavailable in current JpaRepository interface.

So I prepared this PR allowing to access EntityManager from JpaRepository.

This allows to write same custom methods directly in `YourRepositoryInterface extends JpaRepository` without additional classes and logic-split.
(see TestCase in PR for example)

I don't know if this is good idea or not, so I prepared some code (this PR) to ask what do you think about same proposal.
(Probably, we may use not directly my code, but the idea of using `interface default methods` to solve problem for the majority of cases, instead of making additional classes and splitting repository logic)

I will be grateful for any comments




