### PR TITLE
Differentiate between JPQL and native queries in count query derivation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-jpa-parent</artifactId>
-	<version>3.1.0-SNAPSHOT</version>
+	<version>3.1.0-GH-2773-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data JPA Parent</name>

--- a/spring-data-envers/pom.xml
+++ b/spring-data-envers/pom.xml
@@ -5,12 +5,12 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-envers</artifactId>
-	<version>3.1.0-SNAPSHOT</version>
+	<version>3.1.0-GH-2773-SNAPSHOT</version>
 
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-jpa-parent</artifactId>
-		<version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0-GH-2773-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-jpa-distribution/pom.xml
+++ b/spring-data-jpa-distribution/pom.xml
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-jpa-parent</artifactId>
-		<version>3.1.0-SNAPSHOT</version>
+		<version>3.1.0-GH-2773-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-jpa/pom.xml
+++ b/spring-data-jpa/pom.xml
@@ -6,7 +6,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-jpa</artifactId>
-	<version>3.1.0-SNAPSHOT</version>
+	<version>3.1.0-GH-2773-SNAPSHOT</version>
 
 	<name>Spring Data JPA</name>
 	<description>Spring Data module for JPA repositories.</description>
@@ -15,7 +15,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-jpa-parent</artifactId>
-		<version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0-GH-2773-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/DefaultQueryEnhancer.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/DefaultQueryEnhancer.java
@@ -46,7 +46,7 @@ public class DefaultQueryEnhancer implements QueryEnhancer {
 
 	@Override
 	public String createCountQueryFor(@Nullable String countProjection) {
-		return QueryUtils.createCountQueryFor(this.query.getQueryString(), countProjection);
+		return QueryUtils.createCountQueryFor(this.query.getQueryString(), countProjection, this.query.isNativeQuery());
 	}
 
 	@Override

--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/JSqlParserQueryEnhancer.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/JSqlParserQueryEnhancer.java
@@ -15,9 +15,8 @@
  */
 package org.springframework.data.jpa.repository.query;
 
-import static org.springframework.data.jpa.repository.query.JSqlParserUtils.getJSqlCount;
-import static org.springframework.data.jpa.repository.query.JSqlParserUtils.getJSqlLower;
-import static org.springframework.data.jpa.repository.query.QueryUtils.checkSortExpression;
+import static org.springframework.data.jpa.repository.query.JSqlParserUtils.*;
+import static org.springframework.data.jpa.repository.query.QueryUtils.*;
 
 import net.sf.jsqlparser.JSQLParserException;
 import net.sf.jsqlparser.expression.Alias;
@@ -29,11 +28,23 @@ import net.sf.jsqlparser.statement.Statement;
 import net.sf.jsqlparser.statement.delete.Delete;
 import net.sf.jsqlparser.statement.insert.Insert;
 import net.sf.jsqlparser.statement.merge.Merge;
-import net.sf.jsqlparser.statement.select.*;
+import net.sf.jsqlparser.statement.select.OrderByElement;
+import net.sf.jsqlparser.statement.select.PlainSelect;
+import net.sf.jsqlparser.statement.select.Select;
+import net.sf.jsqlparser.statement.select.SelectBody;
+import net.sf.jsqlparser.statement.select.SelectExpressionItem;
+import net.sf.jsqlparser.statement.select.SelectItem;
+import net.sf.jsqlparser.statement.select.SetOperationList;
+import net.sf.jsqlparser.statement.select.WithItem;
 import net.sf.jsqlparser.statement.update.Update;
 import net.sf.jsqlparser.statement.values.ValuesStatement;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.springframework.data.domain.Sort;
@@ -400,7 +411,7 @@ public class JSqlParserQueryEnhancer implements QueryEnhancer {
 			return selectBody.toString();
 		}
 
-		String countProp = tableAlias == null ? "*" : tableAlias;
+		String countProp = query.isNativeQuery() ? (distinct ? "*" : "1") : tableAlias == null ? "*" : tableAlias;
 
 		Function jSqlCount = getJSqlCount(Collections.singletonList(countProp), distinct);
 		selectBody.setSelectItems(Collections.singletonList(new SelectExpressionItem(jSqlCount)));

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/DefaultQueryEnhancerUnitTests.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/DefaultQueryEnhancerUnitTests.java
@@ -15,6 +15,9 @@
  */
 package org.springframework.data.jpa.repository.query;
 
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+
 /**
  * TCK Tests for {@link DefaultQueryEnhancer}.
  *
@@ -27,4 +30,8 @@ public class DefaultQueryEnhancerUnitTests extends QueryEnhancerTckTests {
 		return new DefaultQueryEnhancer(declaredQuery);
 	}
 
+	@Override
+	@Test // GH-2511, GH-2773
+	@Disabled("Not properly supported by QueryUtils")
+	void shouldDeriveNativeCountQueryWithVariable(String query, String expected) {}
 }

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/DefaultQueryEnhancerUnitTests.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/DefaultQueryEnhancerUnitTests.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.jpa.repository.query;
+
+/**
+ * TCK Tests for {@link DefaultQueryEnhancer}.
+ *
+ * @author Mark Paluch
+ */
+public class DefaultQueryEnhancerUnitTests extends QueryEnhancerTckTests {
+
+	@Override
+	QueryEnhancer createQueryEnhancer(DeclaredQuery declaredQuery) {
+		return new DefaultQueryEnhancer(declaredQuery);
+	}
+
+}

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/JSqlParserQueryEnhancerUnitTests.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/JSqlParserQueryEnhancerUnitTests.java
@@ -15,10 +15,23 @@
  */
 package org.springframework.data.jpa.repository.query;
 
+import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assumptions.*;
+
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.data.domain.Sort;
+
 /**
  * TCK Tests for {@link JSqlParserQueryEnhancer}.
  *
  * @author Mark Paluch
+ * @author Diego Krupitza
+ * @author Geoffrey Deremetz
  */
 public class JSqlParserQueryEnhancerUnitTests extends QueryEnhancerTckTests {
 
@@ -27,4 +40,181 @@ public class JSqlParserQueryEnhancerUnitTests extends QueryEnhancerTckTests {
 		return new JSqlParserQueryEnhancer(declaredQuery);
 	}
 
+	@Override
+	@ParameterizedTest // GH-2773
+	@MethodSource("jpqlCountQueries")
+	void shouldDeriveJpqlCountQuery(String query, String expected) {
+
+		assumeThat(query).as("JSQLParser does not support simple JPQL syntax").doesNotStartWithIgnoringCase("FROM");
+
+		assumeThat(query).as("JSQLParser does not support constructor JPQL syntax").doesNotContain(" new ");
+
+		super.shouldDeriveJpqlCountQuery(query, expected);
+	}
+
+	@Test
+	// GH-2578
+	void setOperationListWorks() {
+
+		String setQuery = "select SOME_COLUMN from SOME_TABLE where REPORTING_DATE = :REPORTING_DATE  \n" //
+				+ "except \n" //
+				+ "select SOME_COLUMN from SOME_OTHER_TABLE where REPORTING_DATE = :REPORTING_DATE";
+
+		StringQuery stringQuery = new StringQuery(setQuery, true);
+		QueryEnhancer queryEnhancer = QueryEnhancerFactory.forQuery(stringQuery);
+
+		assertThat(stringQuery.getAlias()).isNullOrEmpty();
+		assertThat(stringQuery.getProjection()).isEqualToIgnoringCase("SOME_COLUMN");
+		assertThat(stringQuery.hasConstructorExpression()).isFalse();
+
+		assertThat(queryEnhancer.createCountQueryFor()).isEqualToIgnoringCase(setQuery);
+		assertThat(queryEnhancer.applySorting(Sort.by("SOME_COLUMN"))).endsWith("ORDER BY SOME_COLUMN ASC");
+		assertThat(queryEnhancer.getJoinAliases()).isEmpty();
+		assertThat(queryEnhancer.detectAlias()).isNullOrEmpty();
+		assertThat(queryEnhancer.getProjection()).isEqualToIgnoringCase("SOME_COLUMN");
+		assertThat(queryEnhancer.hasConstructorExpression()).isFalse();
+	}
+
+	@Test // GH-2578
+	void complexSetOperationListWorks() {
+
+		String setQuery = "select SOME_COLUMN from SOME_TABLE where REPORTING_DATE = :REPORTING_DATE  \n" //
+				+ "except \n" //
+				+ "select SOME_COLUMN from SOME_OTHER_TABLE where REPORTING_DATE = :REPORTING_DATE \n" //
+				+ "union select SOME_COLUMN from SOME_OTHER_OTHER_TABLE";
+
+		StringQuery stringQuery = new StringQuery(setQuery, true);
+		QueryEnhancer queryEnhancer = QueryEnhancerFactory.forQuery(stringQuery);
+
+		assertThat(stringQuery.getAlias()).isNullOrEmpty();
+		assertThat(stringQuery.getProjection()).isEqualToIgnoringCase("SOME_COLUMN");
+		assertThat(stringQuery.hasConstructorExpression()).isFalse();
+
+		assertThat(queryEnhancer.createCountQueryFor()).isEqualToIgnoringCase(setQuery);
+		assertThat(queryEnhancer.applySorting(Sort.by("SOME_COLUMN").ascending())).endsWith("ORDER BY SOME_COLUMN ASC");
+		assertThat(queryEnhancer.getJoinAliases()).isEmpty();
+		assertThat(queryEnhancer.detectAlias()).isNullOrEmpty();
+		assertThat(queryEnhancer.getProjection()).isEqualToIgnoringCase("SOME_COLUMN");
+		assertThat(queryEnhancer.hasConstructorExpression()).isFalse();
+	}
+
+	@Test // GH-2578
+	void deeplyNestedcomplexSetOperationListWorks() {
+
+		String setQuery = "SELECT CustomerID FROM (\n" //
+				+ "\t\t\tselect * from Customers\n" //
+				+ "\t\t\texcept\n"//
+				+ "\t\t\tselect * from Customers where country = 'Austria'\n"//
+				+ "\t)\n" //
+				+ "\texcept\n"//
+				+ "\tselect CustomerID  from customers where country = 'Germany'\n"//
+				+ "\t;";
+
+		StringQuery stringQuery = new StringQuery(setQuery, true);
+		QueryEnhancer queryEnhancer = QueryEnhancerFactory.forQuery(stringQuery);
+
+		assertThat(stringQuery.getAlias()).isNullOrEmpty();
+		assertThat(stringQuery.getProjection()).isEqualToIgnoringCase("CustomerID");
+		assertThat(stringQuery.hasConstructorExpression()).isFalse();
+
+		assertThat(queryEnhancer.createCountQueryFor()).isEqualToIgnoringCase(setQuery);
+		assertThat(queryEnhancer.applySorting(Sort.by("CustomerID").descending())).endsWith("ORDER BY CustomerID DESC");
+		assertThat(queryEnhancer.getJoinAliases()).isEmpty();
+		assertThat(queryEnhancer.detectAlias()).isNullOrEmpty();
+		assertThat(queryEnhancer.getProjection()).isEqualToIgnoringCase("CustomerID");
+		assertThat(queryEnhancer.hasConstructorExpression()).isFalse();
+	}
+
+	@Test // GH-2578
+	void valuesStatementsWorks() {
+
+		String setQuery = "VALUES (1, 2, 'test')";
+
+		StringQuery stringQuery = new StringQuery(setQuery, true);
+		QueryEnhancer queryEnhancer = QueryEnhancerFactory.forQuery(stringQuery);
+
+		assertThat(stringQuery.getAlias()).isNullOrEmpty();
+		assertThat(stringQuery.getProjection()).isNullOrEmpty();
+		assertThat(stringQuery.hasConstructorExpression()).isFalse();
+
+		assertThat(queryEnhancer.createCountQueryFor()).isEqualToIgnoringCase(setQuery);
+		assertThat(queryEnhancer.applySorting(Sort.by("CustomerID").descending())).isEqualTo(setQuery);
+		assertThat(queryEnhancer.getJoinAliases()).isEmpty();
+		assertThat(queryEnhancer.detectAlias()).isNullOrEmpty();
+		assertThat(queryEnhancer.getProjection()).isNullOrEmpty();
+		assertThat(queryEnhancer.hasConstructorExpression()).isFalse();
+	}
+
+	@Test // GH-2578
+	void withStatementsWorks() {
+
+		String setQuery = "with sample_data(day, value) as (values ((0, 13), (1, 12), (2, 15), (3, 4), (4, 8), (5, 16))) \n"
+				+ "select day, value from sample_data as a";
+
+		StringQuery stringQuery = new StringQuery(setQuery, true);
+		QueryEnhancer queryEnhancer = QueryEnhancerFactory.forQuery(stringQuery);
+
+		assertThat(stringQuery.getAlias()).isEqualToIgnoringCase("a");
+		assertThat(stringQuery.getProjection()).isEqualToIgnoringCase("day, value");
+		assertThat(stringQuery.hasConstructorExpression()).isFalse();
+
+		assertThat(queryEnhancer.createCountQueryFor()).isEqualToIgnoringCase(
+				"with sample_data (day, value) AS (VALUES ((0, 13), (1, 12), (2, 15), (3, 4), (4, 8), (5, 16)))\n"
+						+ "SELECT count(1) FROM sample_data AS a");
+		assertThat(queryEnhancer.applySorting(Sort.by("day").descending())).endsWith("ORDER BY a.day DESC");
+		assertThat(queryEnhancer.getJoinAliases()).isEmpty();
+		assertThat(queryEnhancer.detectAlias()).isEqualToIgnoringCase("a");
+		assertThat(queryEnhancer.getProjection()).isEqualToIgnoringCase("day, value");
+		assertThat(queryEnhancer.hasConstructorExpression()).isFalse();
+	}
+
+	@Test // GH-2578
+	void multipleWithStatementsWorks() {
+
+		String setQuery = "with sample_data(day, value) as (values ((0, 13), (1, 12), (2, 15), (3, 4), (4, 8), (5, 16))), test2 as (values (1,2,3)) \n"
+				+ "select day, value from sample_data as a";
+
+		StringQuery stringQuery = new StringQuery(setQuery, true);
+		QueryEnhancer queryEnhancer = QueryEnhancerFactory.forQuery(stringQuery);
+
+		assertThat(stringQuery.getAlias()).isEqualToIgnoringCase("a");
+		assertThat(stringQuery.getProjection()).isEqualToIgnoringCase("day, value");
+		assertThat(stringQuery.hasConstructorExpression()).isFalse();
+
+		assertThat(queryEnhancer.createCountQueryFor()).isEqualToIgnoringCase(
+				"with sample_data (day, value) AS (VALUES ((0, 13), (1, 12), (2, 15), (3, 4), (4, 8), (5, 16))),test2 AS (VALUES (1, 2, 3))\n"
+						+ "SELECT count(1) FROM sample_data AS a");
+		assertThat(queryEnhancer.applySorting(Sort.by("day").descending())).endsWith("ORDER BY a.day DESC");
+		assertThat(queryEnhancer.getJoinAliases()).isEmpty();
+		assertThat(queryEnhancer.detectAlias()).isEqualToIgnoringCase("a");
+		assertThat(queryEnhancer.getProjection()).isEqualToIgnoringCase("day, value");
+		assertThat(queryEnhancer.hasConstructorExpression()).isFalse();
+	}
+
+	@ParameterizedTest // GH-2641
+	@MethodSource("mergeStatementWorksSource")
+	void mergeStatementWorksWithJSqlParser(String query, String alias) {
+
+		StringQuery stringQuery = new StringQuery(query, true);
+		QueryEnhancer queryEnhancer = QueryEnhancerFactory.forQuery(stringQuery);
+
+		assertThat(queryEnhancer.detectAlias()).isEqualTo(alias);
+		assertThat(QueryUtils.detectAlias(query)).isNull();
+
+		assertThat(queryEnhancer.getJoinAliases()).isEmpty();
+		assertThat(queryEnhancer.detectAlias()).isEqualTo(alias);
+		assertThat(queryEnhancer.getProjection()).isEmpty();
+		assertThat(queryEnhancer.hasConstructorExpression()).isFalse();
+	}
+
+	static Stream<Arguments> mergeStatementWorksSource() {
+
+		return Stream.of( //
+				Arguments.of(
+						"merge into a using (select id, value from b) query on (a.id = query.id) when matched then update set a.value = value",
+						"query"),
+				Arguments.of(
+						"merge into a using (select id2, value from b) on (id = id2) when matched then update set a.value = value",
+						null));
+	}
 }

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/JSqlParserQueryEnhancerUnitTests.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/JSqlParserQueryEnhancerUnitTests.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.jpa.repository.query;
+
+/**
+ * TCK Tests for {@link JSqlParserQueryEnhancer}.
+ *
+ * @author Mark Paluch
+ */
+public class JSqlParserQueryEnhancerUnitTests extends QueryEnhancerTckTests {
+
+	@Override
+	QueryEnhancer createQueryEnhancer(DeclaredQuery declaredQuery) {
+		return new JSqlParserQueryEnhancer(declaredQuery);
+	}
+
+}

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/QueryEnhancerTckTests.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/QueryEnhancerTckTests.java
@@ -19,6 +19,7 @@ import static org.assertj.core.api.Assertions.*;
 
 import java.util.stream.Stream;
 
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -36,9 +37,13 @@ abstract class QueryEnhancerTckTests {
 
 		DeclaredQuery declaredQuery = DeclaredQuery.of(query, true);
 		QueryEnhancer enhancer = createQueryEnhancer(declaredQuery);
-		String countQueryFor = enhancer.createCountQueryFor(null);
+		String countQueryFor = enhancer.createCountQueryFor();
 
-		assertThat(countQueryFor).isEqualToIgnoringCase(expected);
+		// lenient cleanup to allow for rendering variance
+		String sanitized = countQueryFor.replaceAll("\r", " ").replaceAll("\n", " ").replaceAll(" {2}", " ")
+				.replaceAll(" {2}", " ").trim();
+
+		assertThat(sanitized).isEqualToIgnoringCase(expected);
 	}
 
 	static Stream<Arguments> nativeCountQueries() {
@@ -53,7 +58,58 @@ abstract class QueryEnhancerTckTests {
 
 				Arguments.of( //
 						"SELECT DISTINCT name FROM table_name some_alias", //
-						"select count(DISTINCT name) FROM table_name some_alias"));
+						"select count(DISTINCT name) FROM table_name some_alias"), //
+
+				Arguments.of( //
+						"select distinct u from User u where u.foo = ?", //
+						"select count(distinct u) from User u where u.foo = ?"),
+
+				Arguments.of( //
+						"select u from User as u", //
+						"select count(u) from User as u"),
+
+				Arguments.of( //
+						"SELECT u FROM User u where u.foo.bar = ?", //
+						"select count(u) FROM User u where u.foo.bar = ?"),
+
+				Arguments.of( //
+						"select p.lastname,p.firstname from Person p", //
+						"select count(1) from Person p"),
+
+				// whitespace quirks
+				Arguments.of( //
+						"""
+								select user.age,
+								  user.name
+								  from User user
+								  where user.age = 18
+								  order
+								by
+								user.name
+								\s""", //
+						"select count(1) from User user where user.age = 18"),
+
+				Arguments.of( //
+						"select * from User user\n" + //
+								"  where user.age = 18\n" + //
+								"  order by user.name\n ", //
+						"select count(1) from User user where user.age = 18"),
+
+				Arguments.of( //
+						"SELECT DISTINCT entity1\nFROM Entity1 entity1\nLEFT JOIN Entity2 entity2 ON entity1.key = entity2.key", //
+						"select count(DISTINCT entity1) FROM Entity1 entity1 LEFT JOIN Entity2 entity2 ON entity1.key = entity2.key"),
+
+				Arguments.of( //
+						"SELECT DISTINCT entity1\nFROM Entity1 entity1 LEFT JOIN Entity2 entity2 ON entity1.key = entity2.key", //
+						"select count(DISTINCT entity1) FROM Entity1 entity1 LEFT JOIN Entity2 entity2 ON entity1.key = entity2.key"),
+
+				Arguments.of( //
+						"SELECT DISTINCT entity1\nFROM Entity1 entity1 LEFT JOIN Entity2 entity2 ON entity1.key = entity2.key\nwhere entity1.id = 1799", //
+						"select count(DISTINCT entity1) FROM Entity1 entity1 LEFT JOIN Entity2 entity2 ON entity1.key = entity2.key where entity1.id = 1799"),
+
+				Arguments.of( //
+						"select distinct m.genre from Media m where m.user = ?1 OrDer  By   m.genre ASC", //
+						"select count(distinct m.genre) from Media m where m.user = ?1"));
 	}
 
 	@ParameterizedTest // GH-2773
