### PR TITLE
Change calls to deprecated methods in tests to their replacements.

### DIFF
--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/mapping/JpaPersistentPropertyImpl.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/mapping/JpaPersistentPropertyImpl.java
@@ -32,7 +32,6 @@ import org.springframework.data.mapping.PersistentEntity;
 import org.springframework.data.mapping.model.AnnotationBasedPersistentProperty;
 import org.springframework.data.mapping.model.Property;
 import org.springframework.data.mapping.model.SimpleTypeHolder;
-import org.springframework.data.util.ClassTypeInformation;
 import org.springframework.data.util.Lazy;
 import org.springframework.data.util.TypeInformation;
 import org.springframework.lang.Nullable;
@@ -46,6 +45,7 @@ import org.springframework.util.Assert;
  * @author Greg Turnquist
  * @author Christoph Strobl
  * @author Mark Paluch
+ * @author Erik Pellizzon
  * @since 1.3
  */
 class JpaPersistentPropertyImpl extends AnnotationBasedPersistentProperty<JpaPersistentProperty>
@@ -254,7 +254,7 @@ class JpaPersistentPropertyImpl extends AnnotationBasedPersistentProperty<JpaPer
 				continue;
 			}
 
-			return ClassTypeInformation.from((Class<?>) entityValue);
+			return TypeInformation.of((Class<?>) entityValue);
 		}
 
 		return null;

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/infrastructure/HibernateTestUtils.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/infrastructure/HibernateTestUtils.java
@@ -26,6 +26,7 @@ import org.springframework.util.ClassUtils;
  * Testing utilities for Hibernate.
  *
  * @author Oliver Gierke
+ * @author Erik Pellizzon
  * @soundtrack Ron Spielman - Africa's Napoleon (Swimming In The Dark)
  * @since 1.10.2
  */
