### PR TITLE
Removed deprecated function call in `JpaQueryMethod`.

### DIFF
--- a/src/main/java/org/springframework/data/jpa/repository/query/JpaQueryMethod.java
+++ b/src/main/java/org/springframework/data/jpa/repository/query/JpaQueryMethod.java
@@ -165,7 +165,7 @@ public class JpaQueryMethod extends QueryMethod {
 				continue;
 			}
 
-			if (StringUtils.isEmpty(annotatedQuery)
+			if (!StringUtils.hasText(annotatedQuery)
 					|| !annotatedQuery.contains(String.format(":%s", parameter.getName().get()))
 							&& !annotatedQuery.contains(String.format("#%s", parameter.getName().get()))) {
 				throw new IllegalStateException(


### PR DESCRIPTION
The method `assertParameterNamesInAnnotatedQuery()` used the deprecated function `StringUtils.isEmpty(String)`. This has been changed to a function call that is not deprecated and has the same logic.

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [ ] You submit test cases (unit or integration tests) that back your changes.
- [ ] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