@@ -79,7 +135,70 @@ abstract class QueryEnhancerTckTests {
 
 				Arguments.of( //
 						"SELECT DISTINCT name FROM table_name some_alias", //
-						"select count(DISTINCT name) FROM table_name some_alias"));
+						"select count(DISTINCT name) FROM table_name some_alias"),
+
+				Arguments.of( //
+						"select distinct new User(u.name) from User u where u.foo = ?", //
+						"select count(distinct u) from User u where u.foo = ?"),
+
+				Arguments.of( //
+						"FROM User u WHERE u.foo.bar = ?", //
+						"select count(u) FROM User u WHERE u.foo.bar = ?"),
+
+				Arguments.of( //
+						"from User u", //
+						"select count(u) FROM User u"),
+
+				Arguments.of( //
+						"select u from User as u", //
+						"select count(u) from User as u"),
+
+				Arguments.of( //
+						"select p.lastname,p.firstname from Person p", //
+						"select count(p) from Person p"),
+
+				Arguments.of( //
+						"select a.b from A a", //
+						"select count(a.b) from A a"),
+
+				Arguments.of( //
+						"select distinct m.genre from Media m where m.user = ?1 order by m.genre asc", //
+						"select count(distinct m.genre) from Media m where m.user = ?1"));
+	}
+
+	@ParameterizedTest // GH-2511, GH-2773
+	@MethodSource("nativeQueriesWithVariables")
+	void shouldDeriveNativeCountQueryWithVariable(String query, String expected) {
+
+		DeclaredQuery declaredQuery = DeclaredQuery.of(query, true);
+		QueryEnhancer enhancer = createQueryEnhancer(declaredQuery);
+		String countQueryFor = enhancer.createCountQueryFor();
+
+		assertThat(countQueryFor).isEqualToIgnoringCase(expected);
+	}
+
+	static Stream<Arguments> nativeQueriesWithVariables() {
+
+		return Stream.of(Arguments.of( //
+				"SELECT * FROM User WHERE created_at > $1", //
+				"SELECT count(1) FROM User WHERE created_at > $1"), //
+
+				Arguments.of( //
+						"SELECT * FROM (select * from test) ", //
+						"SELECT count(1) FROM (SELECT * FROM test)"), //
+
+				Arguments.of( //
+						"SELECT * FROM (select * from test) as test", //
+						"SELECT count(1) FROM (SELECT * FROM test) AS test"));
+	}
+
+	@Test
+	// DATAJPA-1696
+	void findProjectionClauseWithIncludedFrom() {
+
+		StringQuery query = new StringQuery("select x, frommage, y from t", true);
+
+		assertThat(createQueryEnhancer(query).getProjection()).isEqualTo("x, frommage, y");
 	}
 
 	abstract QueryEnhancer createQueryEnhancer(DeclaredQuery declaredQuery);

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/QueryEnhancerTckTests.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/QueryEnhancerTckTests.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.jpa.repository.query;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.stream.Stream;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+/**
+ * TCK Tests for {@link QueryEnhancer}.
+ *
+ * @author Mark Paluch
+ */
+abstract class QueryEnhancerTckTests {
+
+	@ParameterizedTest
+	@MethodSource("nativeCountQueries") // GH-2773
+	void shouldDeriveNativeCountQuery(String query, String expected) {
+
+		DeclaredQuery declaredQuery = DeclaredQuery.of(query, true);
+		QueryEnhancer enhancer = createQueryEnhancer(declaredQuery);
+		String countQueryFor = enhancer.createCountQueryFor(null);
+
+		assertThat(countQueryFor).isEqualToIgnoringCase(expected);
+	}
+
+	static Stream<Arguments> nativeCountQueries() {
+
+		return Stream.of(Arguments.of( //
+				"SELECT * FROM table_name some_alias", //
+				"select count(1) FROM table_name some_alias"), //
+
+				Arguments.of( //
+						"SELECT name FROM table_name some_alias", //
+						"select count(name) FROM table_name some_alias"), //
+
+				Arguments.of( //
+						"SELECT DISTINCT name FROM table_name some_alias", //
+						"select count(DISTINCT name) FROM table_name some_alias"));
+	}
+
+	@ParameterizedTest // GH-2773
+	@MethodSource("jpqlCountQueries")
+	void shouldDeriveJpqlCountQuery(String query, String expected) {
+
+		DeclaredQuery declaredQuery = DeclaredQuery.of(query, false);
+		QueryEnhancer enhancer = createQueryEnhancer(declaredQuery);
+		String countQueryFor = enhancer.createCountQueryFor(null);
+
+		assertThat(countQueryFor).isEqualToIgnoringCase(expected);
+	}
+
+	static Stream<Arguments> jpqlCountQueries() {
+
+		return Stream.of(Arguments.of( //
+				"SELECT some_alias FROM table_name some_alias", //
+				"select count(some_alias) FROM table_name some_alias"), //
+
+				Arguments.of( //
+						"SELECT name FROM table_name some_alias", //
+						"select count(name) FROM table_name some_alias"), //
+
+				Arguments.of( //
+						"SELECT DISTINCT name FROM table_name some_alias", //
+						"select count(DISTINCT name) FROM table_name some_alias"));
+	}
+
+	abstract QueryEnhancer createQueryEnhancer(DeclaredQuery declaredQuery);
+
+}

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/QueryEnhancerUnitTests.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/QueryEnhancerUnitTests.java
@@ -15,9 +15,7 @@
  */
 package org.springframework.data.jpa.repository.query;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.*;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -229,7 +227,12 @@ class QueryEnhancerUnitTests {
 
 	@Test // DATAJPA-420
 	void createsCountQueryForScalarSelects() {
-		assertCountQuery("select p.lastname,p.firstname from Person p", "select count(p) from Person p", true);
+		assertCountQuery("select p.lastname,p.firstname from Person p", "select count(p) from Person p", false);
+	}
+
+	@Test // DATAJPA-420
+	void createsCountQueryForNativeScalarSelects() {
+		assertCountQuery("select p.lastname,p.firstname from Person p", "select count(1) from Person p", true);
 	}
 
 	@Test // DATAJPA-456
@@ -490,7 +493,7 @@ class QueryEnhancerUnitTests {
 				"  order by user.name\n ", true);
 
 		assertThat(getEnhancer(query).createCountQueryFor())
-				.isEqualToIgnoringCase("select count(user) from User user where user.age = 18");
+				.isEqualToIgnoringCase("select count(1) from User user where user.age = 18");
 	}
 
 	@Test
