### PR TITLE
Removed deprecated usage of `Lazy`.

### DIFF
--- a/src/main/java/org/springframework/data/jpa/repository/query/AbstractJpaQuery.java
+++ b/src/main/java/org/springframework/data/jpa/repository/query/AbstractJpaQuery.java
@@ -69,7 +69,7 @@ public abstract class AbstractJpaQuery implements RepositoryQuery {
 	private final PersistenceProvider provider;
 	private final Lazy<JpaQueryExecution> execution;
 
-	final Lazy<ParameterBinder> parameterBinder = new Lazy<>(this::createBinder);
+	final Lazy<ParameterBinder> parameterBinder = Lazy.of(this::createBinder);
 
 	/**
 	 * Creates a new {@link AbstractJpaQuery} from the given {@link JpaQueryMethod}.


### PR DESCRIPTION
Replaced in `AbstractJpaQuery` the depreacted way of using `Lazy` with the suggested `Lazy.of(...)`.

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.