### PR TITLE
`@Query` supports query derivation from substitute.

### DIFF
--- a/src/main/java/org/springframework/data/jpa/repository/Query.java
+++ b/src/main/java/org/springframework/data/jpa/repository/Query.java
@@ -45,7 +45,8 @@ public @interface Query {
 
 	/**
 	 * Defines a special count query that shall be used for pagination queries to lookup the total number of elements for
-	 * a page. If none is configured we will derive the count query from the original query or {@link #countProjection()} query if any.
+	 * a page. If none is configured we will derive the count query from the original query or {@link #countProjection()}
+	 * query if any.
 	 */
 	String countQuery() default "";
 
@@ -77,4 +78,11 @@ public @interface Query {
 	 * @return
 	 */
 	String countName() default "";
+
+	/**
+	 * The substitute to be used instead of the method name to derive the query
+	 * 
+	 * @return the substitue
+	 */
+	String substitute() default "";
 }

--- a/src/main/java/org/springframework/data/jpa/repository/query/PartTreeJpaQuery.java
+++ b/src/main/java/org/springframework/data/jpa/repository/query/PartTreeJpaQuery.java
@@ -84,9 +84,15 @@ public class PartTreeJpaQuery extends AbstractJpaQuery {
 
 		boolean recreationRequired = parameters.hasDynamicProjection() || parameters.potentiallySortsDynamically();
 
+		// if a substitute is present use the given substitute instead
+		String methodName = method.getName();
+		if (method.hasSubstitute()) {
+			methodName = method.getSubstitute();
+		}
+
 		try {
 
-			this.tree = new PartTree(method.getName(), domainClass);
+			this.tree = new PartTree(methodName, domainClass);
 			validate(tree, parameters, method.toString());
 			this.countQuery = new CountQueryPreparer(recreationRequired);
 			this.query = tree.isCountProjection() ? countQuery : new QueryPreparer(recreationRequired);

--- a/src/test/java/org/springframework/data/jpa/repository/UserRepositoryTests.java
+++ b/src/test/java/org/springframework/data/jpa/repository/UserRepositoryTests.java
@@ -2621,6 +2621,18 @@ public class UserRepositoryTests {
 		assertThat(repository.findAllDtoProjectedBy()).hasSize(4);
 	}
 
+	@Test
+	void substituteQueryUsedInsteadOfMethodeName() {
+
+		flushTestUsers();
+
+		assertThat(repository.withDomainEnding(".de")).hasSize(2);
+
+		List<User> olderThan = repository.olderThan(18);
+		assertThat(olderThan).hasSize(4);
+		assertThat(olderThan.stream().map(User::getAge)).allMatch(item -> item > 18);
+	}
+
 	private Page<User> executeSpecWithSort(Sort sort) {
 
 		flushTestUsers();

--- a/src/test/java/org/springframework/data/jpa/repository/sample/UserRepository.java
+++ b/src/test/java/org/springframework/data/jpa/repository/sample/UserRepository.java
@@ -614,6 +614,12 @@ public interface UserRepository
 	// #2363
 	List<NameOnlyDto> findAllDtoProjectedBy();
 
+	@Query(substitute = "findAllByEmailAddressEndingWith")
+	List<User> withDomainEnding(String domainEnding);
+
+	@Query(substitute = "findAllByAgeGreaterThan")
+	List<User> olderThan(int age);
+
 	interface RolesAndFirstname {
 
 		String getFirstname();


### PR DESCRIPTION
Method names for derived queries can become quite long if a property of the class has a long name, even though the logic behind the query is trivial. For such simple queries we now can provide the long and maybe ugly name as a substitute via the `@Query` annotation and have a more pleasant/short and useable method name. The `PartTreeJpaQuery` will use the substitute to derive the query.

Example Use case:

`Course.java`
```java
class Course {
   private LocalDateTime preferenceSubDeadline;
   private LocalDateTime teamSubDeadline;
   //...
}
```

`CourseRepositoryWithLongName.java`
```java
@Repository
public interface CourseRepositoryWithLongName
    extends PagingAndSortingRepository<Course, Long> {

    List<Course> findAllByPreferenceSubDeadlineBeforeAndTeamSubDeadlineAfter(LocalDateTime pref, LocalDateTime team);

}
```

The super long but actually trivial method to find all courses with preference deadline before X and team deadline after Y inside `CourseRepositoryWithLongName` could be simplified by using the now introduced "substitute" way.

`CourseRepositoryWithSubstitute.java`
```java
@Repository
public interface CourseRepositoryWithSubstitute
    extends PagingAndSortingRepository<Course, Long> {

    @Query(substitute = "findAllByPreferenceSubDeadlineBeforeAndTeamSubDeadlineAfter")
    List<Course> inbetweenPrefAndTeamDeadline(LocalDateTime pref, LocalDateTime team);

}
```

As you can see the `CourseRepositoryWithSubstitute` is now cleaner and still does not required the programmer to write a custom query. 

I often encountered the case that the method name became quite long although the idea behind the method is trivial. I always thought writing a query by hand would be too much, since for most trivial cases the derived query is more convenient.


PS: I did not know if I should add myself to the list of authors since I did not know if my change is worthy enough 😄 .


- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [ ] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