@@ -503,7 +506,7 @@ class QueryEnhancerUnitTests {
 				"  order\nby\nuser.name\n ", true);
 
 		assertThat(getEnhancer(query).createCountQueryFor())
-				.isEqualToIgnoringCase("select count(user) from User user where user.age = 18");
+				.isEqualToIgnoringCase("select count(1) from User user where user.age = 18");
 	}
 
 	@Test // DATAJPA-1061
@@ -724,17 +727,17 @@ class QueryEnhancerUnitTests {
 
 		QueryEnhancer queryEnhancer = getEnhancer(nativeQuery);
 		String countQueryFor = queryEnhancer.createCountQueryFor();
-		assertThat(countQueryFor).isEqualTo("SELECT count(*) FROM User WHERE created_at > $1");
+		assertThat(countQueryFor).isEqualTo("SELECT count(1) FROM User WHERE created_at > $1");
 
 		nativeQuery = new StringQuery("SELECT * FROM (select * from test) ", true);
 		queryEnhancer = getEnhancer(nativeQuery);
 		countQueryFor = queryEnhancer.createCountQueryFor();
-		assertThat(countQueryFor).isEqualTo("SELECT count(*) FROM (SELECT * FROM test)");
+		assertThat(countQueryFor).isEqualTo("SELECT count(1) FROM (SELECT * FROM test)");
 
 		nativeQuery = new StringQuery("SELECT * FROM (select * from test) as test", true);
 		queryEnhancer = getEnhancer(nativeQuery);
 		countQueryFor = queryEnhancer.createCountQueryFor();
-		assertThat(countQueryFor).isEqualTo("SELECT count(test) FROM (SELECT * FROM test) AS test");
+		assertThat(countQueryFor).isEqualTo("SELECT count(1) FROM (SELECT * FROM test) AS test");
 	}
 
 	@Test // GH-2555
