### PR TITLE
Fix use wrong object reference in fluent Query API

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-jpa</artifactId>
-	<version>2.7.0-SNAPSHOT</version>
+	<version>2.7.0-GH-2438-SNAPSHOT</version>
 
 	<name>Spring Data JPA</name>
 	<description>Spring Data module for JPA repositories.</description>

--- a/src/main/java/org/springframework/data/jpa/repository/support/FetchableFluentQueryByExample.java
+++ b/src/main/java/org/springframework/data/jpa/repository/support/FetchableFluentQueryByExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 the original author or authors.
+ * Copyright 2021-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -45,6 +45,7 @@ import org.springframework.util.Assert;
  * @author Greg Turnquist
  * @author Mark Paluch
  * @author Jens Schauder
+ * @author J.R. Onyschak
  * @since 2.6
  */
 class FetchableFluentQueryByExample<S, R> extends FluentQuerySupport<S, R> implements FetchableFluentQuery<R> {
@@ -86,8 +87,8 @@ class FetchableFluentQueryByExample<S, R> extends FluentQuerySupport<S, R> imple
 
 		Assert.notNull(sort, "Sort must not be null!");
 
-		return new FetchableFluentQueryByExample<>(example, entityType, resultType, sort.and(sort), properties, finder,
-				countOperation, existsOperation, entityManager, escapeCharacter);
+		return new FetchableFluentQueryByExample<>(example, entityType, resultType, this.sort.and(sort), properties,
+				finder, countOperation, existsOperation, entityManager, escapeCharacter);
 	}
 
 	/*

--- a/src/main/java/org/springframework/data/jpa/repository/support/FetchableFluentQueryByPredicate.java
+++ b/src/main/java/org/springframework/data/jpa/repository/support/FetchableFluentQueryByPredicate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 the original author or authors.
+ * Copyright 2021-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -46,6 +46,7 @@ import com.querydsl.jpa.impl.AbstractJPAQuery;
  * @author Greg Turnquist
  * @author Mark Paluch
  * @author Jens Schauder
+ * @author J.R. Onyschak
  * @since 2.6
  */
 class FetchableFluentQueryByPredicate<S, R> extends FluentQuerySupport<S, R> implements FetchableFluentQuery<R> {
@@ -89,8 +90,8 @@ class FetchableFluentQueryByPredicate<S, R> extends FluentQuerySupport<S, R> imp
 
 		Assert.notNull(sort, "Sort must not be null!");
 
-		return new FetchableFluentQueryByPredicate<>(predicate, entityType, resultType, sort.and(sort), properties, finder,
-				pagedFinder, countOperation, existsOperation, entityManager);
+		return new FetchableFluentQueryByPredicate<>(predicate, entityType, resultType, this.sort.and(sort), properties,
+				finder, pagedFinder, countOperation, existsOperation, entityManager);
 	}
 
 	/*

--- a/src/test/java/org/springframework/data/jpa/repository/support/FetchableFluentQueryByExampleUnitTests.java
+++ b/src/test/java/org/springframework/data/jpa/repository/support/FetchableFluentQueryByExampleUnitTests.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.jpa.repository.support;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.data.domain.Example;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.domain.Sort.Order;
+
+/**
+ * Unit tests for {@link FetchableFluentQueryByExample}.
+ *
+ * @author J.R. Onyschak
+ */
+class FetchableFluentQueryByExampleUnitTests {
+
+	@Test // GH-2438
+	@SuppressWarnings({ "rawtypes", "unchecked" })
+	void multipleSortBy() {
+		Sort s1 = Sort.by(Order.by("s1"));
+		Sort s2 = Sort.by(Order.by("s2"));
+		FetchableFluentQueryByExample f = new FetchableFluentQueryByExample(Example.of(""), null, null, null, null, null);
+		f = (FetchableFluentQueryByExample) f.sortBy(s1).sortBy(s2);
+		assertThat(f.sort).isEqualTo(s1.and(s2));
+	}
+}

--- a/src/test/java/org/springframework/data/jpa/repository/support/FetchableFluentQueryByPredicateUnitTests.java
+++ b/src/test/java/org/springframework/data/jpa/repository/support/FetchableFluentQueryByPredicateUnitTests.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.jpa.repository.support;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.domain.Sort.Order;
+
+/**
+ * Unit tests for {@link FetchableFluentQueryByPredicate}.
+ *
+ * @author J.R. Onyschak
+ */
+class FetchableFluentQueryByPredicateUnitTests {
+
+	@Test // GH-2438
+	@SuppressWarnings({ "rawtypes", "unchecked" })
+	void multipleSortBy() {
+		Sort s1 = Sort.by(Order.by("s1"));
+		Sort s2 = Sort.by(Order.by("s2"));
+		FetchableFluentQueryByPredicate f = new FetchableFluentQueryByPredicate(null, null, null, null, null, null, null);
+		f = (FetchableFluentQueryByPredicate) f.sortBy(s1).sortBy(s2);
+		assertThat(f.sort).isEqualTo(s1.and(s2));
+	}
+}


### PR DESCRIPTION
Fixing object reference in FetchableFluentQueryByExample.sortBy and FetchableFluentQueryByPredicate.sortBy

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
