### PR TITLE
Use IdentifiableType.hasSingleIdAttribute() to detect IdClass presence to obtain IdClass attributes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-jpa</artifactId>
-	<version>2.6.2-SNAPSHOT</version>
+	<version>2.6.2-GH-2391-SNAPSHOT</version>
 
 	<name>Spring Data JPA</name>
 	<description>Spring Data module for JPA repositories.</description>

--- a/src/main/java/org/springframework/data/jpa/provider/PersistenceProvider.java
+++ b/src/main/java/org/springframework/data/jpa/provider/PersistenceProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2008-2021 the original author or authors.
+ * Copyright 2008-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,8 +32,8 @@ import org.eclipse.persistence.jpa.JpaQuery;
 import org.eclipse.persistence.queries.ScrollableCursor;
 import org.hibernate.ScrollMode;
 import org.hibernate.ScrollableResults;
-import org.hibernate.metamodel.model.domain.spi.IdentifiableTypeDescriptor;
 import org.hibernate.proxy.HibernateProxy;
+
 import org.springframework.data.util.CloseableIterator;
 import org.springframework.lang.Nullable;
 import org.springframework.transaction.support.TransactionSynchronizationManager;
@@ -103,9 +103,7 @@ public enum PersistenceProvider implements QueryExtractor, ProxyIdAccessor {
 		 */
 		@Override
 		public <T> Set<SingularAttribute<? super T, ?>> getIdClassAttributes(IdentifiableType<T> type) {
-			return type instanceof IdentifiableTypeDescriptor && ((IdentifiableTypeDescriptor<T>) type).hasIdClass()
-					? super.getIdClassAttributes(type)
-					: Collections.emptySet();
+			return type.hasSingleIdAttribute() ? Collections.emptySet() : super.getIdClassAttributes(type);
 		}
 
 		/*


### PR DESCRIPTION
We now use `IdentifiableType.hasSingleIdAttribute()` to detect whether a type should have an IdClass. hasSingleIdAttribute is defined to return false if an `IdClass` is being used. It could also return false in case multiple identifier attributes are in place (composite Id) which is a bit of a grey area. At least we avoid using Hibernate-specific API.

See #2330
Closes #2391

---

We should backport and forward port this to `2.5.x` and `main`