### PR TITLE
Fix typo on JpaMetamodelMappingContext & MergingPersistenceUnitManager

### DIFF
--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/mapping/JpaMetamodelMappingContext.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/mapping/JpaMetamodelMappingContext.java
@@ -180,7 +180,7 @@ public class JpaMetamodelMappingContext
 				} catch (IllegalArgumentException o_O) {
 
 					// Fall back to inspect *all* managed types manually as Metamodel.managedType(…) only
-					// returns for entities, embeddables and managed supperclasses.
+					// returns for entities, embeddables and managed superclasses.
 
 					for (ManagedType<?> managedType : model.getManagedTypes()) {
 						if (type.equals(managedType.getJavaType())) {

--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/support/MergingPersistenceUnitManager.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/support/MergingPersistenceUnitManager.java
@@ -27,7 +27,7 @@ import org.springframework.orm.jpa.persistenceunit.MutablePersistenceUnitInfo;
 
 /**
  * Extends {@link DefaultPersistenceUnitManager} to merge configurations of one persistence unit residing in multiple
- * {@code persistence.xml} files into one. This is necessary to allow the declaration of entities in seperate modules.
+ * {@code persistence.xml} files into one. This is necessary to allow the declaration of entities in separate modules.
  *
  * @author Oliver Gierke
  * @link https://github.com/spring-projects/spring-framework/issues/7287


### PR DESCRIPTION
Hello, Just a small change to fix typos within the docs.
thanks.

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
