### PR TITLE
Removed unnecessray interface modifier in `BeanDefinitionNames`.

### DIFF
--- a/src/main/java/org/springframework/data/jpa/repository/config/BeanDefinitionNames.java
+++ b/src/main/java/org/springframework/data/jpa/repository/config/BeanDefinitionNames.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2021 the original author or authors.
+ * Copyright 2014-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,7 +24,7 @@ package org.springframework.data.jpa.repository.config;
  */
 interface BeanDefinitionNames {
 
-	public static final String JPA_MAPPING_CONTEXT_BEAN_NAME = "jpaMappingContext";
-	public static final String JPA_CONTEXT_BEAN_NAME = "jpaContext";
-	public static final String EM_BEAN_DEFINITION_REGISTRAR_POST_PROCESSOR_BEAN_NAME = "emBeanDefinitionRegistrarPostProcessor";
+	String JPA_MAPPING_CONTEXT_BEAN_NAME = "jpaMappingContext";
+	String JPA_CONTEXT_BEAN_NAME = "jpaContext";
+	String EM_BEAN_DEFINITION_REGISTRAR_POST_PROCESSOR_BEAN_NAME = "emBeanDefinitionRegistrarPostProcessor";
 }


### PR DESCRIPTION
All fields of an interface are by default `public static final`. To make the code more readable the redundancy is removed.

- [X] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [X] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [X] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
