### PR TITLE
Fixed EntityGraphFactory overwriting subgraphs

### DIFF
--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/support/EntityGraphFactory.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/support/EntityGraphFactory.java
@@ -15,6 +15,8 @@
  */
 package org.springframework.data.jpa.repository.support;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Set;
 
 import jakarta.persistence.EntityGraph;
@@ -27,6 +29,7 @@ import org.springframework.data.mapping.PropertyPath;
  * Factory class to create an {@link EntityGraph} from a collection of property paths.
  *
  * @author Jens Schauder
+ * @author Petr Strnad
  * @since 2.6
  */
 abstract class EntityGraphFactory {
@@ -42,16 +45,20 @@ abstract class EntityGraphFactory {
 	public static <T> EntityGraph<T> create(EntityManager entityManager, Class<T> domainType, Set<String> properties) {
 
 		EntityGraph<T> entityGraph = entityManager.createEntityGraph(domainType);
+		Map<String, Subgraph<Object>> existingSubgraphs = new HashMap<>();
 
 		for (String property : properties) {
 
 			Subgraph<Object> current = null;
+			String currentFullPath = "";
 
 			for (PropertyPath path : PropertyPath.from(property, domainType)) {
 
+				currentFullPath += path.getSegment() + ".";
 				if (path.hasNext()) {
-					current = current == null ? entityGraph.addSubgraph(path.getSegment())
-							: current.addSubgraph(path.getSegment());
+					final Subgraph<Object> finalCurrent = current;
+					current = current == null ? existingSubgraphs.computeIfAbsent(currentFullPath, k -> entityGraph.addSubgraph(path.getSegment()))
+							: existingSubgraphs.computeIfAbsent(currentFullPath, k -> finalCurrent.addSubgraph(path.getSegment()));
 					continue;
 				}
 

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/support/EntityGraphFactoryUnitTests.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/support/EntityGraphFactoryUnitTests.java
@@ -31,6 +31,7 @@ import org.junit.jupiter.api.Test;
  * Unit tests for {@link EntityGraphFactory}.
  *
  * @author Jens Schauder
+ * @author Petr Strnad
  */
 @SuppressWarnings("rawtypes")
 class EntityGraphFactoryUnitTests {
@@ -61,12 +62,13 @@ class EntityGraphFactoryUnitTests {
 	@Test
 	void setOfCompositePropertiesGetRegisteredPiecewise() {
 
-		HashSet<String> properties = new HashSet<>(asList("one.two", "eins.zwei.drei"));
+		HashSet<String> properties = new HashSet<>(asList("one.one", "one.two", "eins.zwei.drei"));
 
 		entityGraph = EntityGraphFactory.create(em, DummyEntity.class, properties);
 
 		verify(entityGraph).addSubgraph("one");
 		Subgraph<?> one = entityGraph.addSubgraph("one");
+		verify(one).addAttributeNodes("one");
 		verify(one).addAttributeNodes("two");
 
 		verify(entityGraph).addSubgraph("eins");


### PR DESCRIPTION
<!--

Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
Make sure that:

-->

EntityGraphFactory doesn't check whether a subgraph for a joined entity has already been created, and instead always creates a new one which overwrites the previous one.

E.g. when properties "a.b.field" and "a.c.field" are passed, it will first create a subgraph for "a" with a nested subgraph for "b", then create a new subgraph for "a" with a nested subgraph for "c", which will replace the the previous subgraph for "a". Therefore, no eager join for the b entity will be generated.

Related ticket #2527 

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
