### PR TITLE
GH-2393 The count query pattern matches queries that start with a space.

### DIFF
--- a/src/main/java/org/springframework/data/jpa/repository/query/QueryUtils.java
+++ b/src/main/java/org/springframework/data/jpa/repository/query/QueryUtils.java
@@ -140,6 +140,7 @@ public abstract class QueryUtils {
 		ALIAS_MATCH = compile(builder.toString(), CASE_INSENSITIVE);
 
 		builder = new StringBuilder();
+		builder.append("\\s*");
 		builder.append("(select\\s+((distinct)?((?s).+?)?)\\s+)?(from\\s+");
 		builder.append(IDENTIFIER);
 		builder.append("(?:\\s+as)?\\s+)");

--- a/src/test/java/org/springframework/data/jpa/repository/query/QueryUtilsUnitTests.java
+++ b/src/test/java/org/springframework/data/jpa/repository/query/QueryUtilsUnitTests.java
@@ -17,6 +17,7 @@ package org.springframework.data.jpa.repository.query;
 
 import static org.assertj.core.api.Assertions.*;
 import static org.springframework.data.jpa.repository.query.QueryUtils.*;
+import static org.springframework.test.web.servlet.result.StatusResultMatchersExtensionsKt.isEqualTo;
 
 import java.util.Collections;
 import java.util.Set;
@@ -509,6 +510,14 @@ class QueryUtilsUnitTests {
 	@Test // DATAJPA-1696
 	void findProjectionClauseWithIncludedFrom() {
 		assertThat(QueryUtils.getProjection("select x, frommage, y from t")).isEqualTo("x, frommage, y");
+	}
+
+	@Test // GH-2393
+	void createCountQueryStartsWithWhitespace() {
+		assertThat(createCountQueryFor("  \nselect * from user where user.age>:age"))
+				.isEqualTo("select count(*) from user where user.age>:age");
+		assertThat(createCountQueryFor("  \nselect u from User u where user.age>:age"))
+				.isEqualTo("select count(u) from user where user.age>:age");
 	}
 
 	private static void assertCountQuery(String originalQuery, String countQuery) {


### PR DESCRIPTION
<!--

Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
Make sure that:

-->
The COUNT_MATCH did not consider a query string staring with whitespace. This lead to cause illegal query syntax in the construction of the count query. With the fix we now use a native query string starting with whitespaces with paging.
Related tickets #2393

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
