### PR TITLE
Optimize SimpleJpaRepository.exists(Example) for better performance

### DIFF
--- a/src/main/java/org/springframework/data/jpa/repository/support/SimpleJpaRepository.java
+++ b/src/main/java/org/springframework/data/jpa/repository/support/SimpleJpaRepository.java
@@ -530,8 +530,12 @@ public class SimpleJpaRepository<T, ID> implements JpaRepositoryImplementation<T
 	 */
 	@Override
 	public <S extends T> boolean exists(Example<S> example) {
-		return !getQuery(new ExampleSpecification<S>(example, escapeCharacter), example.getProbeType(), Sort.unsorted())
-				.getResultList().isEmpty();
+		Specification<S> spec = new ExampleSpecification<>(example, this.escapeCharacter);
+		CriteriaQuery<Integer> cq = this.em.getCriteriaBuilder().createQuery(Integer.class);
+		cq.select(this.em.getCriteriaBuilder().literal(1));
+		applySpecificationToCriteria(spec, example.getProbeType(), cq);
+		TypedQuery<Integer> query = applyRepositoryMethodMetadata(this.em.createQuery(cq));
+		return query.setMaxResults(1).getSingleResult() != null;
 	}
 
 	/*


### PR DESCRIPTION
1. Set max results to 1 to avoid full scan
2. Select 1 to reduce size of ResultSet