@@ -48,7 +49,7 @@ public class HibernateTestUtils {
 			if (ClassUtils.isPresent(provider, classLoader)) {
 
 				try {
-					return (PersistenceProvider) ClassUtils.forName(provider, classLoader).newInstance();
+					return (PersistenceProvider) ClassUtils.forName(provider, classLoader).getDeclaredConstructor().newInstance();
 				} catch (Exception o_O) {
 					throw new RuntimeException(o_O);
 				}

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/mapping/JpaPersistentPropertyImplUnitTests.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/mapping/JpaPersistentPropertyImplUnitTests.java
@@ -43,7 +43,6 @@ import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 import org.springframework.data.annotation.AccessType.Type;
 import org.springframework.data.annotation.Version;
-import org.springframework.data.util.ClassTypeInformation;
 import org.springframework.data.util.TypeInformation;
 
 /**
@@ -52,6 +51,7 @@ import org.springframework.data.util.TypeInformation;
  * @author Oliver Gierke
  * @author Greg Turnquist
  * @author Jens Schauder
+ * @author Erik Pellizzon
  */
 @ExtendWith(MockitoExtension.class)
 @MockitoSettings(strictness = Strictness.LENIENT)
@@ -147,7 +147,7 @@ public class JpaPersistentPropertyImplUnitTests {
 		Iterable<? extends TypeInformation<?>> entityType = property.getPersistentEntityTypeInformation();
 		assertThat(entityType.iterator().hasNext()).isTrue();
 		assertThat(entityType.iterator().next())
-				.isEqualTo(ClassTypeInformation.from(Implementation.class));
+				.isEqualTo(TypeInformation.of(Implementation.class));
 	}
 
 	@Test // DATAJPA-716

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/config/JpaRepositoriesRegistrarIntegrationTests.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/config/JpaRepositoriesRegistrarIntegrationTests.java
@@ -28,6 +28,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 
 import org.springframework.aop.Advisor;
 import org.springframework.aop.framework.Advised;
+import org.springframework.aop.support.AopUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -43,13 +44,13 @@ import org.springframework.stereotype.Repository;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.transaction.PlatformTransactionManager;
-import org.springframework.util.ClassUtils;
 
 /**
  * Integration test for {@link JpaRepositoriesRegistrar}.
  *
  * @author Oliver Gierke
  * @author Jens Schauder
+ * @author Erik Pellizzon
  */
 @ExtendWith(SpringExtension.class)
 @ContextConfiguration
@@ -103,7 +104,7 @@ public class JpaRepositoriesRegistrarIntegrationTests {
 	void doesNotProxyPlainAtRepositoryBeans() {
 
 		assertThat(sampleRepository).isNotNull();
-		assertThat(ClassUtils.isCglibProxy(sampleRepository)).isFalse();
+		assertThat(AopUtils.isCglibProxy(sampleRepository)).isFalse();
 
 		assertExceptionTranslationActive(repository);
 	}

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/config/JpaRepositoriesRegistrarUnitTests.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/config/JpaRepositoriesRegistrarUnitTests.java
@@ -26,7 +26,6 @@ import org.springframework.beans.factory.support.DefaultListableBeanFactory;
 import org.springframework.core.env.StandardEnvironment;
 import org.springframework.core.io.DefaultResourceLoader;
 import org.springframework.core.type.AnnotationMetadata;
-import org.springframework.core.type.StandardAnnotationMetadata;
 import org.springframework.data.jpa.repository.sample.UserRepository;
 
 /**
@@ -34,6 +33,7 @@ import org.springframework.data.jpa.repository.sample.UserRepository;
  *
  * @author Oliver Gierke
  * @author Jens Schauder
+ * @author Erik Pellizzon
  */
 class JpaRepositoriesRegistrarUnitTests {
 
@@ -43,7 +43,7 @@ class JpaRepositoriesRegistrarUnitTests {
 	@BeforeEach
 	void setUp() {
 
-		metadata = new StandardAnnotationMetadata(Config.class, true);
+		metadata = AnnotationMetadata.introspect(Config.class);
 		registry = new DefaultListableBeanFactory();
 	}
 

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/JpaQueryMethodUnitTests.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/JpaQueryMethodUnitTests.java
@@ -56,7 +56,7 @@ import org.springframework.data.repository.core.RepositoryMetadata;
 import org.springframework.data.repository.core.support.DefaultRepositoryMetadata;
 import org.springframework.data.repository.query.Param;
 import org.springframework.data.repository.query.QueryMethod;
-import org.springframework.data.util.ClassTypeInformation;
+import org.springframework.data.util.TypeInformation;
 
 /**
  * Unit test for {@link QueryMethod}.
@@ -66,6 +66,7 @@ import org.springframework.data.util.ClassTypeInformation;
  * @author Christoph Strobl
  * @author Jens Schauder
  * @author Mark Paluch
+ * @author Erik Pellizzon
  */
 @ExtendWith(MockitoExtension.class)
 @MockitoSettings(strictness = Strictness.LENIENT)
@@ -107,7 +108,7 @@ public class JpaQueryMethodUnitTests {
 				Integer.class);
 
 		when(metadata.getReturnType(any(Method.class)))
-				.thenAnswer(invocation -> ClassTypeInformation.fromReturnTypeOf(invocation.getArgument(0)));
+				.thenAnswer(invocation -> TypeInformation.fromReturnTypeOf(invocation.getArgument(0)));
 	}
 
 	@Test

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/NamedQueryUnitTests.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/NamedQueryUnitTests.java
@@ -41,7 +41,7 @@ import org.springframework.data.projection.ProjectionFactory;
 import org.springframework.data.projection.SpelAwareProxyProjectionFactory;
 import org.springframework.data.repository.core.RepositoryMetadata;
 import org.springframework.data.repository.query.QueryCreationException;
-import org.springframework.data.util.ClassTypeInformation;
+import org.springframework.data.util.TypeInformation;
 
 /**
  * Unit tests for {@link NamedQuery}.
@@ -49,6 +49,7 @@ import org.springframework.data.util.ClassTypeInformation;
  * @author Oliver Gierke
  * @author Thomas Darimont
  * @author Mark Paluch
+ * @author Erik Pellizzon
  */
 @ExtendWith(MockitoExtension.class)
 @MockitoSettings(strictness = Strictness.LENIENT)
@@ -72,7 +73,7 @@ class NamedQueryUnitTests {
 		when(metadata.getDomainType()).thenReturn((Class) String.class);
 		when(metadata.getReturnedDomainClass(method)).thenReturn((Class) String.class);
 		when(metadata.getReturnType(any(Method.class)))
-				.thenAnswer(invocation -> ClassTypeInformation.fromReturnTypeOf(invocation.getArgument(0)));
+				.thenAnswer(invocation -> TypeInformation.fromReturnTypeOf(invocation.getArgument(0)));
 
 		when(em.getMetamodel()).thenReturn(metamodel);
 		when(em.getEntityManagerFactory()).thenReturn(emf);

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/QueryUtilsUnitTests.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/QueryUtilsUnitTests.java
@@ -30,7 +30,6 @@ import org.springframework.dao.InvalidDataAccessApiUsageException;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.domain.Sort.Order;
 import org.springframework.data.jpa.domain.JpaSort;
-import org.springframework.util.StringUtils;
 
 /**
  * Unit test for {@link QueryUtils}.
@@ -48,6 +47,7 @@ import org.springframework.util.StringUtils;
  * @author Darin Manica
  * @author Chris Fraser
  * @author Michał Pachucki
+ * @author Erik Pellizzon
  */
 class QueryUtilsUnitTests {
 
@@ -264,7 +264,7 @@ class QueryUtilsUnitTests {
 			return matcher.replaceAll(" ").trim();
 		}
 
-		return StringUtils.trimWhitespace(s);
+		return s.strip();
 	}
 
 	@Test

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/SimpleJpaQueryUnitTests.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/SimpleJpaQueryUnitTests.java
@@ -52,7 +52,7 @@ import org.springframework.data.projection.SpelAwareProxyProjectionFactory;
 import org.springframework.data.repository.core.RepositoryMetadata;
 import org.springframework.data.repository.query.QueryMethodEvaluationContextProvider;
 import org.springframework.data.repository.query.RepositoryQuery;
-import org.springframework.data.util.ClassTypeInformation;
+import org.springframework.data.util.TypeInformation;
 import org.springframework.expression.spel.standard.SpelExpressionParser;
 
 /**
@@ -64,6 +64,7 @@ import org.springframework.expression.spel.standard.SpelExpressionParser;
  * @author Tom Hombergs
  * @author Mark Paluch
  * @author Greg Turnquist
+ * @author Erik Pellizzon
  */
 @ExtendWith(MockitoExtension.class)
 @MockitoSettings(strictness = Strictness.LENIENT)
@@ -99,7 +100,7 @@ class SimpleJpaQueryUnitTests {
 		when(metadata.getDomainType()).thenReturn((Class) User.class);
 		when(metadata.getReturnedDomainClass(Mockito.any(Method.class))).thenReturn((Class) User.class);
 		when(metadata.getReturnType(Mockito.any(Method.class)))
-				.thenAnswer(invocation -> ClassTypeInformation.fromReturnTypeOf(invocation.getArgument(0)));
+				.thenAnswer(invocation -> TypeInformation.fromReturnTypeOf(invocation.getArgument(0)));
 
 		Method setUp = UserRepository.class.getMethod("findByLastname", String.class);
 		method = new JpaQueryMethod(setUp, metadata, factory, extractor);


### PR DESCRIPTION
ClassTypeInformation is deprecated and will be removed, use TypeInformation instead. 

StringUtils.trimWhitespace can be replaced with the strip method called on the String object. StandardAnnotationMetadata is deprecated in favor of the factory method AnnotationMetadata.introspect(Class).