### PR TITLE
Explicit type replaced with diamond operator.

### DIFF
--- a/src/main/java/org/springframework/data/jpa/domain/JpaSort.java
+++ b/src/main/java/org/springframework/data/jpa/domain/JpaSort.java
@@ -161,7 +161,7 @@ public class JpaSort extends Sort {
 
 		Assert.notNull(paths, "Paths must not be null!");
 
-		List<Order> existing = new ArrayList<Order>();
+		List<Order> existing = new ArrayList<>();
 
 		for (Order order : this) {
 			existing.add(order);
@@ -181,7 +181,7 @@ public class JpaSort extends Sort {
 
 		Assert.notEmpty(properties, "Properties must not be empty!");
 
-		List<Order> orders = new ArrayList<Order>();
+		List<Order> orders = new ArrayList<>();
 
 		for (Order order : this) {
 			orders.add(order);
@@ -216,7 +216,7 @@ public class JpaSort extends Sort {
 
 	private static List<Order> combine(List<Order> orders, @Nullable Direction direction, List<Path<?, ?>> paths) {
 
-		List<Order> result = new ArrayList<Sort.Order>(orders);
+		List<Order> result = new ArrayList<>(orders);
 
 		for (Path<?, ?> path : paths) {
 			result.add(new Order(direction, path.toString()));
@@ -315,7 +315,7 @@ public class JpaSort extends Sort {
 		 * @return
 		 */
 		public <A extends Attribute<S, U>, U> Path<S, U> dot(A attribute) {
-			return new Path<S, U>(add(attribute));
+			return new Path<>(add(attribute));
 		}
 
 		/**

--- a/src/main/java/org/springframework/data/jpa/mapping/JpaPersistentPropertyImpl.java
+++ b/src/main/java/org/springframework/data/jpa/mapping/JpaPersistentPropertyImpl.java
@@ -57,7 +57,7 @@ class JpaPersistentPropertyImpl extends AnnotationBasedPersistentProperty<JpaPer
 
 	static {
 
-		Set<Class<? extends Annotation>> annotations = new HashSet<Class<? extends Annotation>>();
+		Set<Class<? extends Annotation>> annotations = new HashSet<>();
 		annotations.add(OneToMany.class);
 		annotations.add(OneToOne.class);
 		annotations.add(ManyToMany.class);
@@ -65,13 +65,13 @@ class JpaPersistentPropertyImpl extends AnnotationBasedPersistentProperty<JpaPer
 
 		ASSOCIATION_ANNOTATIONS = Collections.unmodifiableSet(annotations);
 
-		annotations = new HashSet<Class<? extends Annotation>>();
+		annotations = new HashSet<>();
 		annotations.add(Id.class);
 		annotations.add(EmbeddedId.class);
 
 		ID_ANNOTATIONS = Collections.unmodifiableSet(annotations);
 
-		annotations = new HashSet<Class<? extends Annotation>>();
+		annotations = new HashSet<>();
 		annotations.add(Column.class);
 		annotations.add(OrderColumn.class);
 
@@ -187,7 +187,7 @@ class JpaPersistentPropertyImpl extends AnnotationBasedPersistentProperty<JpaPer
 	 */
 	@Override
 	protected Association<JpaPersistentProperty> createAssociation() {
-		return new Association<JpaPersistentProperty>(this, null);
+		return new Association<>(this, null);
 	}
 
 	/*

--- a/src/main/java/org/springframework/data/jpa/repository/query/Jpa21Utils.java
+++ b/src/main/java/org/springframework/data/jpa/repository/query/Jpa21Utils.java
@@ -144,7 +144,7 @@ public class Jpa21Utils {
 	 */
 	static void configureFetchGraphFrom(JpaEntityGraph jpaEntityGraph, EntityGraph<?> entityGraph) {
 
-		List<String> attributePaths = new ArrayList<String>(jpaEntityGraph.getAttributePaths());
+		List<String> attributePaths = new ArrayList<>(jpaEntityGraph.getAttributePaths());
 
 		// Sort to ensure that the intermediate entity subgraphs are created accordingly.
 		Collections.sort(attributePaths);

--- a/src/main/java/org/springframework/data/jpa/repository/support/DefaultJpaContext.java
+++ b/src/main/java/org/springframework/data/jpa/repository/support/DefaultJpaContext.java
@@ -47,7 +47,7 @@ public class DefaultJpaContext implements JpaContext {
 		Assert.notNull(entityManagers, "EntityManagers must not be null!");
 		Assert.notEmpty(entityManagers, "EntityManagers must not be empty!");
 
-		this.entityManagers = new LinkedMultiValueMap<Class<?>, EntityManager>();
+		this.entityManagers = new LinkedMultiValueMap<>();
 
 		for (EntityManager em : entityManagers) {
 			for (ManagedType<?> managedType : em.getMetamodel().getManagedTypes()) {

--- a/src/main/java/org/springframework/data/jpa/repository/support/JpaEntityInformationSupport.java
+++ b/src/main/java/org/springframework/data/jpa/repository/support/JpaEntityInformationSupport.java
@@ -42,7 +42,7 @@ public abstract class JpaEntityInformationSupport<T, ID> extends AbstractEntityI
 	 */
 	public JpaEntityInformationSupport(Class<T> domainClass) {
 		super(domainClass);
-		this.metadata = new DefaultJpaEntityMetadata<T>(domainClass);
+		this.metadata = new DefaultJpaEntityMetadata<>(domainClass);
 	}
 
 	/**

--- a/src/main/java/org/springframework/data/jpa/repository/support/Querydsl.java
+++ b/src/main/java/org/springframework/data/jpa/repository/support/Querydsl.java
@@ -79,13 +79,13 @@ public class Querydsl {
 	public <T> AbstractJPAQuery<T, JPAQuery<T>> createQuery() {
 
 		switch (provider) {
-			case ECLIPSELINK:
-				return new JPAQuery<T>(em, EclipseLinkTemplates.DEFAULT);
-			case HIBERNATE:
-				return new JPAQuery<T>(em, HQLTemplates.DEFAULT);
-			case GENERIC_JPA:
-			default:
-				return new JPAQuery<T>(em);
+		case ECLIPSELINK:
+			return new JPAQuery<>(em, EclipseLinkTemplates.DEFAULT);
+		case HIBERNATE:
+			return new JPAQuery<>(em, HQLTemplates.DEFAULT);
+		case GENERIC_JPA:
+		default:
+			return new JPAQuery<>(em);
 		}
 	}
 
@@ -209,15 +209,15 @@ public class Querydsl {
 
 		switch (nullHandling) {
 
-			case NULLS_FIRST:
-				return NullHandling.NullsFirst;
+		case NULLS_FIRST:
+			return NullHandling.NullsFirst;
 
-			case NULLS_LAST:
-				return NullHandling.NullsLast;
+		case NULLS_LAST:
+			return NullHandling.NullsLast;
 
-			case NATIVE:
-			default:
-				return NullHandling.Default;
+		case NATIVE:
+		default:
+			return NullHandling.Default;
 		}
 	}
 

--- a/src/main/java/org/springframework/data/jpa/repository/support/QuerydslJpaRepository.java
+++ b/src/main/java/org/springframework/data/jpa/repository/support/QuerydslJpaRepository.java
@@ -92,7 +92,7 @@ public class QuerydslJpaRepository<T, ID extends Serializable> extends SimpleJpa
 		super(entityInformation, entityManager);
 
 		this.path = resolver.createPath(entityInformation.getJavaType());
-		this.builder = new PathBuilder<T>(path.getType(), path.getMetadata());
+		this.builder = new PathBuilder<>(path.getType(), path.getMetadata());
 		this.querydsl = new Querydsl(entityManager, builder);
 		this.entityManager = entityManager;
 	}

--- a/src/main/java/org/springframework/data/jpa/util/BeanDefinitionUtils.java
+++ b/src/main/java/org/springframework/data/jpa/util/BeanDefinitionUtils.java
@@ -49,11 +49,12 @@ public final class BeanDefinitionUtils {
 	private static final String JNDI_OBJECT_FACTORY_BEAN = "org.springframework.jndi.JndiObjectFactoryBean";
 	private static final List<Class<?>> EMF_TYPES;
 
-	private BeanDefinitionUtils() {}
+	private BeanDefinitionUtils() {
+	}
 
 	static {
 
-		List<Class<?>> types = new ArrayList<Class<?>>();
+		List<Class<?>> types = new ArrayList<>();
 		types.add(EntityManagerFactory.class);
 		types.add(AbstractEntityManagerFactoryBean.class);
 
@@ -96,7 +97,7 @@ public final class BeanDefinitionUtils {
 	public static Collection<EntityManagerFactoryBeanDefinition> getEntityManagerFactoryBeanDefinitions(
 			ConfigurableListableBeanFactory beanFactory) {
 
-		Set<EntityManagerFactoryBeanDefinition> definitions = new HashSet<EntityManagerFactoryBeanDefinition>();
+		Set<EntityManagerFactoryBeanDefinition> definitions = new HashSet<>();
 
 		for (Class<?> type : EMF_TYPES) {
 

--- a/src/test/java/org/springframework/data/jpa/domain/sample/Child.java
+++ b/src/test/java/org/springframework/data/jpa/domain/sample/Child.java
@@ -31,7 +31,7 @@ public class Child {
 	Long id;
 
 	@ManyToMany(mappedBy = "children")
-	Set<Parent> parents = new HashSet<Parent>();
+	Set<Parent> parents = new HashSet<>();
 
 	/**
 	 * @param parent

--- a/src/test/java/org/springframework/data/jpa/domain/sample/Parent.java
+++ b/src/test/java/org/springframework/data/jpa/domain/sample/Parent.java
@@ -34,7 +34,7 @@ public class Parent {
 	static final long serialVersionUID = -89717120680485957L;
 
 	@ManyToMany(cascade = CascadeType.ALL)
-	Set<Child> children = new HashSet<Child>();
+	Set<Child> children = new HashSet<>();
 
 	public Parent add(Child child) {
 

--- a/src/test/java/org/springframework/data/jpa/domain/sample/User.java
+++ b/src/test/java/org/springframework/data/jpa/domain/sample/User.java
@@ -135,9 +135,9 @@ public class User {
 		this.lastname = lastname;
 		this.emailAddress = emailAddress;
 		this.active = true;
-		this.roles = new HashSet<Role>(Arrays.asList(roles));
-		this.colleagues = new HashSet<User>();
-		this.attributes = new HashSet<String>();
+		this.roles = new HashSet<>(Arrays.asList(roles));
+		this.colleagues = new HashSet<>();
+		this.attributes = new HashSet<>();
 		this.createdAt = new Date();
 	}
 

--- a/src/test/java/org/springframework/data/jpa/repository/JavaConfigUserRepositoryTests.java
+++ b/src/test/java/org/springframework/data/jpa/repository/JavaConfigUserRepositoryTests.java
@@ -61,8 +61,10 @@ class JavaConfigUserRepositoryTests extends UserRepositoryTests {
 	@ImportResource("classpath:infrastructure.xml")
 	static class Config {
 
-		@PersistenceContext EntityManager entityManager;
-		@Autowired ApplicationContext applicationContext;
+		@PersistenceContext
+		EntityManager entityManager;
+		@Autowired
+		ApplicationContext applicationContext;
 
 		@Bean
 		public EvaluationContextExtension sampleEvaluationContextExtension() {
@@ -75,7 +77,7 @@ class JavaConfigUserRepositoryTests extends UserRepositoryTests {
 			QueryMethodEvaluationContextProvider evaluationContextProvider = new ExtensionAwareQueryMethodEvaluationContextProvider(
 					applicationContext);
 
-			JpaRepositoryFactoryBean<UserRepository, User, Integer> factory = new JpaRepositoryFactoryBean<UserRepository, User, Integer>(
+			JpaRepositoryFactoryBean<UserRepository, User, Integer> factory = new JpaRepositoryFactoryBean<>(
 					UserRepository.class);
 			factory.setEntityManager(entityManager);
 			factory.setBeanFactory(applicationContext);
@@ -111,5 +113,6 @@ class JavaConfigUserRepositoryTests extends UserRepositoryTests {
 	@Configuration
 	@EnableJpaRepositories(basePackageClasses = UserRepository.class)
 	@ImportResource("classpath:infrastructure.xml")
-	static class JpaRepositoryConfig {}
+	static class JpaRepositoryConfig {
+	}
 }

--- a/src/test/java/org/springframework/data/jpa/repository/UserRepositoryTests.java
+++ b/src/test/java/org/springframework/data/jpa/repository/UserRepositoryTests.java
@@ -101,10 +101,12 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional
 public class UserRepositoryTests {
 
-	@PersistenceContext EntityManager em;
+	@PersistenceContext
+	EntityManager em;
 
 	// CUT
-	@Autowired UserRepository repository;
+	@Autowired
+	UserRepository repository;
 
 	// Test fixture
 	private User firstUser;
@@ -298,7 +300,7 @@ public class UserRepositoryTests {
 	@Test
 	void deleteEmptyCollectionDoesNotDeleteAnything() {
 
-		assertDeleteCallDoesNotDeleteAnything(new ArrayList<User>());
+		assertDeleteCallDoesNotDeleteAnything(new ArrayList<>());
 	}
 
 	@Test

--- a/src/test/java/org/springframework/data/jpa/repository/custom/CustomGenericJpaRepositoryFactory.java
+++ b/src/test/java/org/springframework/data/jpa/repository/custom/CustomGenericJpaRepositoryFactory.java
@@ -52,7 +52,7 @@ public class CustomGenericJpaRepositoryFactory extends JpaRepositoryFactory {
 
 		JpaEntityInformation<Object, Serializable> entityMetadata = mock(JpaEntityInformation.class);
 		when(entityMetadata.getJavaType()).thenReturn((Class<Object>) information.getDomainType());
-		return new CustomGenericJpaRepository<Object, Serializable>(entityMetadata, em);
+		return new CustomGenericJpaRepository<>(entityMetadata, em);
 	}
 
 	/*

--- a/src/test/java/org/springframework/data/jpa/repository/support/DefaultJpaContextIntegrationTests.java
+++ b/src/test/java/org/springframework/data/jpa/repository/support/DefaultJpaContextIntegrationTests.java
@@ -21,7 +21,6 @@ import static org.mockito.Mockito.*;
 import java.util.Arrays;
 import java.util.HashSet;
 
-import javax.naming.NamingException;
 import javax.persistence.EntityManager;
 import javax.persistence.EntityManagerFactory;
 import javax.sql.DataSource;
@@ -29,7 +28,6 @@ import javax.sql.DataSource;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
@@ -99,7 +97,7 @@ public class DefaultJpaContextIntegrationTests {
 		this.firstEm = firstEmf.createEntityManager();
 		this.secondEm = secondEmf.createEntityManager();
 
-		this.jpaContext = new DefaultJpaContext(new HashSet<EntityManager>(Arrays.asList(firstEm, secondEm)));
+		this.jpaContext = new DefaultJpaContext(new HashSet<>(Arrays.asList(firstEm, secondEm)));
 	}
 
 	@Test // DATAJPA-669
@@ -148,8 +146,7 @@ public class DefaultJpaContextIntegrationTests {
 	}
 
 	@EnableJpaRepositories
-	@ComponentScan(includeFilters = @Filter(type = FilterType.ASSIGNABLE_TYPE, value = ApplicationComponent.class),
-			useDefaultFilters = false)
+	@ComponentScan(includeFilters = @Filter(type = FilterType.ASSIGNABLE_TYPE, value = ApplicationComponent.class), useDefaultFilters = false)
 	static class Config {
 
 		@Bean

--- a/src/test/java/org/springframework/data/jpa/repository/support/DefaultJpaEntityMetadataUnitTest.java
+++ b/src/test/java/org/springframework/data/jpa/repository/support/DefaultJpaEntityMetadataUnitTest.java
@@ -44,28 +44,28 @@ public class DefaultJpaEntityMetadataUnitTest {
 	@Test
 	void returnsConfiguredType() {
 
-		DefaultJpaEntityMetadata<Foo> metadata = new DefaultJpaEntityMetadata<Foo>(Foo.class);
+		DefaultJpaEntityMetadata<Foo> metadata = new DefaultJpaEntityMetadata<>(Foo.class);
 		assertThat(metadata.getJavaType()).isEqualTo(Foo.class);
 	}
 
 	@Test
 	void returnsSimpleClassNameAsEntityNameByDefault() {
 
-		DefaultJpaEntityMetadata<Foo> metadata = new DefaultJpaEntityMetadata<Foo>(Foo.class);
+		DefaultJpaEntityMetadata<Foo> metadata = new DefaultJpaEntityMetadata<>(Foo.class);
 		assertThat(metadata.getEntityName()).isEqualTo(Foo.class.getSimpleName());
 	}
 
 	@Test
 	void returnsCustomizedEntityNameIfConfigured() {
 
-		DefaultJpaEntityMetadata<Bar> metadata = new DefaultJpaEntityMetadata<Bar>(Bar.class);
+		DefaultJpaEntityMetadata<Bar> metadata = new DefaultJpaEntityMetadata<>(Bar.class);
 		assertThat(metadata.getEntityName()).isEqualTo("Entity");
 	}
 
 	@Test // DATAJPA-871
 	void returnsCustomizedEntityNameIfConfiguredViaComposedAnnotation() {
 
-		DefaultJpaEntityMetadata<BarWithComposedAnnotation> metadata = new DefaultJpaEntityMetadata<BarWithComposedAnnotation>(
+		DefaultJpaEntityMetadata<BarWithComposedAnnotation> metadata = new DefaultJpaEntityMetadata<>(
 				BarWithComposedAnnotation.class);
 		assertThat(metadata.getEntityName()).isEqualTo("Entity");
 	}
@@ -78,11 +78,14 @@ public class DefaultJpaEntityMetadataUnitTest {
 		String entityName();
 	}
 
-	private static class Foo {}
+	private static class Foo {
+	}
 
 	@Entity(name = "Entity")
-	static class Bar {}
+	static class Bar {
+	}
 
 	@CustomEntityAnnotationUsingAliasFor(entityName = "Entity")
-	private static class BarWithComposedAnnotation {}
+	private static class BarWithComposedAnnotation {
+	}
 }

--- a/src/test/java/org/springframework/data/jpa/repository/support/JpaMetamodelEntityInformationUnitTests.java
+++ b/src/test/java/org/springframework/data/jpa/repository/support/JpaMetamodelEntityInformationUnitTests.java
@@ -35,7 +35,6 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
-
 import org.springframework.data.jpa.domain.sample.PersistableWithIdClass;
 import org.springframework.data.jpa.domain.sample.PersistableWithIdClassPK;
 
@@ -49,12 +48,17 @@ import org.springframework.data.jpa.domain.sample.PersistableWithIdClassPK;
 @MockitoSettings(strictness = Strictness.LENIENT)
 class JpaMetamodelEntityInformationUnitTests {
 
-	@Mock Metamodel metamodel;
+	@Mock
+	Metamodel metamodel;
 
-	@Mock IdentifiableType<PersistableWithIdClass> type;
-	@Mock SingularAttribute<PersistableWithIdClass, ?> first, second;
+	@Mock
+	IdentifiableType<PersistableWithIdClass> type;
+	@Mock
+	SingularAttribute<PersistableWithIdClass, ?> first, second;
 
-	@Mock @SuppressWarnings("rawtypes") Type idType;
+	@Mock
+	@SuppressWarnings("rawtypes")
+	Type idType;
 
 	@BeforeEach
 	@SuppressWarnings("unchecked")
@@ -62,8 +66,7 @@ class JpaMetamodelEntityInformationUnitTests {
 
 		when(first.getName()).thenReturn("first");
 		when(second.getName()).thenReturn("second");
-		Set<SingularAttribute<? super PersistableWithIdClass, ?>> attributes = new HashSet<SingularAttribute<? super PersistableWithIdClass, ?>>(
-				asList(first, second));
+		Set<SingularAttribute<? super PersistableWithIdClass, ?>> attributes = new HashSet<>(asList(first, second));
 
 		when(type.getIdClassAttributes()).thenReturn(attributes);
 
@@ -77,7 +80,7 @@ class JpaMetamodelEntityInformationUnitTests {
 	@Test // DATAJPA-50
 	void doesNotCreateIdIfAllPartialAttributesAreNull() {
 
-		JpaMetamodelEntityInformation<PersistableWithIdClass, Serializable> information = new JpaMetamodelEntityInformation<PersistableWithIdClass, Serializable>(
+		JpaMetamodelEntityInformation<PersistableWithIdClass, Serializable> information = new JpaMetamodelEntityInformation<>(
 				PersistableWithIdClass.class, metamodel);
 
 		PersistableWithIdClass entity = new PersistableWithIdClass(null, null);

--- a/src/test/java/org/springframework/data/jpa/repository/support/JpaPersistableEntityInformationUnitTests.java
+++ b/src/test/java/org/springframework/data/jpa/repository/support/JpaPersistableEntityInformationUnitTests.java
@@ -29,7 +29,6 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
-
 import org.springframework.data.domain.Persistable;
 import org.springframework.data.repository.core.EntityInformation;
 
@@ -43,11 +42,15 @@ import org.springframework.data.repository.core.EntityInformation;
 @MockitoSettings(strictness = Strictness.LENIENT)
 class JpaPersistableEntityInformationUnitTests {
 
-	@Mock Metamodel metamodel;
+	@Mock
+	Metamodel metamodel;
 
-	@Mock EntityType<Foo> type;
+	@Mock
+	EntityType<Foo> type;
 
-	@Mock @SuppressWarnings("rawtypes") Type idType;
+	@Mock
+	@SuppressWarnings("rawtypes")
+	Type idType;
 
 	@BeforeEach
 	@SuppressWarnings("unchecked")
@@ -61,8 +64,7 @@ class JpaPersistableEntityInformationUnitTests {
 	@Test
 	void usesPersistableMethodsForIsNewAndGetId() {
 
-		EntityInformation<Foo, Long> entityInformation = new JpaPersistableEntityInformation<Foo, Long>(Foo.class,
-				metamodel);
+		EntityInformation<Foo, Long> entityInformation = new JpaPersistableEntityInformation<>(Foo.class, metamodel);
 
 		Foo foo = new Foo();
 		assertThat(entityInformation.isNew(foo)).isFalse();

--- a/src/test/java/org/springframework/data/jpa/repository/support/QuerydslJpaRepositoryTests.java
+++ b/src/test/java/org/springframework/data/jpa/repository/support/QuerydslJpaRepositoryTests.java
@@ -16,10 +16,6 @@
 package org.springframework.data.jpa.repository.support;
 
 import static org.assertj.core.api.Assertions.*;
-import static org.springframework.data.domain.Example.*;
-import static org.springframework.data.domain.ExampleMatcher.*;
-
-import lombok.Data;
 
 import java.sql.Date;
 import java.time.LocalDate;
@@ -68,7 +64,8 @@ import com.querydsl.core.types.dsl.PathBuilderFactory;
 @Transactional
 class QuerydslJpaRepositoryTests {
 
-	@PersistenceContext EntityManager em;
+	@PersistenceContext
+	EntityManager em;
 
 	private QuerydslJpaRepository<User, Integer> repository;
 	private QUser user = new QUser("user");
@@ -80,10 +77,10 @@ class QuerydslJpaRepositoryTests {
 	@BeforeEach
 	void setUp() {
 
-		JpaEntityInformation<User, Integer> information = new JpaMetamodelEntityInformation<User, Integer>(User.class,
+		JpaEntityInformation<User, Integer> information = new JpaMetamodelEntityInformation<>(User.class,
 				em.getMetamodel());
 
-		repository = new QuerydslJpaRepository<User, Integer>(information, em);
+		repository = new QuerydslJpaRepository<>(information, em);
 		dave = repository.save(new User("Dave", "Matthews", "dave@matthews.com"));
 		carter = repository.save(new User("Carter", "Beauford", "carter@beauford.com"));
 		oliver = repository.save(new User("Oliver", "matthews", "oliver@matthews.com"));

--- a/src/test/java/org/springframework/data/jpa/repository/support/SimpleJpaRepositoryUnitTests.java
+++ b/src/test/java/org/springframework/data/jpa/repository/support/SimpleJpaRepositoryUnitTests.java
@@ -84,7 +84,7 @@ class SimpleJpaRepositoryUnitTests {
 		when(metadata.getQueryHints()).thenReturn(hints);
 		when(metadata.getQueryHintsForCount()).thenReturn(hints);
 
-		repo = new SimpleJpaRepository<User, Integer>(information, em);
+		repo = new SimpleJpaRepository<>(information, em);
 		repo.setRepositoryMethodMetadata(metadata);
 	}
 


### PR DESCRIPTION
In modern java you do not need to add the explicit type if it can be inferred. To make the code more readable, we removed the explicit type and replaced it with the diamond operator (<>).

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.