### PR TITLE
Fix grammar mistakes in countOccurrences method of QueryUtils class

### DIFF
--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/QueryUtils.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/QueryUtils.java
@@ -78,6 +78,7 @@ import org.springframework.util.StringUtils;
  * @author Jędrzej Biedrzycki
  * @author Darin Manica
  * @author Simon Paradies
+ * @author Vladislav Yukharin
  */
 public abstract class QueryUtils {
 
@@ -292,7 +293,7 @@ public abstract class QueryUtils {
 	 * @return {@code true} if the query has {@code order by} clause, {@code false} otherwise
 	 */
 	private static boolean hasOrderByClause(String query) {
-		return countOccurences(ORDER_BY, query) > countOccurences(ORDER_BY_IN_WINDOW_OR_SUBSELECT, query);
+		return countOccurrences(ORDER_BY, query) > countOccurrences(ORDER_BY_IN_WINDOW_OR_SUBSELECT, query);
 	}
 
 	/**
@@ -300,17 +301,17 @@ public abstract class QueryUtils {
 	 *
 	 * @param pattern regex with a group to match
 	 * @param string analysed string
-	 * @return the number of occurences of the pattern in the string
+	 * @return the number of occurrences of the pattern in the string
 	 */
-	private static int countOccurences(Pattern pattern, String string) {
+	private static int countOccurrences(Pattern pattern, String string) {
 
 		Matcher matcher = pattern.matcher(string);
 
-		int occurences = 0;
+		int occurrences = 0;
 		while (matcher.find()) {
-			occurences++;
+			occurrences++;
 		}
-		return occurences;
+		return occurrences;
 	}
 
 	/**


### PR DESCRIPTION
Replaced incorrect spelling 'occurences' with correct 'occurrences' for 'countOccurrences' method of QueryUtils class

[V] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
[V] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
[V] You submit test cases (unit or integration tests) that back your changes.
[V] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