@@ -864,7 +867,7 @@ class QueryEnhancerUnitTests {
 
 		assertThat(queryEnhancer.createCountQueryFor()).isEqualToIgnoringCase(
 				"with sample_data (day, value) AS (VALUES ((0, 13), (1, 12), (2, 15), (3, 4), (4, 8), (5, 16)))\n"
-						+ "SELECT count(a) FROM sample_data AS a");
+						+ "SELECT count(1) FROM sample_data AS a");
 		assertThat(queryEnhancer.applySorting(Sort.by("day").descending())).endsWith("ORDER BY a.day DESC");
 		assertThat(queryEnhancer.getJoinAliases()).isEmpty();
 		assertThat(queryEnhancer.detectAlias()).isEqualToIgnoringCase("a");
@@ -887,7 +890,7 @@ class QueryEnhancerUnitTests {
 
 		assertThat(queryEnhancer.createCountQueryFor()).isEqualToIgnoringCase(
 				"with sample_data (day, value) AS (VALUES ((0, 13), (1, 12), (2, 15), (3, 4), (4, 8), (5, 16))),test2 AS (VALUES (1, 2, 3))\n"
-						+ "SELECT count(a) FROM sample_data AS a");
+						+ "SELECT count(1) FROM sample_data AS a");
 		assertThat(queryEnhancer.applySorting(Sort.by("day").descending())).endsWith("ORDER BY a.day DESC");
 		assertThat(queryEnhancer.getJoinAliases()).isEmpty();
 		assertThat(queryEnhancer.detectAlias()).isEqualToIgnoringCase("a");
@@ -985,4 +988,5 @@ class QueryEnhancerUnitTests {
 	private static QueryEnhancer getEnhancer(DeclaredQuery query) {
 		return QueryEnhancerFactory.forQuery(query);
 	}
+
 }


### PR DESCRIPTION
We now consider whether a query is a native one when deriving a count query for pagination. Previously, the generated queries used JPQL syntax that doesn't comply with native SQL syntax rules.

Also, cleanup tests, deduplicate test code, and rearrange test cases into a maintainable form. 

Closes #2773