### PR TITLE
Fix total count for paged specifications with GROUP BY

### DIFF
--- a/src/main/java/org/springframework/data/jpa/repository/support/SimpleJpaRepository.java
+++ b/src/main/java/org/springframework/data/jpa/repository/support/SimpleJpaRepository.java
@@ -81,6 +81,7 @@ import org.springframework.util.Assert;
  * @author Jesse Wouters
  * @author Greg Turnquist
  * @author Yanming Zhou
+ * @author Robin Dupret
  */
 @Repository
 @Transactional(readOnly = true)
@@ -816,7 +817,7 @@ public class SimpleJpaRepository<T, ID> implements JpaRepositoryImplementation<T
 
 		Root<S> root = applySpecificationToCriteria(spec, domainClass, query);
 
-		if (query.isDistinct()) {
+		if (query.isDistinct() || query.getGroupList().size() > 0) {
 			query.select(builder.countDistinct(root));
 		} else {
 			query.select(builder.count(root));


### PR DESCRIPTION
Hello,

This patch tries to fix using paginated results found through a custom `Specification` that relies on a `GROUP BY` clause.

I hope the test is clear enough, but just in case, the problem is that since the `getCountQuery` method of `SimpleJpaRepository` takes the exact same query produced by the specification but injects a `COUNT` in the `SELECT`, the `COUNT` is done on each group of records so we end up counting them and not the "root" ones.

Using `DISTINCT` does the trick here. Actually I can't think of a case where using `DISTINCT` would be problematic so in my mind the patch could be to totally remove the `if/else` statement and rely on `countDistinct` anyway but maybe I'm blinded with my application and that's a bit too rash.

For the record, the `if/else` statement has been added in https://github.com/spring-projects/spring-data-jpa/commit/a74fadd2344e1358a5ce85b98ff3edf8e3e0a367.

Closes #1296.
Closes #2361.
Closes #1858.

Have a nice day.

------

- [X] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [X] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [X] You submit test cases (unit or integration tests) that back your changes.
- [X] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
