### PR TITLE
Fix NullPointer when deriving a count query for non-SELECT statements, delay count query derivation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-jpa-parent</artifactId>
-	<version>3.1.0-SNAPSHOT</version>
+	<version>3.1.0-GH-2812-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data JPA Parent</name>

--- a/spring-data-envers/pom.xml
+++ b/spring-data-envers/pom.xml
@@ -5,12 +5,12 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-envers</artifactId>
-	<version>3.1.0-SNAPSHOT</version>
+	<version>3.1.0-GH-2812-SNAPSHOT</version>
 
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-jpa-parent</artifactId>
-		<version>3.1.0-SNAPSHOT</version>
+		<version>3.1.0-GH-2812-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-jpa-distribution/pom.xml
+++ b/spring-data-jpa-distribution/pom.xml
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-jpa-parent</artifactId>
-		<version>3.1.0-SNAPSHOT</version>
+		<version>3.1.0-GH-2812-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-jpa/pom.xml
+++ b/spring-data-jpa/pom.xml
@@ -6,7 +6,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-jpa</artifactId>
-	<version>3.1.0-SNAPSHOT</version>
+	<version>3.1.0-GH-2812-SNAPSHOT</version>
 
 	<name>Spring Data JPA</name>
 	<description>Spring Data module for JPA repositories.</description>
@@ -15,7 +15,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-jpa-parent</artifactId>
-		<version>3.1.0-SNAPSHOT</version>
+		<version>3.1.0-GH-2812-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/DeclaredQuery.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/DeclaredQuery.java
@@ -105,7 +105,7 @@ interface DeclaredQuery {
 
 	/**
 	 * Return whether the query is a native query of not.
-	 * 
+	 *
 	 * @return <code>true</code> if native query otherwise <code>false</code>
 	 */
 	default boolean isNativeQuery() {

--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/QueryUtils.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/QueryUtils.java
@@ -617,7 +617,7 @@ public abstract class QueryUtils {
 
 			String replacement = useVariable ? SIMPLE_COUNT_VALUE : complexCountValue;
 
-			if (nativeQuery && (variable.contains(",") || "*".equals(variable))) {
+			if (variable != null && (nativeQuery && (variable.contains(",") || "*".equals(variable)))) {
 				replacement = "1";
 			} else {
 

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/DefaultQueryUtilsUnitTests.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/DefaultQueryUtilsUnitTests.java
@@ -70,6 +70,15 @@ class DefaultQueryUtilsUnitTests {
 				"select count(distinct u) from User u where u.foo = ?");
 	}
 
+	@Test // GH-2812
+	void createsCountQueryForDeleteQuery() {
+
+		String result = createCountQueryFor("delete from some_table where id in :ids", null, true);
+
+		// ح(•̀ж•́)ง †
+		assertThat(result).isEqualTo("deleteselect count(where) from some_table where id in :ids");
+	}
+
 	@Test
 	void createsCountQueryForConstructorQueries() {
 

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/QueryEnhancerUnitTests.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/QueryEnhancerUnitTests.java
@@ -172,6 +172,15 @@ class QueryEnhancerUnitTests {
 		assertThat(query).endsWithIgnoringCase("ORDER BY p.firstname, p.lastname asc");
 	}
 
+	@Test // GH-2812
+	void createCountQueryFromDeleteQuery() {
+
+		StringQuery query = new StringQuery("delete from some_table where id in :ids", true);
+
+		assertThat(getEnhancer(query).createCountQueryFor("p.lastname"))
+				.isEqualToIgnoringCase("delete from some_table where id in :ids");
+	}
+
 	@Test // DATAJPA-456
 	void createCountQueryFromTheGivenCountProjection() {
 


### PR DESCRIPTION
Should be backported to `2.7.x` and `3.0.x` as well.