### PR TITLE
Remove unnecessary `toString()` call.

### DIFF
--- a/src/main/java/org/springframework/data/jpa/convert/QueryByExamplePredicateBuilder.java
+++ b/src/main/java/org/springframework/data/jpa/convert/QueryByExamplePredicateBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2021 the original author or authors.
+ * Copyright 2016-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -278,7 +278,7 @@ public class QueryByExamplePredicateBuilder {
 
 			StringBuilder sb = new StringBuilder();
 			if (parent != null) {
-				sb.append(parent.toString());
+				sb.append(parent);
 				sb.append(" -");
 				sb.append(name);
 				sb.append("-> ");

--- a/src/main/java/org/springframework/data/jpa/repository/query/StringQuery.java
+++ b/src/main/java/org/springframework/data/jpa/repository/query/StringQuery.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2021 the original author or authors.
+ * Copyright 2013-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -752,11 +752,11 @@ class StringQuery implements DeclaredQuery {
 
 			switch (type) {
 				case STARTING_WITH:
-					return String.format("%s%%", value.toString());
+					return String.format("%s%%", value);
 				case ENDING_WITH:
-					return String.format("%%%s", value.toString());
+					return String.format("%%%s", value);
 				case CONTAINING:
-					return String.format("%%%s%%", value.toString());
+					return String.format("%%%s%%", value);
 				case LIKE:
 				default:
 					return value;

--- a/src/main/java/org/springframework/data/jpa/support/ClasspathScanningPersistenceUnitPostProcessor.java
+++ b/src/main/java/org/springframework/data/jpa/support/ClasspathScanningPersistenceUnitPostProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2021 the original author or authors.
+ * Copyright 2011-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -191,7 +191,7 @@ public class ClasspathScanningPersistenceUnitPostProcessor
 				mappingFileUris.add(resourcePathInClasspath);
 
 			} catch (IOException e) {
-				throw new IllegalStateException(String.format("Couldn't get URI for %s!", resource.toString()), e);
+				throw new IllegalStateException(String.format("Couldn't get URI for %s!", resource), e);
 			}
 		}
 


### PR DESCRIPTION
There were few explicit `toString()` calls that are not needed, since `toString()` will be called by default.


- [X] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [X] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [X] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
