### PR TITLE
Ensure proper hint is applied for projections of paginated queries for Querydsl fluent queries

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-jpa-parent</artifactId>
-	<version>3.1.0-SNAPSHOT</version>
+	<version>3.1.0-gh-2820-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data JPA Parent</name>

--- a/spring-data-envers/pom.xml
+++ b/spring-data-envers/pom.xml
@@ -5,12 +5,12 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-envers</artifactId>
-	<version>3.1.0-SNAPSHOT</version>
+	<version>3.1.0-gh-2820-SNAPSHOT</version>
 
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-jpa-parent</artifactId>
-		<version>3.1.0-SNAPSHOT</version>
+		<version>3.1.0-gh-2820-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-jpa-distribution/pom.xml
+++ b/spring-data-jpa-distribution/pom.xml
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-jpa-parent</artifactId>
-		<version>3.1.0-SNAPSHOT</version>
+		<version>3.1.0-gh-2820-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-jpa/pom.xml
+++ b/spring-data-jpa/pom.xml
@@ -6,7 +6,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-jpa</artifactId>
-	<version>3.1.0-SNAPSHOT</version>
+	<version>3.1.0-gh-2820-SNAPSHOT</version>
 
 	<name>Spring Data JPA</name>
 	<description>Spring Data module for JPA repositories.</description>
@@ -15,7 +15,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-jpa-parent</artifactId>
-		<version>3.1.0-SNAPSHOT</version>
+		<version>3.1.0-gh-2820-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/UserRepositoryTests.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/UserRepositoryTests.java
@@ -15,23 +15,14 @@
  */
 package org.springframework.data.jpa.repository;
 
-import static java.util.Arrays.asList;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.springframework.data.domain.Example.of;
-import static org.springframework.data.domain.ExampleMatcher.GenericPropertyMatcher;
-import static org.springframework.data.domain.ExampleMatcher.StringMatcher;
-import static org.springframework.data.domain.ExampleMatcher.matching;
-import static org.springframework.data.domain.Sort.Direction.ASC;
-import static org.springframework.data.domain.Sort.Direction.DESC;
+import static java.util.Arrays.*;
+import static org.assertj.core.api.Assertions.*;
+import static org.springframework.data.domain.Example.*;
+import static org.springframework.data.domain.ExampleMatcher.*;
+import static org.springframework.data.domain.Sort.Direction.*;
+import static org.springframework.data.jpa.domain.Specification.*;
 import static org.springframework.data.jpa.domain.Specification.not;
-import static org.springframework.data.jpa.domain.Specification.where;
-import static org.springframework.data.jpa.domain.sample.UserSpecifications.userHasAgeLess;
-import static org.springframework.data.jpa.domain.sample.UserSpecifications.userHasFirstname;
-import static org.springframework.data.jpa.domain.sample.UserSpecifications.userHasFirstnameLike;
-import static org.springframework.data.jpa.domain.sample.UserSpecifications.userHasLastname;
-import static org.springframework.data.jpa.domain.sample.UserSpecifications.userHasLastnameLikeWithSort;
+import static org.springframework.data.jpa.domain.sample.UserSpecifications.*;
 
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
@@ -75,6 +66,7 @@ import org.springframework.data.domain.Sort.Direction;
 import org.springframework.data.domain.Sort.Order;
 import org.springframework.data.jpa.domain.Specification;
 import org.springframework.data.jpa.domain.sample.Address;
+import org.springframework.data.jpa.domain.sample.QUser;
 import org.springframework.data.jpa.domain.sample.Role;
 import org.springframework.data.jpa.domain.sample.SpecialUser;
 import org.springframework.data.jpa.domain.sample.User;
