### PR TITLE
Fix generics for JpaSpecificationExecutor::findBy

### DIFF
--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/JpaSpecificationExecutor.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/JpaSpecificationExecutor.java
@@ -32,6 +32,7 @@ import org.springframework.lang.Nullable;
  * @author Oliver Gierke
  * @author Christoph Strobl
  * @author Diego Krupitza
+ * @author Yanming Zhou
  */
 public interface JpaSpecificationExecutor<T> {
 
@@ -104,6 +105,6 @@ public interface JpaSpecificationExecutor<T> {
 	 * @return all entities matching the given Example.
 	 * @since 3.0
 	 */
-	<S extends T, R> R findBy(Specification<T> spec, Function<FluentQuery.FetchableFluentQuery<S>, R> queryFunction);
+	<R> R findBy(Specification<T> spec, Function<FluentQuery.FetchableFluentQuery<T>, R> queryFunction);
 
 }

--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/support/SimpleJpaRepository.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/support/SimpleJpaRepository.java
@@ -575,17 +575,17 @@ public class SimpleJpaRepository<T, ID> implements JpaRepositoryImplementation<T
 	}
 
 	@Override
-	public <S extends T, R> R findBy(Specification<T> spec, Function<FetchableFluentQuery<S>, R> queryFunction) {
+	public <R> R findBy(Specification<T> spec, Function<FetchableFluentQuery<T>, R> queryFunction) {
 
 		Assert.notNull(spec, "Specification must not be null");
 		Assert.notNull(queryFunction, "Query function must not be null");
 
 		Function<Sort, TypedQuery<T>> finder = sort -> getQuery(spec, getDomainClass(), sort);
 
-		FetchableFluentQuery<R> fluentQuery = new FetchableFluentQueryBySpecification<T, R>(spec, getDomainClass(),
+		FetchableFluentQuery<T> fluentQuery = new FetchableFluentQueryBySpecification<>(spec, getDomainClass(),
 				Sort.unsorted(), null, finder, this::count, this::exists, this.em);
 
-		return queryFunction.apply((FetchableFluentQuery<S>) fluentQuery);
+		return queryFunction.apply(fluentQuery);
 	}
 
 	@Override


### PR DESCRIPTION
`Specification<T>` does not hold type `S` like `Example<S>`