### PR TITLE
Support Contains with ElementCollection of type String.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-jpa-parent</artifactId>
-	<version>3.0.0-SNAPSHOT</version>
+	<version>3.0.0-2607-contains-for-collections-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data JPA Parent</name>

--- a/spring-data-envers/pom.xml
+++ b/spring-data-envers/pom.xml
@@ -5,12 +5,12 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-envers</artifactId>
-	<version>3.0.0-SNAPSHOT</version>
+	<version>3.0.0-2607-contains-for-collections-SNAPSHOT</version>
 
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-jpa-parent</artifactId>
-		<version>3.0.0-SNAPSHOT</version>
+		<version>3.0.0-2607-contains-for-collections-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-jpa-distribution/pom.xml
+++ b/spring-data-jpa-distribution/pom.xml
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-jpa-parent</artifactId>
-		<version>3.0.0-SNAPSHOT</version>
+		<version>3.0.0-2607-contains-for-collections-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-jpa/pom.xml
+++ b/spring-data-jpa/pom.xml
@@ -6,7 +6,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-jpa</artifactId>
-	<version>3.0.0-SNAPSHOT</version>
+	<version>3.0.0-2607-contains-for-collections-SNAPSHOT</version>
 
 	<name>Spring Data JPA</name>
 	<description>Spring Data module for JPA repositories.</description>
@@ -15,7 +15,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-jpa-parent</artifactId>
-		<version>3.0.0-SNAPSHOT</version>
+		<version>3.0.0-2607-contains-for-collections-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/ParameterMetadataProvider.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/ParameterMetadataProvider.java
@@ -196,6 +196,7 @@ class ParameterMetadataProvider {
 		private final ParameterExpression<T> expression;
 		private final EscapeCharacter escape;
 		private final boolean ignoreCase;
+		private final boolean noWildcards;
 
 		/**
 		 * Creates a new {@link ParameterMetadata}.
@@ -206,6 +207,7 @@ class ParameterMetadataProvider {
 			this.expression = expression;
 			this.type = value == null && Type.SIMPLE_PROPERTY.equals(part.getType()) ? Type.IS_NULL : part.getType();
 			this.ignoreCase = IgnoreCaseType.ALWAYS.equals(part.shouldIgnoreCase());
+			this.noWildcards = part.getProperty().getLeafProperty().isCollection();
 			this.escape = escape;
 		}
 
@@ -241,7 +243,7 @@ class ParameterMetadataProvider {
 				return value;
 			}
 
-			if (String.class.equals(expressionType)) {
+			if (String.class.equals(expressionType) && !noWildcards) {
 
 				switch (type) {
 					case STARTING_WITH:

--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/QueryParameterSetterFactory.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/QueryParameterSetterFactory.java
@@ -15,11 +15,11 @@
  */
 package org.springframework.data.jpa.repository.query;
 
-import java.util.List;
-import java.util.function.Function;
-
 import jakarta.persistence.Query;
 import jakarta.persistence.TemporalType;
+
+import java.util.List;
+import java.util.function.Function;
 
 import org.springframework.data.jpa.repository.query.JpaParameters.JpaParameter;
 import org.springframework.data.jpa.repository.query.ParameterMetadataProvider.ParameterMetadata;
@@ -260,7 +260,7 @@ abstract class QueryParameterSetterFactory {
 	private static class CriteriaQueryParameterSetterFactory extends QueryParameterSetterFactory {
 
 		private final JpaParameters parameters;
-		private final List<ParameterMetadata<?>> expressions;
+		private final List<ParameterMetadata<?>> parameterMetadata;
 
 		/**
 		 * Creates a new {@link QueryParameterSetterFactory} from the given {@link JpaParameters} and
@@ -275,7 +275,7 @@ abstract class QueryParameterSetterFactory {
 			Assert.notNull(metadata, "Expressions must not be null");
 
 			this.parameters = parameters;
-			this.expressions = metadata;
+			this.parameterMetadata = metadata;
 		}
 
 		@Override
@@ -284,15 +284,15 @@ abstract class QueryParameterSetterFactory {
 			int parameterIndex = binding.getRequiredPosition() - 1;
 
 			Assert.isTrue( //
-					parameterIndex < expressions.size(), //
+					parameterIndex < parameterMetadata.size(), //
 					() -> String.format( //
 							"At least %s parameter(s) provided but only %s parameter(s) present in query", //
 							binding.getRequiredPosition(), //
-							expressions.size() //
+							parameterMetadata.size() //
 					) //
 			);
 
-			ParameterMetadata<?> metadata = expressions.get(parameterIndex);
+			ParameterMetadata<?> metadata = parameterMetadata.get(parameterIndex);
 
 			if (metadata.isIsNullParameter()) {
 				return QueryParameterSetter.NOOP;
@@ -301,9 +301,8 @@ abstract class QueryParameterSetterFactory {
 			JpaParameter parameter = parameters.getBindableParameter(parameterIndex);
 			TemporalType temporalType = parameter.isTemporalParameter() ? parameter.getRequiredTemporalType() : null;
 
-			return new NamedOrIndexedQueryParameterSetter(values -> {
-				return getAndPrepare(parameter, metadata, values);
-			}, metadata.getExpression(), temporalType);
+			return new NamedOrIndexedQueryParameterSetter(values -> getAndPrepare(parameter, metadata, values),
+					metadata.getExpression(), temporalType);
 		}
 
 		@Nullable

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/UserRepositoryTests.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/UserRepositoryTests.java
@@ -2968,6 +2968,24 @@ public class UserRepositoryTests {
 		assertThat(foundData).containsExactly("joachim", "dave", "kevin");
 	}
 
+	@Test // GH-2607
+	void containsWithCollection(){
+
+		firstUser.getAttributes().add("cool");
+		firstUser.getAttributes().add("hip");
+
+		secondUser.getAttributes().add("hip");
+
+		thirdUser.getAttributes().add("rockstar");
+		thirdUser.getAttributes().add("%hip%");
+
+		flushTestUsers();
+
+		List<User> result = repository.findByAttributesContains("hip");
+
+		assertThat(result).containsOnly(firstUser, secondUser);
+	}
+
 	private Page<User> executeSpecWithSort(Sort sort) {
 
 		flushTestUsers();

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/sample/UserRepository.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/sample/UserRepository.java
@@ -676,6 +676,9 @@ public interface UserRepository
 			nativeQuery = true)
 	List<String> complexWithNativeStatement();
 
+	// GH-2607
+	List<User> findByAttributesContains(String attribute);
+
 	interface RolesAndFirstname {
 
 		String getFirstname();


### PR DESCRIPTION
Part of the logic considered `contains` on an ElementCollection of type String a like query, wrapping the parameter in wildcards.
This is now fixed.

Closes #2607