### PR TITLE
fixing flaky tests in UserRepositoryStoredProcedureIntegrationTests.java 

### DIFF
--- a/src/test/java/org/springframework/data/jpa/repository/UserRepositoryStoredProcedureIntegrationTests.java
+++ b/src/test/java/org/springframework/data/jpa/repository/UserRepositoryStoredProcedureIntegrationTests.java
@@ -96,7 +96,7 @@ public class UserRepositoryStoredProcedureIntegrationTests {
 
 		Map<String, Integer> result = repository.entityAnnotatedCustomNamedProcedurePlus1IO2(1);
 
-		assertThat(result).containsExactly(entry("res", 2), entry("res2", 3));
+		assertThat(result).containsOnly(entry("res", 2), entry("res2", 3));
 	}
 
 	@Test // DATAJPA-1579
@@ -104,7 +104,7 @@ public class UserRepositoryStoredProcedureIntegrationTests {
 
 		Map<String, Integer> result = repository.entityAnnotatedCustomNamedProcedurePlus1IOoptional(1);
 
-		assertThat(result).containsExactly(entry("res", 2), entry("res2", null));
+		assertThat(result).containsOnly(entry("res", 2), entry("res2", null));
 	}
 
 	@Test // DATAJPA-455


### PR DESCRIPTION
Hi, 

These two flaky tests (`entityAnnotatedCustomNamedProcedurePlus1IO2` and `entityAnnotatedCustomNamedProcedurePlus1IOoptional`) are detected by using [NonDex](https://github.com/TestingResearchIllinois/NonDex) using the following command: `mvn -pl . edu.illinois:nondex-maven-plugin:1.1.2:nondex -Dtest=org.springframework.data.jpa.repository.UserRepositoryStoredProcedureIntegrationTests`

These two tests are flaky because `Map<String, Integer> result` is not in order, and therefore the `containsExactly` may be flaky. I updated it into `containsOnly` to make sure the assertion is order independent.

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
