### PR TITLE
Added exists method with specification to `JpaSpecificationExecutor`.

### DIFF
--- a/src/main/java/org/springframework/data/jpa/repository/JpaSpecificationExecutor.java
+++ b/src/main/java/org/springframework/data/jpa/repository/JpaSpecificationExecutor.java
@@ -29,6 +29,7 @@ import org.springframework.lang.Nullable;
  *
  * @author Oliver Gierke
  * @author Christoph Strobl
+ * @author Diego Krupitza
  */
 public interface JpaSpecificationExecutor<T> {
 
@@ -74,4 +75,13 @@ public interface JpaSpecificationExecutor<T> {
 	 * @return the number of instances.
 	 */
 	long count(@Nullable Specification<T> spec);
+
+	/**
+	 * Checks whether the data store contains elements that match the given {@link Specification}.
+	 * 
+	 * @param spec the {@link Specification} to use for the existence check. Must not be {@literal null}.
+	 * @return <code>true</code> if the data store contains elements that match the given {@link Specification} otherwise
+	 *         <code>false</code>.
+	 */
+	boolean exists(Specification<T> spec);
 }

--- a/src/test/java/org/springframework/data/jpa/domain/sample/UserSpecifications.java
+++ b/src/test/java/org/springframework/data/jpa/domain/sample/UserSpecifications.java
@@ -26,6 +26,7 @@ import org.springframework.data.jpa.domain.Specification;
  * Collection of {@link Specification}s for a {@link User}.
  *
  * @author Oliver Gierke
+ * @author Diego Krupitza
  */
 public class UserSpecifications {
 
@@ -67,6 +68,17 @@ public class UserSpecifications {
 				return cb.like(root.get("firstname").as(String.class), String.format("%%%s%%", expression));
 			}
 		};
+	}
+
+	/**
+	 * A {@link Specification} to do an age check.
+	 *
+	 * @param age upper (exclusive) bound of the age
+	 * @return
+	 */
+	public static Specification<User> userHasAgeLess(final Integer age) {
+
+		return (root, query, cb) -> cb.lessThan(root.get("age").as(Integer.class), age);
 	}
 
 	/**

--- a/src/test/java/org/springframework/data/jpa/repository/UserRepositoryTests.java
+++ b/src/test/java/org/springframework/data/jpa/repository/UserRepositoryTests.java
@@ -96,6 +96,7 @@ import org.springframework.transaction.annotation.Transactional;
  * @author Sander Krabbenborg
  * @author Jesse Wouters
  * @author Greg Turnquist
+ * @author Diego Krupitza
  */
 @ExtendWith(SpringExtension.class)
 @ContextConfiguration("classpath:application-context.xml")
@@ -2638,6 +2639,17 @@ public class UserRepositoryTests {
 		flushTestUsers();
 
 		assertThat(repository.findAllInterfaceProjectedBy()).hasSize(4);
+	}
+
+	@Test // GH-2388
+	void existsWithSpec() {
+		flushTestUsers();
+
+		Specification<User> minorSpec = userHasAgeLess(18);
+		Specification<User> hundredYearsOld = userHasAgeLess(100);
+
+		assertThat(repository.exists(minorSpec)).isFalse();
+		assertThat(repository.exists(hundredYearsOld)).isTrue();
 	}
 
 	private Page<User> executeSpecWithSort(Sort sort) {


### PR DESCRIPTION
It is now possible to make existence checks with `Specification`s. This is an addition to checking existence with using an `Example`.

Closes #2388

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
