### PR TITLE
Made `JSqlParserQueryEnhancer` aware of `INSERT` statements.

### DIFF
--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/JSqlParserQueryEnhancer.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/JSqlParserQueryEnhancer.java
@@ -26,6 +26,7 @@ import net.sf.jsqlparser.parser.CCJSqlParserUtil;
 import net.sf.jsqlparser.schema.Column;
 import net.sf.jsqlparser.statement.Statement;
 import net.sf.jsqlparser.statement.delete.Delete;
+import net.sf.jsqlparser.statement.insert.Insert;
 import net.sf.jsqlparser.statement.select.OrderByElement;
 import net.sf.jsqlparser.statement.select.PlainSelect;
 import net.sf.jsqlparser.statement.select.Select;
@@ -82,7 +83,9 @@ public class JSqlParserQueryEnhancer implements QueryEnhancer {
 		try {
 			Statement statement = CCJSqlParserUtil.parse(this.query.getQueryString());
 
-			if (statement instanceof Update) {
+			if (statement instanceof Insert) {
+				return ParsedType.INSERT;
+			} else if (statement instanceof Update) {
 				return ParsedType.UPDATE;
 			} else if (statement instanceof Delete) {
 				return ParsedType.DELETE;
@@ -475,10 +478,11 @@ public class JSqlParserQueryEnhancer implements QueryEnhancer {
 	 * <li>{@code ParsedType.DELETE}: means the top level statement is {@link Delete}</li>
 	 * <li>{@code ParsedType.UPDATE}: means the top level statement is {@link Update}</li>
 	 * <li>{@code ParsedType.SELECT}: means the top level statement is {@link Select}</li>
+	 * <li>{@code ParsedType.INSERT}: means the top level statement is {@link Insert}</li>
 	 * </ul>
 	 */
 	enum ParsedType {
-		DELETE, UPDATE, SELECT;
+		DELETE, UPDATE, SELECT, INSERT;
 	}
 
 }

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/UserRepositoryTests.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/UserRepositoryTests.java
@@ -2968,6 +2968,35 @@ public class UserRepositoryTests {
 		assertThat(foundData).containsExactly("joachim", "dave", "kevin");
 	}
 
+	@Test // GH-2593
+	void insertStatementModifyingQueryWorks() {
+		flushTestUsers();
+		repository.insertNewUserWithNativeQuery();
+
+		List<User> all = repository.findAll();
+		assertThat(all) //
+				.isNotNull() //
+				.isNotEmpty() //
+				.hasSize(5) //
+				.map(User::getLastname) //
+				.contains("Gierke", "Arrasz", "Matthews", "raymond", "K");
+	}
+
+	@Test // GH-2593
+	void insertStatementModifyingQueryWithParamsWorks() {
+		flushTestUsers();
+		String testLastName = "TestLastName";
+		repository.insertNewUserWithParamNativeQuery(testLastName);
+
+		List<User> all = repository.findAll();
+		assertThat(all) //
+				.isNotNull() //
+				.isNotEmpty() //
+				.hasSize(5) //
+				.map(User::getLastname) //
+				.contains("Gierke", "Arrasz", "Matthews", "raymond", testLastName);
+	}
+
 	private Page<User> executeSpecWithSort(Sort sort) {
 
 		flushTestUsers();

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/QueryEnhancerUnitTests.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/QueryEnhancerUnitTests.java
@@ -889,6 +889,44 @@ class QueryEnhancerUnitTests {
 		assertThat(queryEnhancer.hasConstructorExpression()).isFalse();
 	}
 
+	@ParameterizedTest // GH-2593
+	@MethodSource("insertStatementIsProcessedSameAsDefaultSource")
+	void insertStatementIsProcessedSameAsDefault(String insertQuery) {
+
+		StringQuery stringQuery = new StringQuery(insertQuery, true);
+		QueryEnhancer queryEnhancer = QueryEnhancerFactory.forQuery(stringQuery);
+
+		Sort sorting = Sort.by("day").descending();
+
+		// queryutils results
+		String queryUtilsDetectAlias = QueryUtils.detectAlias(insertQuery);
+		String queryUtilsProjection = QueryUtils.getProjection(insertQuery);
+		String queryUtilsCountQuery = QueryUtils.createCountQueryFor(insertQuery);
+		Set<String> queryUtilsOuterJoinAlias = QueryUtils.getOuterJoinAliases(insertQuery);
+
+		// direct access
+		assertThat(stringQuery.getAlias()).isEqualToIgnoringCase(queryUtilsDetectAlias);
+		assertThat(stringQuery.getProjection()).isEqualToIgnoringCase(queryUtilsProjection);
+		assertThat(stringQuery.hasConstructorExpression()).isFalse();
+
+		// access over enhancer
+		assertThat(queryEnhancer.createCountQueryFor()).isEqualToIgnoringCase(queryUtilsCountQuery);
+		assertThat(queryEnhancer.applySorting(sorting)).isEqualTo(insertQuery); // cant check with queryutils result since
+																																						// query utils appens order by which is not
+																																						// supported by sql standard.
+		assertThat(queryEnhancer.getJoinAliases()).isEqualTo(queryUtilsOuterJoinAlias);
+		assertThat(queryEnhancer.detectAlias()).isEqualToIgnoringCase(queryUtilsDetectAlias);
+		assertThat(queryEnhancer.getProjection()).isEqualToIgnoringCase(queryUtilsProjection);
+		assertThat(queryEnhancer.hasConstructorExpression()).isFalse();
+	}
+
+	public static Stream<Arguments> insertStatementIsProcessedSameAsDefaultSource() {
+		return Stream.of( //
+				Arguments.of("INSERT INTO FOO(A) VALUES('A')"), //
+				Arguments.of("INSERT INTO randomsecondTable(A,B,C,D) VALUES('A','B','C','D')") //
+		);
+	}
+
 	public static Stream<Arguments> detectsJoinAliasesCorrectlySource() {
 
 		return Stream.of( //

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/sample/UserRepository.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/sample/UserRepository.java
@@ -55,6 +55,7 @@ import org.springframework.transaction.annotation.Transactional;
  * @author JyotirmoyVS
  * @author Greg Turnquist
  * @author Simon Paradies
+ * @author Diego Krupitza
  */
 public interface UserRepository
 		extends JpaRepository<User, Integer>, JpaSpecificationExecutor<User>, UserRepositoryCustom {
@@ -675,6 +676,20 @@ public interface UserRepository
 			+ "select lower(s.firstname) as lowFirst from sample_data as s,another as a where s.firstname = a.firstname ",
 			nativeQuery = true)
 	List<String> complexWithNativeStatement();
+
+	// GH-2593
+	@Modifying
+	@Query(
+			value = "INSERT INTO SD_User(id,active,age,firstname,lastname,emailAddress,DTYPE) VALUES (9999,true,23,'Diego','K','dk@email.com','User')",
+			nativeQuery = true)
+	void insertNewUserWithNativeQuery();
+
+	// GH-2593
+	@Modifying
+	@Query(
+			value = "INSERT INTO SD_User(id,active,age,firstname,lastname,emailAddress,DTYPE) VALUES (9999,true,23,'Diego',:lastname,'dk@email.com','User')",
+			nativeQuery = true)
+	void insertNewUserWithParamNativeQuery(@Param("lastname") String lastname);
 
 	interface RolesAndFirstname {
 


### PR DESCRIPTION
The `detectParsedType()` inside `JSqlParserQueryEnhancer` is now aware of `INSERT` statements, which means `INSERT` statements can now be used in native queries.

Closes #2593

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