@@ -2442,6 +2434,47 @@ class UserRepositoryTests {
 				.isThrownBy( //
 						() -> users.forEach(u -> u.getRoles().size()) // forces loading of roles
 				);
+	}
+
+	@Test // GH-2820
+	void findByFluentPredicateWithProjectionAndPageRequest() {
+
+		flushTestUsers();
+		em.clear();
+
+		Page<User> users = repository.findBy(QUser.user.firstname.contains("v"), q -> q //
+				.project("firstname") //
+				.page(PageRequest.of(0, 10)));
+
+		assertThat(users).extracting(User::getFirstname).containsExactlyInAnyOrder(firstUser.getFirstname(),
+				thirdUser.getFirstname(), fourthUser.getFirstname());
+	}
+
+	@Test // GH-2820
+	void findByFluentPredicateWithProjectionAndAll() {
+
+		flushTestUsers();
+		em.clear();
+
+		List<User> users = repository.findBy(QUser.user.firstname.contains("v"), q -> q //
+				.project("firstname") //
+				.all());
+
+		assertThat(users).extracting(User::getFirstname).containsExactlyInAnyOrder(firstUser.getFirstname(),
+				thirdUser.getFirstname(), fourthUser.getFirstname());
+	}
+
+	@Test // GH-2820
+	void findByFluentPredicateWithPageRequest() {
+
+		flushTestUsers();
+		em.clear();
+
+		Page<User> users = repository.findBy(QUser.user.firstname.contains("v"), q -> q //
+				.page(PageRequest.of(0, 10)));
+
+		assertThat(users).extracting(User::getFirstname).containsExactlyInAnyOrder(firstUser.getFirstname(),
+				thirdUser.getFirstname(), fourthUser.getFirstname());
 	}
 
 	@Test // GH-2274

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/sample/UserRepository.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/sample/UserRepository.java
@@ -18,15 +18,29 @@ package org.springframework.data.jpa.repository.sample;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.QueryHint;
 
-import java.util.*;
+import java.util.Collection;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Stream;
 
-import org.springframework.data.domain.*;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.Sort;
 import org.springframework.data.jpa.domain.sample.Role;
 import org.springframework.data.jpa.domain.sample.SpecialUser;
 import org.springframework.data.jpa.domain.sample.User;
-import org.springframework.data.jpa.repository.*;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.jpa.repository.QueryHints;
 import org.springframework.data.jpa.repository.query.Procedure;
+import org.springframework.data.querydsl.ListQuerydslPredicateExecutor;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.data.repository.query.Param;
 import org.springframework.transaction.annotation.Transactional;
@@ -45,8 +59,8 @@ import org.springframework.transaction.annotation.Transactional;
  * @author Diego Krupitza
  * @author Geoffrey Deremetz
  */
-public interface UserRepository
-		extends JpaRepository<User, Integer>, JpaSpecificationExecutor<User>, UserRepositoryCustom {
+public interface UserRepository extends JpaRepository<User, Integer>, JpaSpecificationExecutor<User>,
+		UserRepositoryCustom, ListQuerydslPredicateExecutor<User> {
 
 	/**
 	 * Retrieve users by their lastname. The finder {@literal User.findByLastname} is declared in

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/support/JpaRepositoryFactoryBeanEntityPathResolverIntegrationTests.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/support/JpaRepositoryFactoryBeanEntityPathResolverIntegrationTests.java
@@ -32,8 +32,6 @@ import org.springframework.data.querydsl.EntityPathResolver;
 import org.springframework.data.querydsl.SimpleEntityPathResolver;
 import org.springframework.test.util.ReflectionTestUtils;
 
-import com.querydsl.core.types.EntityPath;
-
 /**
  * Unit tests for {@link EntityPathResolver} related tests on {@link JpaRepositoryFactoryBean}.
  *
@@ -47,14 +45,7 @@ class JpaRepositoryFactoryBeanEntityPathResolverIntegrationTests {
 	@EnableJpaRepositories(basePackageClasses = UserRepository.class, //
 			includeFilters = @Filter(type = FilterType.ASSIGNABLE_TYPE, classes = UserRepository.class))
 	static class BaseConfig {
-
-		static final EntityPathResolver RESOLVER = new EntityPathResolver() {
-
-			@Override
-			public <T> EntityPath<T> createPath(Class<T> domainClass) {
-				return null;
-			}
-		};
+		static final EntityPathResolver RESOLVER = SimpleEntityPathResolver.INSTANCE;
 	}
 
 	@Configuration


### PR DESCRIPTION
Resolves #2820

I have added the application of hints in case of a projection to the paginated query. I cannot seem to find a logging option to SHOW me it's working, but OP has verified it works as expected on their end. Any tips to expose this happening in our test suite would be appreciate. But apart from that, I believe test by analysis is of use in this situation.

And please alert me to any other issues with this PR.