### PR TITLE
Remove of useless `throws ...` in jUnit tests.

### DIFF
--- a/src/test/java/org/springframework/data/jpa/domain/support/AuditingBeanFactoryPostProcessorUnitTests.java
+++ b/src/test/java/org/springframework/data/jpa/domain/support/AuditingBeanFactoryPostProcessorUnitTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2008-2021 the original author or authors.
+ * Copyright 2008-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -59,7 +59,7 @@ class AuditingBeanFactoryPostProcessorUnitTests {
 	}
 
 	@Test
-	void beanConfigurerAspectShouldBeConfiguredAfterPostProcessing() throws Exception {
+	void beanConfigurerAspectShouldBeConfiguredAfterPostProcessing() {
 
 		processor.postProcessBeanFactory(beanFactory);
 

--- a/src/test/java/org/springframework/data/jpa/domain/support/AuditingNamespaceUnitTests.java
+++ b/src/test/java/org/springframework/data/jpa/domain/support/AuditingNamespaceUnitTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2008-2021 the original author or authors.
+ * Copyright 2008-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -39,7 +39,7 @@ class AuditingNamespaceUnitTests extends AuditingBeanFactoryPostProcessorUnitTes
 	}
 
 	@Test
-	void registersBeanDefinitions() throws Exception {
+	void registersBeanDefinitions() {
 
 		BeanDefinition definition = beanFactory.getBeanDefinition(AuditingEntityListener.class.getName());
 		PropertyValue propertyValue = definition.getPropertyValues().getPropertyValue("auditingHandler");

--- a/src/test/java/org/springframework/data/jpa/repository/EclipseLinkNamespaceUserRepositoryTests.java
+++ b/src/test/java/org/springframework/data/jpa/repository/EclipseLinkNamespaceUserRepositoryTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2008-2021 the original author or authors.
+ * Copyright 2008-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -106,7 +106,7 @@ class EclipseLinkNamespaceUserRepositoryTests extends NamespaceUserRepositoryTes
 	 * Ignores the test. Reconsider once https://bugs.eclipse.org/bugs/show_bug.cgi?id=533240 is fixed.
 	 */
 	@Override
-	void findByEmptyArrayOfIntegers() throws Exception {}
+	void findByEmptyArrayOfIntegers() {}
 
 	/**
 	 * Ignores the test. Reconsider once https://bugs.eclipse.org/bugs/show_bug.cgi?id=533240 is fixed.
@@ -119,13 +119,13 @@ class EclipseLinkNamespaceUserRepositoryTests extends NamespaceUserRepositoryTes
 	 * Ignores the test. Reconsider once https://bugs.eclipse.org/bugs/show_bug.cgi?id=533240 is fixed.
 	 */
 	@Override
-	void findByEmptyCollectionOfIntegers() throws Exception {}
+	void findByEmptyCollectionOfIntegers() {}
 
 	/**
 	 * Ignores the test. Reconsider once https://bugs.eclipse.org/bugs/show_bug.cgi?id=533240 is fixed.
 	 */
 	@Override
-	void findByEmptyCollectionOfStrings() throws Exception {}
+	void findByEmptyCollectionOfStrings() {}
 
 	/**
 	 * Ignores the test for EclipseLink.

--- a/src/test/java/org/springframework/data/jpa/repository/EclipseLinkUserRepositoryFinderTests.java
+++ b/src/test/java/org/springframework/data/jpa/repository/EclipseLinkUserRepositoryFinderTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2021 the original author or authors.
+ * Copyright 2011-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,7 +29,7 @@ class EclipseLinkUserRepositoryFinderTests extends UserRepositoryFinderTests {
 
 	@Disabled
 	@Override
-	void executesNotInQueryCorrectly() throws Exception {}
+	void executesNotInQueryCorrectly() {}
 
 	@Disabled
 	@Override

--- a/src/test/java/org/springframework/data/jpa/repository/ORMInfrastructureTests.java
+++ b/src/test/java/org/springframework/data/jpa/repository/ORMInfrastructureTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2008-2021 the original author or authors.
+ * Copyright 2008-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -40,10 +40,9 @@ public class ORMInfrastructureTests {
 	/**
 	 * Tests, that the context got initialized and injected correctly.
 	 *
-	 * @throws Exception
 	 */
 	@Test
-	void contextInitialized() throws Exception {
+	void contextInitialized() {
 
 		assertThat(context).isNotNull();
 	}

--- a/src/test/java/org/springframework/data/jpa/repository/OpenJpaParentRepositoryIntegrationTests.java
+++ b/src/test/java/org/springframework/data/jpa/repository/OpenJpaParentRepositoryIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2021 the original author or authors.
+ * Copyright 2013-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,5 +23,5 @@ class OpenJpaParentRepositoryIntegrationTests extends ParentRepositoryIntegratio
 
 	@Override
 	@Disabled
-	void testWithJoin() throws Exception {}
+	void testWithJoin() {}
 }

--- a/src/test/java/org/springframework/data/jpa/repository/OpenJpaUserRepositoryFinderTests.java
+++ b/src/test/java/org/springframework/data/jpa/repository/OpenJpaUserRepositoryFinderTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2021 the original author or authors.
+ * Copyright 2011-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,5 +29,5 @@ class OpenJpaUserRepositoryFinderTests extends UserRepositoryFinderTests {
 
 	@Disabled
 	@Override
-	void findsByLastnameIgnoringCaseLike() throws Exception {}
+	void findsByLastnameIgnoringCaseLike() {}
 }

--- a/src/test/java/org/springframework/data/jpa/repository/ParentRepositoryIntegrationTests.java
+++ b/src/test/java/org/springframework/data/jpa/repository/ParentRepositoryIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2021 the original author or authors.
+ * Copyright 2013-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -84,7 +84,7 @@ public class ParentRepositoryIntegrationTests {
 	}
 
 	@Test // DATAJPA-287
-	void testWithJoin() throws Exception {
+	void testWithJoin() {
 		Page<Parent> page = repository.findAll(new Specification<Parent>() {
 			@Override
 			public Predicate toPredicate(Root<Parent> root, CriteriaQuery<?> query, CriteriaBuilder cb) {

--- a/src/test/java/org/springframework/data/jpa/repository/RepositoryWithCompositeKeyTests.java
+++ b/src/test/java/org/springframework/data/jpa/repository/RepositoryWithCompositeKeyTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2021 the original author or authors.
+ * Copyright 2013-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -110,7 +110,7 @@ public class RepositoryWithCompositeKeyTests {
 	}
 
 	@Test // DATAJPA-472, DATAJPA-912
-	void shouldSupportFindAllWithPageableAndEntityWithIdClass() throws Exception {
+	void shouldSupportFindAllWithPageableAndEntityWithIdClass() {
 
 		IdClassExampleDepartment dep = new IdClassExampleDepartment();
 		dep.setName("TestDepartment");

--- a/src/test/java/org/springframework/data/jpa/repository/RepositoryWithIdClassKeyTests.java
+++ b/src/test/java/org/springframework/data/jpa/repository/RepositoryWithIdClassKeyTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2021 the original author or authors.
+ * Copyright 2016-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -61,7 +61,7 @@ public class RepositoryWithIdClassKeyTests {
 	 *      Specification 2.4.1.3 Derived Identities Example 2</a>
 	 */
 	@Test // DATAJPA-413
-	void shouldSaveAndLoadEntitiesWithDerivedIdentities() throws Exception {
+	void shouldSaveAndLoadEntitiesWithDerivedIdentities() {
 
 		Site site = siteRepository.save(new Site());
 		Item item = itemRepository.save(new Item(123, 456));

--- a/src/test/java/org/springframework/data/jpa/repository/RoleRepositoryIntegrationTests.java
+++ b/src/test/java/org/springframework/data/jpa/repository/RoleRepositoryIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2021 the original author or authors.
+ * Copyright 2011-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -45,7 +45,7 @@ public class RoleRepositoryIntegrationTests {
 	@Autowired RoleRepository repository;
 
 	@Test
-	void createsRole() throws Exception {
+	void createsRole() {
 
 		Role reference = new Role("ADMIN");
 		Role result = repository.save(reference);
@@ -53,7 +53,7 @@ public class RoleRepositoryIntegrationTests {
 	}
 
 	@Test
-	void updatesRole() throws Exception {
+	void updatesRole() {
 
 		Role reference = new Role("ADMIN");
 		Role result = repository.save(reference);

--- a/src/test/java/org/springframework/data/jpa/repository/UserRepositoryFinderTests.java
+++ b/src/test/java/org/springframework/data/jpa/repository/UserRepositoryFinderTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2008-2021 the original author or authors.
+ * Copyright 2008-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -144,7 +144,7 @@ public class UserRepositoryFinderTests {
 	}
 
 	@Test
-	void executesNotInQueryCorrectly() throws Exception {
+	void executesNotInQueryCorrectly() {
 
 		List<User> result = userRepository.findByFirstnameNotIn(Arrays.asList("Dave", "Carter"));
 
@@ -160,7 +160,7 @@ public class UserRepositoryFinderTests {
 	}
 
 	@Test // DATAJPA-92
-	void findsByLastnameIgnoringCaseLike() throws Exception {
+	void findsByLastnameIgnoringCaseLike() {
 
 		List<User> result = userRepository.findByLastnameIgnoringCaseLike("BeAUfo%");
 

--- a/src/test/java/org/springframework/data/jpa/repository/config/JpaRepositoryConfigDefinitionParserTests.java
+++ b/src/test/java/org/springframework/data/jpa/repository/config/JpaRepositoryConfigDefinitionParserTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2008-2021 the original author or authors.
+ * Copyright 2008-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,7 +33,7 @@ import org.springframework.core.io.ClassPathResource;
 class JpaRepositoryConfigDefinitionParserTests {
 
 	@Test
-	void getsTransactionManagerSet() throws Exception {
+	void getsTransactionManagerSet() {
 
 		DefaultListableBeanFactory factory = new DefaultListableBeanFactory();
 		XmlBeanDefinitionReader reader = new XmlBeanDefinitionReader(factory);

--- a/src/test/java/org/springframework/data/jpa/repository/config/JpaRepositoryConfigExtensionUnitTests.java
+++ b/src/test/java/org/springframework/data/jpa/repository/config/JpaRepositoryConfigExtensionUnitTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2021 the original author or authors.
+ * Copyright 2013-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -92,7 +92,7 @@ class JpaRepositoryConfigExtensionUnitTests {
 	}
 
 	@Test // DATAJPA-525
-	void guardsAgainstNullJavaTypesReturnedFromJpaMetamodel() throws Exception {
+	void guardsAgainstNullJavaTypesReturnedFromJpaMetamodel() {
 
 		ApplicationContext context = mock(ApplicationContext.class);
 		EntityManagerFactory emf = mock(EntityManagerFactory.class);

--- a/src/test/java/org/springframework/data/jpa/repository/query/Jpa21UtilsUnitTests.java
+++ b/src/test/java/org/springframework/data/jpa/repository/query/Jpa21UtilsUnitTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2021 the original author or authors.
+ * Copyright 2015-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,7 +33,7 @@ import org.springframework.data.jpa.repository.EntityGraph.EntityGraphType;
 class Jpa21UtilsUnitTests {
 
 	@Test // DATAJPA-696
-	void shouldBuildCorrectSubgraphForJpaEntityGraph() throws Exception {
+	void shouldBuildCorrectSubgraphForJpaEntityGraph() {
 
 		EntityGraph<?> entityGraph = mock(EntityGraph.class);
 		Subgraph<?> subgraph = mock(Subgraph.class);

--- a/src/test/java/org/springframework/data/jpa/repository/query/JpaQueryMethodUnitTests.java
+++ b/src/test/java/org/springframework/data/jpa/repository/query/JpaQueryMethodUnitTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2008-2021 the original author or authors.
+ * Copyright 2008-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -275,7 +275,7 @@ public class JpaQueryMethodUnitTests {
 	}
 
 	@Test // DATAJPA-185
-	void rejectsInvalidNamedParameter() throws Exception {
+	void rejectsInvalidNamedParameter() {
 
 		assertThatThrownBy(() -> getQueryMethod(InvalidRepository.class, "findByAnnotatedQuery", String.class))
 				.isInstanceOf(IllegalStateException.class)
@@ -344,8 +344,8 @@ public class JpaQueryMethodUnitTests {
 		doReturn(User.class).when(metadata).getDomainType();
 		doReturn(User.class).when(metadata).getReturnedDomainClass((Method) any());
 
-		JpaQueryMethod method = new JpaQueryMethod(JpaRepositoryOverride.class.getMethod("findOne", Integer.class), metadata,
-				factory, extractor);
+		JpaQueryMethod method = new JpaQueryMethod(JpaRepositoryOverride.class.getMethod("findOne", Integer.class),
+				metadata, factory, extractor);
 
 		assertThat(method.getEntityGraph()).isNotNull();
 		assertThat(method.getEntityGraph().getName()).isEqualTo("User.detail");

--- a/src/test/java/org/springframework/data/jpa/repository/query/ParameterBinderUnitTests.java
+++ b/src/test/java/org/springframework/data/jpa/repository/query/ParameterBinderUnitTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2008-2021 the original author or authors.
+ * Copyright 2008-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -123,7 +123,7 @@ public class ParameterBinderUnitTests {
 	}
 
 	@Test
-	void usesIndexedParametersIfNoParamAnnotationPresent() throws Exception {
+	void usesIndexedParametersIfNoParamAnnotationPresent() {
 
 		Object[] values = { "foo" };
 		bind(useIndexedParameters, values);
@@ -131,7 +131,7 @@ public class ParameterBinderUnitTests {
 	}
 
 	@Test
-	void usesParameterNameIfAnnotated() throws Exception {
+	void usesParameterNameIfAnnotated() {
 
 		when(query.setParameter(eq("username"), any())).thenReturn(query);
 
@@ -185,8 +185,7 @@ public class ParameterBinderUnitTests {
 	}
 
 	@Test // DATAJPA-107
-	void shouldThrowIllegalArgumentExceptionIfIsAnnotatedWithTemporalParamAndParameterTypeIsNotDate()
-			throws Exception {
+	void shouldThrowIllegalArgumentExceptionIfIsAnnotatedWithTemporalParamAndParameterTypeIsNotDate() throws Exception {
 		Method method = SampleRepository.class.getMethod("invalidWithTemporalTypeParameter", String.class);
 
 		assertThatIllegalArgumentException().isThrownBy(() -> new JpaParameters(method));

--- a/src/test/java/org/springframework/data/jpa/repository/query/QueryUtilsUnitTests.java
+++ b/src/test/java/org/springframework/data/jpa/repository/query/QueryUtilsUnitTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2008-2021 the original author or authors.
+ * Copyright 2008-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -51,7 +51,7 @@ class QueryUtilsUnitTests {
 	private static final String QUERY_WITH_AS = "select u from User as u where u.username = ?";
 
 	@Test
-	void createsCountQueryCorrectly() throws Exception {
+	void createsCountQueryCorrectly() {
 		assertCountQuery(QUERY, COUNT_QUERY);
 	}
 
@@ -64,47 +64,47 @@ class QueryUtilsUnitTests {
 	}
 
 	@Test
-	void createsCountQueryForDistinctQueries() throws Exception {
+	void createsCountQueryForDistinctQueries() {
 
 		assertCountQuery("select distinct u from User u where u.foo = ?",
 				"select count(distinct u) from User u where u.foo = ?");
 	}
 
 	@Test
-	void createsCountQueryForConstructorQueries() throws Exception {
+	void createsCountQueryForConstructorQueries() {
 
 		assertCountQuery("select distinct new User(u.name) from User u where u.foo = ?",
 				"select count(distinct u) from User u where u.foo = ?");
 	}
 
 	@Test
-	void createsCountQueryForJoins() throws Exception {
+	void createsCountQueryForJoins() {
 
 		assertCountQuery("select distinct new User(u.name) from User u left outer join u.roles r WHERE r = ?",
 				"select count(distinct u) from User u left outer join u.roles r WHERE r = ?");
 	}
 
 	@Test
-	void createsCountQueryForQueriesWithSubSelects() throws Exception {
+	void createsCountQueryForQueriesWithSubSelects() {
 
 		assertCountQuery("select u from User u left outer join u.roles r where r in (select r from Role)",
 				"select count(u) from User u left outer join u.roles r where r in (select r from Role)");
 	}
 
 	@Test
-	void createsCountQueryForAliasesCorrectly() throws Exception {
+	void createsCountQueryForAliasesCorrectly() {
 
 		assertCountQuery("select u from User as u", "select count(u) from User as u");
 	}
 
 	@Test
-	void allowsShortJpaSyntax() throws Exception {
+	void allowsShortJpaSyntax() {
 
 		assertCountQuery(SIMPLE_QUERY, COUNT_QUERY);
 	}
 
 	@Test
-	void detectsAliasCorrectly() throws Exception {
+	void detectsAliasCorrectly() {
 
 		assertThat(detectAlias(QUERY)).isEqualTo("u");
 		assertThat(detectAlias(SIMPLE_QUERY)).isEqualTo("u");

--- a/src/test/java/org/springframework/data/jpa/repository/support/DefaultJpaContextIntegrationTests.java
+++ b/src/test/java/org/springframework/data/jpa/repository/support/DefaultJpaContextIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2021 the original author or authors.
+ * Copyright 2015-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -160,7 +160,7 @@ public class DefaultJpaContextIntegrationTests {
 		// A non-EntityManagerFactory JNDI object to make sure the detection doesn't include it
 		// see DATAJPA-956
 		@Bean
-		public JndiObjectFactoryBean jndiObject() throws NamingException {
+		public JndiObjectFactoryBean jndiObject() {
 
 			JndiObjectFactoryBean bean = new JndiObjectFactoryBean();
 

--- a/src/test/java/org/springframework/data/jpa/repository/support/EntityManagerFactoryRefTests.java
+++ b/src/test/java/org/springframework/data/jpa/repository/support/EntityManagerFactoryRefTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2008-2021 the original author or authors.
+ * Copyright 2008-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -43,13 +43,13 @@ public class EntityManagerFactoryRefTests {
 
 	@Test
 	@Transactional
-	void useUserRepository() throws Exception {
+	void useUserRepository() {
 		userRepository.saveAndFlush(new User("firstname", "lastname", "foo@bar.de"));
 	}
 
 	@Test
 	@Transactional("transactionManager-2")
-	void useAuditableUserRepository() throws Exception {
+	void useAuditableUserRepository() {
 		auditableUserRepository.saveAndFlush(new AuditableUser());
 	}
 }

--- a/src/test/java/org/springframework/data/jpa/repository/support/JpaEntityInformationSupportUnitTests.java
+++ b/src/test/java/org/springframework/data/jpa/repository/support/JpaEntityInformationSupportUnitTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2021 the original author or authors.
+ * Copyright 2011-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -47,7 +47,7 @@ public class JpaEntityInformationSupportUnitTests {
 	@Mock Metamodel metaModel;
 
 	@Test
-	void usesSimpleClassNameIfNoEntityNameGiven() throws Exception {
+	void usesSimpleClassNameIfNoEntityNameGiven() {
 
 		JpaEntityInformation<User, Integer> information = new DummyJpaEntityInformation<>(User.class);
 		assertThat(information.getEntityName()).isEqualTo("User");

--- a/src/test/java/org/springframework/data/jpa/repository/support/JpaRepositoryFactoryUnitTests.java
+++ b/src/test/java/org/springframework/data/jpa/repository/support/JpaRepositoryFactoryUnitTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2008-2021 the original author or authors.
+ * Copyright 2008-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -91,7 +91,7 @@ public class JpaRepositoryFactoryUnitTests {
 	 * @throws Exception
 	 */
 	@Test
-	void setsUpBasicInstanceCorrectly() throws Exception {
+	void setsUpBasicInstanceCorrectly() {
 
 		assertThat(factory.getRepository(SimpleSampleRepository.class)).isNotNull();
 	}
@@ -111,10 +111,9 @@ public class JpaRepositoryFactoryUnitTests {
 	 * implementation could be found. Furthremore the exception has to contain the name of the predicateExecutor interface
 	 * as for a large predicateExecutor configuration it's hard to find out where this error occured.
 	 *
-	 * @throws Exception
 	 */
 	@Test
-	void capturesMissingCustomImplementationAndProvidesInterfacename() throws Exception {
+	void capturesMissingCustomImplementationAndProvidesInterfacename() {
 
 		try {
 			factory.getRepository(SampleRepository.class);
@@ -194,14 +193,14 @@ public class JpaRepositoryFactoryUnitTests {
 
 	}
 
-static class CustomJpaRepository<T, ID extends Serializable> extends SimpleJpaRepository<T, ID> {
+	static class CustomJpaRepository<T, ID extends Serializable> extends SimpleJpaRepository<T, ID> {
 
-	CustomJpaRepository(JpaEntityInformation<T, ?> entityInformation, EntityManager entityManager) {
+		CustomJpaRepository(JpaEntityInformation<T, ?> entityInformation, EntityManager entityManager) {
 			super(entityInformation, entityManager);
 		}
 	}
 
-		/**
+	/**
 	 * Implementation of the custom predicateExecutor interface.
 	 *
 	 * @author Oliver Gierke

--- a/src/test/java/org/springframework/data/jpa/repository/support/JpaRepositoryTests.java
+++ b/src/test/java/org/springframework/data/jpa/repository/support/JpaRepositoryTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2008-2021 the original author or authors.
+ * Copyright 2008-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -62,7 +62,7 @@ class JpaRepositoryTests {
 	}
 
 	@Test
-	void testCrudOperationsForCompoundKeyEntity() throws Exception {
+	void testCrudOperationsForCompoundKeyEntity() {
 
 		SampleEntity entity = new SampleEntity("foo", "bar");
 		repository.saveAndFlush(entity);
@@ -90,7 +90,7 @@ class JpaRepositoryTests {
 	}
 
 	@Test // DATAJPA-266
-	void testExistsForDomainObjectsWithCompositeKeys() throws Exception {
+	void testExistsForDomainObjectsWithCompositeKeys() {
 
 		PersistableWithIdClass s1 = idClassRepository.save(new PersistableWithIdClass(1L, 1L));
 		PersistableWithIdClass s2 = idClassRepository.save(new PersistableWithIdClass(2L, 2L));
@@ -123,7 +123,8 @@ class JpaRepositoryTests {
 		repository.saveAll(Arrays.asList(one, two, three));
 		repository.flush();
 
-		repository.deleteAllByIdInBatch(Arrays.asList(new SampleEntityPK("one", "eins"),new SampleEntityPK("three", "drei")));
+		repository
+				.deleteAllByIdInBatch(Arrays.asList(new SampleEntityPK("one", "eins"), new SampleEntityPK("three", "drei")));
 		assertThat(repository.findAll()).containsExactly(two);
 	}
 

--- a/src/test/java/org/springframework/data/jpa/repository/support/OpenJpaJpaRepositoryTests.java
+++ b/src/test/java/org/springframework/data/jpa/repository/support/OpenJpaJpaRepositoryTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2021 the original author or authors.
+ * Copyright 2013-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,6 +32,6 @@ class OpenJpaJpaRepositoryTests extends JpaRepositoryTests {
 	 */
 	@Override
 	@Disabled
-	void testCrudOperationsForCompoundKeyEntity() throws Exception {
+	void testCrudOperationsForCompoundKeyEntity() {
 	}
 }

--- a/src/test/java/org/springframework/data/jpa/repository/support/QuerydslJpaPredicateExecutorUnitTests.java
+++ b/src/test/java/org/springframework/data/jpa/repository/support/QuerydslJpaPredicateExecutorUnitTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2008-2021 the original author or authors.
+ * Copyright 2008-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -97,7 +97,7 @@ class QuerydslJpaPredicateExecutorUnitTests {
 	}
 
 	@Test
-	void executesPredicatesCorrectly() throws Exception {
+	void executesPredicatesCorrectly() {
 
 		BooleanExpression isCalledDave = user.firstname.eq("Dave");
 		BooleanExpression isBeauford = user.lastname.eq("Beauford");
@@ -108,7 +108,7 @@ class QuerydslJpaPredicateExecutorUnitTests {
 	}
 
 	@Test
-	void executesStringBasedPredicatesCorrectly() throws Exception {
+	void executesStringBasedPredicatesCorrectly() {
 
 		PathBuilder<User> builder = new PathBuilderFactory().create(User.class);
 
@@ -268,7 +268,7 @@ class QuerydslJpaPredicateExecutorUnitTests {
 	}
 
 	@Test // DATAJPA-665
-	void shouldSupportExistsWithPredicate() throws Exception {
+	void shouldSupportExistsWithPredicate() {
 
 		assertThat(predicateExecutor.exists(user.firstname.eq("Dave"))).isEqualTo(true);
 		assertThat(predicateExecutor.exists(user.firstname.eq("Unknown"))).isEqualTo(false);
@@ -511,9 +511,9 @@ class QuerydslJpaPredicateExecutorUnitTests {
 		em.clear();
 
 		assertThat(users).extracting(User::getFirstname).containsExactlyInAnyOrder( //
-						dave.getFirstname(), //
-						oliver.getFirstname() //
-				);
+				dave.getFirstname(), //
+				oliver.getFirstname() //
+		);
 
 		assertThat(users).allMatch(u -> u.getRoles().isEmpty());
 	}

--- a/src/test/java/org/springframework/data/jpa/repository/support/QuerydslJpaRepositoryTests.java
+++ b/src/test/java/org/springframework/data/jpa/repository/support/QuerydslJpaRepositoryTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2008-2021 the original author or authors.
+ * Copyright 2008-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -91,7 +91,7 @@ class QuerydslJpaRepositoryTests {
 	}
 
 	@Test
-	void executesPredicatesCorrectly() throws Exception {
+	void executesPredicatesCorrectly() {
 
 		BooleanExpression isCalledDave = user.firstname.eq("Dave");
 		BooleanExpression isBeauford = user.lastname.eq("Beauford");
@@ -102,7 +102,7 @@ class QuerydslJpaRepositoryTests {
 	}
 
 	@Test
-	void executesStringBasedPredicatesCorrectly() throws Exception {
+	void executesStringBasedPredicatesCorrectly() {
 
 		PathBuilder<User> builder = new PathBuilderFactory().create(User.class);
 
@@ -273,7 +273,7 @@ class QuerydslJpaRepositoryTests {
 	}
 
 	@Test // DATAJPA-665
-	void shouldSupportExistsWithPredicate() throws Exception {
+	void shouldSupportExistsWithPredicate() {
 
 		assertThat(repository.exists(user.firstname.eq("Dave"))).isEqualTo(true);
 		assertThat(repository.exists(user.firstname.eq("Unknown"))).isEqualTo(false);

--- a/src/test/java/org/springframework/data/jpa/repository/support/QuerydslRepositorySupportTests.java
+++ b/src/test/java/org/springframework/data/jpa/repository/support/QuerydslRepositorySupportTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2021 the original author or authors.
+ * Copyright 2011-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -67,7 +67,7 @@ public class QuerydslRepositorySupportTests {
 	}
 
 	@Test
-	void readsUsersCorrectly() throws Exception {
+	void readsUsersCorrectly() {
 
 		List<User> result = repository.findUsersByLastname("Matthews");
 		assertThat(result.size()).isEqualTo(1);
@@ -79,7 +79,7 @@ public class QuerydslRepositorySupportTests {
 	}
 
 	@Test
-	void updatesUsersCorrectly() throws Exception {
+	void updatesUsersCorrectly() {
 
 		long updates = repository.updateLastnamesTo("Foo");
 		assertThat(updates).isEqualTo(2L);

--- a/src/test/java/org/springframework/data/jpa/repository/support/TransactionalRepositoryTests.java
+++ b/src/test/java/org/springframework/data/jpa/repository/support/TransactionalRepositoryTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2008-2021 the original author or authors.
+ * Copyright 2008-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -58,35 +58,35 @@ public class TransactionalRepositoryTests {
 	}
 
 	@Test
-	void simpleManipulatingOperation() throws Exception {
+	void simpleManipulatingOperation() {
 
 		repository.saveAndFlush(new User("foo", "bar", "foo@bar.de"));
 		assertThat(transactionManager.getTransactionRequests()).isEqualTo(1);
 	}
 
 	@Test
-	void unannotatedFinder() throws Exception {
+	void unannotatedFinder() {
 
 		repository.findByEmailAddress("foo@bar.de");
 		assertThat(transactionManager.getTransactionRequests()).isEqualTo(0);
 	}
 
 	@Test
-	void invokeTransactionalFinder() throws Exception {
+	void invokeTransactionalFinder() {
 
 		repository.findByAnnotatedQuery("foo@bar.de");
 		assertThat(transactionManager.getTransactionRequests()).isEqualTo(1);
 	}
 
 	@Test
-	void invokeRedeclaredMethod() throws Exception {
+	void invokeRedeclaredMethod() {
 
 		repository.findById(1);
 		assertThat(transactionManager.getDefinition().isReadOnly()).isFalse();
 	}
 
 	@Test // DATACMNS-649
-	void invokeRedeclaredDeleteMethodWithoutTransactionDeclaration() throws Exception {
+	void invokeRedeclaredDeleteMethodWithoutTransactionDeclaration() {
 
 		User user = repository.saveAndFlush(new User("foo", "bar", "foo@bar.de"));
 		repository.deleteById(user.getId());


### PR DESCRIPTION
A lot of jUnit tests had in the method header a `throws` that is useless. For example `throws Exception` on a method where no exception is thrown. Removing this noice will make the tests more readable.

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
