### PR TITLE
Disable domain type inspection.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-jpa-parent</artifactId>
-	<version>3.0.0-SNAPSHOT</version>
+	<version>3.0.x-GH-2628-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data JPA Parent</name>

--- a/spring-data-envers/pom.xml
+++ b/spring-data-envers/pom.xml
@@ -5,12 +5,12 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-envers</artifactId>
-	<version>3.0.0-SNAPSHOT</version>
+	<version>3.0.x-GH-2628-SNAPSHOT</version>
 
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-jpa-parent</artifactId>
-		<version>3.0.0-SNAPSHOT</version>
+		<version>3.0.x-GH-2628-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-jpa-distribution/pom.xml
+++ b/spring-data-jpa-distribution/pom.xml
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-jpa-parent</artifactId>
-		<version>3.0.0-SNAPSHOT</version>
+		<version>3.0.x-GH-2628-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-jpa/pom.xml
+++ b/spring-data-jpa/pom.xml
@@ -6,7 +6,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-jpa</artifactId>
-	<version>3.0.0-SNAPSHOT</version>
+	<version>3.0.x-GH-2628-SNAPSHOT</version>
 
 	<name>Spring Data JPA</name>
 	<description>Spring Data module for JPA repositories.</description>
@@ -15,7 +15,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-jpa-parent</artifactId>
-		<version>3.0.0-SNAPSHOT</version>
+		<version>3.0.x-GH-2628-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/config/JpaRepositoryConfigExtensionUnitTests.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/config/JpaRepositoryConfigExtensionUnitTests.java
@@ -18,11 +18,11 @@ package org.springframework.data.jpa.repository.config;
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
-import java.util.Arrays;
-import java.util.Collections;
-
 import jakarta.persistence.EntityManagerFactory;
 import jakarta.persistence.metamodel.Metamodel;
+
+import java.util.Arrays;
+import java.util.Collections;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -30,7 +30,6 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
-
 import org.springframework.beans.factory.NoSuchBeanDefinitionException;
 import org.springframework.beans.factory.support.BeanDefinitionReaderUtils;
 import org.springframework.beans.factory.support.DefaultListableBeanFactory;
@@ -139,6 +138,13 @@ class JpaRepositoryConfigExtensionUnitTests {
 		ClassLoader classLoader = extension.getConfigurationInspectionClassLoader(context);
 
 		assertThat(classLoader).isNotInstanceOf(InspectionClassLoader.class);
+	}
+
+	@Test // GH-2628
+	void exposesJpaAotProcessor() {
+
+		assertThat(new JpaRepositoryConfigExtension().getRepositoryAotProcessor())
+				.isEqualTo(JpaRepositoryConfigExtension.JpaRepositoryRegistrationAotProcessor.class);
 	}
 
 	private void assertOnlyOnePersistenceAnnotationBeanPostProcessorRegistered(DefaultListableBeanFactory factory,

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/config/JpaRepositoryRegistrationAotProcessorUnitTests.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/config/JpaRepositoryRegistrationAotProcessorUnitTests.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.jpa.repository.config;
+
+import static org.assertj.core.api.Assertions.*;
+
+import jakarta.persistence.Entity;
+
+import java.lang.annotation.Annotation;
+import java.util.Collections;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.aot.generate.ClassNameGenerator;
+import org.springframework.aot.generate.DefaultGenerationContext;
+import org.springframework.aot.generate.GenerationContext;
+import org.springframework.aot.generate.InMemoryGeneratedFiles;
+import org.springframework.aot.hint.predicate.RuntimeHintsPredicates;
+import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
+import org.springframework.core.annotation.MergedAnnotation;
+import org.springframework.data.aot.AotRepositoryContext;
+import org.springframework.data.repository.core.RepositoryInformation;
+
+/**
+ * @author Christoph Strobl
+ */
+class JpaRepositoryRegistrationAotProcessorUnitTests {
+
+	@Test // GH-2628
+	void aotProcessorMustNotRegisterDomainTypes() {
+
+		GenerationContext ctx = new DefaultGenerationContext(new ClassNameGenerator(Object.class),
+				new InMemoryGeneratedFiles());
+
+		new JpaRepositoryConfigExtension.JpaRepositoryRegistrationAotProcessor()
+				.contribute(new DummyAotRepositoryContext() {
+					@Override
+					public Set<Class<?>> getResolvedTypes() {
+						return Collections.singleton(Person.class);
+					}
+				}, ctx);
+
+		assertThat(RuntimeHintsPredicates.reflection().onType(Person.class)).rejects(ctx.getRuntimeHints());
+	}
+
+	@Test // GH-2628
+	void aotProcessorMustNotRegisterAnnotations() {
+
+		GenerationContext ctx = new DefaultGenerationContext(new ClassNameGenerator(Object.class),
+				new InMemoryGeneratedFiles());
+
+		new JpaRepositoryConfigExtension.JpaRepositoryRegistrationAotProcessor()
+				.contribute(new DummyAotRepositoryContext() {
+
+					@Override
+					public Set<MergedAnnotation<Annotation>> getResolvedAnnotations() {
+
+						MergedAnnotation mergedAnnotation = MergedAnnotation.of(Entity.class);
+						return Set.of(mergedAnnotation);
+					}
+				}, ctx);
+
+		assertThat(RuntimeHintsPredicates.reflection().onType(Entity.class)).rejects(ctx.getRuntimeHints());
+	}
+
+	static class Person {}
+
+	static class DummyAotRepositoryContext implements AotRepositoryContext {
+
+		@Override
+		public String getBeanName() {
+			return "jpaRepository";
+		}
+
+		@Override
+		public Set<String> getBasePackages() {
+			return Collections.singleton(this.getClass().getPackageName());
+		}
+
+		@Override
+		public Set<Class<? extends Annotation>> getIdentifyingAnnotations() {
+			return Collections.singleton(Entity.class);
+		}
+
+		@Override
+		public RepositoryInformation getRepositoryInformation() {
+			return null;
+		}
+
+		@Override
+		public Set<MergedAnnotation<Annotation>> getResolvedAnnotations() {
+			return null;
+		}
+
+		@Override
+		public Set<Class<?>> getResolvedTypes() {
+			return null;
+		}
+
+		@Override
+		public ConfigurableListableBeanFactory getBeanFactory() {
+			return null;
+		}
+
+		@Override
+		public TypeIntrospector introspectType(String typeName) {
+			return null;
+		}
+
+		@Override
+		public IntrospectedBeanDefinition introspectBeanDefinition(String beanName) {
+			return null;
+		}
+	}
+}


### PR DESCRIPTION
JPA managed types are now registered via `PersistenceManagedTypes` in `spring.orm` so there is no need to do it twice.

Closes: #2628 