### PR TITLE
Fixed typos in JpaRepositoryExtension class. 

### DIFF
--- a/src/main/java/org/springframework/data/jpa/repository/cdi/JpaRepositoryExtension.java
+++ b/src/main/java/org/springframework/data/jpa/repository/cdi/JpaRepositoryExtension.java
@@ -56,7 +56,7 @@ public class JpaRepositoryExtension extends CdiRepositoryExtensionSupport {
 	}
 
 	/**
-	 * Implementation of a an observer which checks for EntityManager beans and stores them in {@link #entityManagers} for
+	 * Implementation of an observer which checks for EntityManager beans and stores them in {@link #entityManagers} for
 	 * later association with corresponding repository beans.
 	 *
 	 * @param <X> The type.
@@ -78,8 +78,7 @@ public class JpaRepositoryExtension extends CdiRepositoryExtensionSupport {
 	}
 
 	/**
-	 * Implementation of a an observer which registers beans to the CDI container for the detected Spring Data
-	 * repositories.
+	 * Implementation of an observer which registers beans to the CDI container for the detected Spring Data repositories.
 	 * <p>
 	 * The repository beans are associated to the EntityManagers using their qualifiers.
 	 *


### PR DESCRIPTION
I was browsing through the code to get a better inside into Spring Data JPA and saw two typos in the `JpaRepositoryExtension` class. This PR just fixes the typos. 

- [X] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [X] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.