### PR TITLE
Fix case where the from clause is misidentified.

### DIFF
--- a/src/main/java/org/springframework/data/jpa/repository/query/QueryUtils.java
+++ b/src/main/java/org/springframework/data/jpa/repository/query/QueryUtils.java
@@ -138,7 +138,7 @@ public abstract class QueryUtils {
 	static {
 
 		StringBuilder builder = new StringBuilder();
-		builder.append("(?<=from)"); // from as starting delimiter
+		builder.append("(?<=\\bfrom)"); // from as starting delimiter
 		builder.append("(?:\\s)+"); // at least one space separating
 		builder.append(IDENTIFIER_GROUP); // Entity name, can be qualified (any
 		builder.append("(?:\\sas)*"); // exclude possible "as" keyword

--- a/src/test/java/org/springframework/data/jpa/repository/query/QueryUtilsUnitTests.java
+++ b/src/test/java/org/springframework/data/jpa/repository/query/QueryUtilsUnitTests.java
@@ -130,6 +130,9 @@ class QueryUtilsUnitTests {
 		assertThat(detectAlias(
 				"(from Foo f max(f) ((((select * from Foo f2 (from Foo f3) max(*)) (from Foo f4)) max(f5)) (f6)) (from Foo f7))"))
 						.isEqualTo("f");
+		assertThat(detectAlias(
+				"SELECT e FROM DbEvent e WHERE (CAST(:modifiedFrom AS date) IS NULL OR e.modificationDate >= :modifiedFrom)"))
+						.isEqualTo("e");
 	}
 
 	@Test // GH-2260


### PR DESCRIPTION
Fix case where the from clause is misidentified.
fixes #2260

Added a zero-width word boundary to the regex that identifies the from clause.  This is used in alias detection for order by clauses.

<!--

Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
Make sure that:

-->

- [✓] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [✓] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [✓] You submit test cases (unit or integration tests) that back your changes.
- [✓] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
