### PR TITLE
Fix the JDK version required to build from the source code

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -152,7 +152,7 @@ https://github.com/spring-projects/spring-data-jpa/issues[issue tracker] to see 
 == Building from Source
 
 You don’t need to build from source to use Spring Data (binaries in https://repo.spring.io[repo.spring.io]), but if you want to try out the latest and greatest, Spring Data can be easily built with the https://github.com/takari/maven-wrapper[maven wrapper].
-You also need JDK 1.8.
+You also need JDK 17 or above.
 
 [source,bash]
 ----


### PR DESCRIPTION
Fix the JDK version required to build from the source code #2610

the project spring-data-build has been upgraded to Java 17

[maven-enforcer-plugin](https://github.com/spring-projects/spring-data-build/blob/2f4baf1bb0db09e21d5784b4274b616281efa6b2/pom.xml?_pjax=%23js-repo-pjax-container#L83-L114)

[17,18)