### PR TITLE
Improve query method validation exceptions for declared queries

### DIFF
--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/SimpleJpaQueryUnitTests.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/SimpleJpaQueryUnitTests.java
@@ -37,7 +37,6 @@ import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
-
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -175,14 +174,15 @@ class SimpleJpaQueryUnitTests {
 	}
 
 	@Test // DATAJPA-352
-	@SuppressWarnings("unchecked")
 	void validatesAndRejectsCountQueryIfPagingMethod() throws Exception {
 
 		Method method = SampleRepository.class.getMethod("pageByAnnotatedQuery", Pageable.class);
 
 		when(em.createQuery(Mockito.contains("count"))).thenThrow(IllegalArgumentException.class);
 
-		assertThatIllegalArgumentException().isThrownBy(() -> createJpaQuery(method)).withMessageContaining("Count")
+		assertThatIllegalArgumentException() //
+				.isThrownBy(() -> createJpaQuery(method)) //
+				.withMessageContaining("Count") //
 				.withMessageContaining(method.getName());
 	}
 


### PR DESCRIPTION
When validating manually declared queries on repositories, the exception that captures the query to validate now actually also reports it in the exception message.

Related ticket: #2736.

NOTE: This could be further improved. See comments on the original ticket.