### PR TITLE
GH-2341 - Fix missing `DISTINCT` in count query bug.

### DIFF
--- a/src/main/java/org/springframework/data/jpa/repository/query/QueryUtils.java
+++ b/src/main/java/org/springframework/data/jpa/repository/query/QueryUtils.java
@@ -146,7 +146,7 @@ public abstract class QueryUtils {
 		builder.append(IDENTIFIER_GROUP);
 		builder.append("(.*)");
 
-		COUNT_MATCH = compile(builder.toString(), CASE_INSENSITIVE);
+		COUNT_MATCH = compile(builder.toString(), CASE_INSENSITIVE | DOTALL);
 
 		Map<PersistentAttributeType, Class<? extends Annotation>> persistentAttributeTypes = new HashMap<>();
 		persistentAttributeTypes.put(ONE_TO_ONE, OneToOne.class);
@@ -482,7 +482,8 @@ public abstract class QueryUtils {
 			boolean useVariable = StringUtils.hasText(variable) //
 					&& !variable.startsWith(" new") //
 					&& !variable.startsWith("count(") //
-					&& !variable.contains(","); //
+					&& !variable.contains(",") //
+					&& !variable.contains("*");
 
 			String complexCountValue = matcher.matches() && StringUtils.hasText(matcher.group(COMPLEX_COUNT_FIRST_INDEX))
 					? COMPLEX_COUNT_VALUE

--- a/src/test/java/org/springframework/data/jpa/repository/query/QueryUtilsUnitTests.java
+++ b/src/test/java/org/springframework/data/jpa/repository/query/QueryUtilsUnitTests.java
@@ -422,6 +422,11 @@ class QueryUtilsUnitTests {
 						"  where user.age = 18\n ");
 	}
 
+	@Test // GH-2341
+	void createCountQueryStarCharacterConverted() {
+		assertThat(createCountQueryFor("select * from User user")).isEqualTo("select count(user) from User user");
+	}
+
 	@Test
 	void createCountQuerySupportsLineBreaksInSelectClause() {
 
@@ -509,6 +514,28 @@ class QueryUtilsUnitTests {
 	@Test // DATAJPA-1696
 	void findProjectionClauseWithIncludedFrom() {
 		assertThat(QueryUtils.getProjection("select x, frommage, y from t")).isEqualTo("x, frommage, y");
+	}
+
+	@Test // GH-2341
+	void countProjectionDistrinctQueryIncludesNewLineAfterFromAndBeforeJoin() {
+		String originalQuery = "SELECT DISTINCT entity1\nFROM Entity1 entity1\nLEFT JOIN Entity2 entity2 ON entity1.key = entity2.key";
+
+		assertCountQuery(originalQuery,
+				"select count(DISTINCT entity1) FROM Entity1 entity1\nLEFT JOIN Entity2 entity2 ON entity1.key = entity2.key");
+	}
+
+	@Test
+	void countProjectionDistinctQueryIncludesNewLineAfterEntity() {
+		String originalQuery = "SELECT DISTINCT entity1\nFROM Entity1 entity1 LEFT JOIN Entity2 entity2 ON entity1.key = entity2.key";
+		assertCountQuery(originalQuery,
+				"select count(DISTINCT entity1) FROM Entity1 entity1 LEFT JOIN Entity2 entity2 ON entity1.key = entity2.key");
+	}
+
+	@Test
+	void countProjectionDistinctQueryIncludesNewLineAfterEntityAndBeforeWhere() {
+		String originalQuery = "SELECT DISTINCT entity1\nFROM Entity1 entity1 LEFT JOIN Entity2 entity2 ON entity1.key = entity2.key\nwhere entity1.id = 1799";
+		assertCountQuery(originalQuery,
+				"select count(DISTINCT entity1) FROM Entity1 entity1 LEFT JOIN Entity2 entity2 ON entity1.key = entity2.key\nwhere entity1.id = 1799");
 	}
 
 	private static void assertCountQuery(String originalQuery, String countQuery) {


### PR DESCRIPTION
The `COUNT_MATCH` did not consider line breaks after the `from` clause or the `where` clause. This lead to a no match scenario in the construction of the count query. With the fix we now consider line breaks/whitespaces after the `from` and `where` clause.

Closes #2341
Related tickets #2177


- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.