### PR TITLE
Correctly handle order by aliases.

### DIFF
--- a/src/main/java/org/springframework/data/jpa/repository/query/QueryUtils.java
+++ b/src/main/java/org/springframework/data/jpa/repository/query/QueryUtils.java
@@ -76,6 +76,7 @@ import org.springframework.util.StringUtils;
  * @author Greg Turnquist
  * @author Diego Krupitza
  * @author Jędrzej Biedrzycki
+ * @author Darin Manica
  */
 public abstract class QueryUtils {
 

--- a/src/test/java/org/springframework/data/jpa/repository/query/QueryUtilsUnitTests.java
+++ b/src/test/java/org/springframework/data/jpa/repository/query/QueryUtilsUnitTests.java
@@ -41,6 +41,7 @@ import org.springframework.data.jpa.domain.JpaSort;
  * @author Mohammad Hewedy
  * @author Greg Turnquist
  * @author Jędrzej Biedrzycki
+ * @author Darin Manica
  */
 class QueryUtilsUnitTests {
 
@@ -104,7 +105,7 @@ class QueryUtilsUnitTests {
 		assertCountQuery(SIMPLE_QUERY, COUNT_QUERY);
 	}
 
-	@Test
+	@Test // GH-2260
 	void detectsAliasCorrectly() throws Exception {
 
 		assertThat(detectAlias(QUERY)).isEqualTo("u");
@@ -120,7 +121,7 @@ class QueryUtilsUnitTests {
 		assertThat(detectAlias("(select u from User u where not exists ((from User u2 where not exists (from User u3))))")).isEqualTo("u");
 	}
 
-	@Test
+	@Test // GH-2260
 	void testRemoveNestedParens() throws Exception {
 		// boundary conditions
 		assertThat(removeSubqueries(null)).isNull();


### PR DESCRIPTION
Correctly handle order by aliases.

fixes #2260 related to c93aa25

In order to correctly identify aliases in the order by clause, we cannot process the from clauses left-to-right using regular expressions.  These must be removed inner-to-outer.  Commit c93aa25 resulted in a bug where the subquery would be incorrectly identified as the alias, as by the following query:

```
from Parent p join p.children c where not c.id not in (select c2.id from Child c2)
```

Passing in a Sort.by("name") would result in "order by c2.name" instead of "order by p.name".  Thus, it was using the alias of the inner query instead of the outer query.  [This comment](https://github.com/spring-projects/spring-data-jpa/issues/2260#issuecomment-929510358) suggests removing the content of the inner query, with the caveat of the entire query being surrounded by parenthesis.  This commit does exactly that, by removing the subquery before the alias is identified.  It also handles the case when the entire query is surrounded by parenthesis.  Unit tests illustrate this along with several examples of removing the subquery to correctly identify the alias for the order by clause.