### PR TITLE
Fix string formatting in MergingPersistenceUnitManager#postProcessPersistenceUnitInfo debug log

### DIFF
--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/support/MergingPersistenceUnitManager.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/support/MergingPersistenceUnitManager.java
@@ -82,7 +82,7 @@ public class MergingPersistenceUnitManager extends DefaultPersistenceUnitManager
 			if (!pui.getMappingFileNames().contains(mappingFileName)) {
 
 				if (LOG.isDebugEnabled()) {
-					LOG.debug(String.format("Adding mapping file to persistence unit %s.", mappingFileName, persistenceUnitName));
+					LOG.debug(String.format("Adding mapping file %s to persistence unit %s.", mappingFileName, persistenceUnitName));
 				}
 				pui.addMappingFileName(mappingFileName);
 			}


### PR DESCRIPTION
`%s` was missed, so `mappingFileName` was printed instead of a `persistenceUnitName`, and `persistenceUnitName` wasn't actually printed at all