### PR TITLE
** SEEKING FEEDBACK **

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-jpa-parent</artifactId>
-	<version>3.1.0-SNAPSHOT</version>
+	<version>3.1.0-gh-2032-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data JPA Parent</name>

--- a/spring-data-envers/pom.xml
+++ b/spring-data-envers/pom.xml
@@ -5,12 +5,12 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-envers</artifactId>
-	<version>3.1.0-SNAPSHOT</version>
+	<version>3.1.0-gh-2032-SNAPSHOT</version>
 
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-jpa-parent</artifactId>
-		<version>3.1.0-SNAPSHOT</version>
+		<version>3.1.0-gh-2032-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-jpa-distribution/pom.xml
+++ b/spring-data-jpa-distribution/pom.xml
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-jpa-parent</artifactId>
-		<version>3.1.0-SNAPSHOT</version>
+		<version>3.1.0-gh-2032-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-jpa/pom.xml
+++ b/spring-data-jpa/pom.xml
@@ -6,7 +6,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-jpa</artifactId>
-	<version>3.1.0-SNAPSHOT</version>
+	<version>3.1.0-gh-2032-SNAPSHOT</version>
 
 	<name>Spring Data JPA</name>
 	<description>Spring Data module for JPA repositories.</description>
@@ -15,7 +15,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-jpa-parent</artifactId>
-		<version>3.1.0-SNAPSHOT</version>
+		<version>3.1.0-gh-2032-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/HqlQueryTransformer.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/HqlQueryTransformer.java
@@ -235,13 +235,27 @@ class HqlQueryTransformer extends HqlQueryRenderer {
 
 		if (ctx.entityName() != null) {
 
-			tokens.addAll(visit(ctx.entityName()));
+			List<JpaQueryParsingToken> entityName = visit(ctx.entityName());
+
+			tokens.addAll(entityName);
 
 			if (ctx.variable() != null) {
 				tokens.addAll(visit(ctx.variable()));
 
 				if (this.alias == null && !isSubquery(ctx)) {
 					this.alias = tokens.get(tokens.size() - 1).getToken();
+				}
+			} else {
+
+				if (countQuery) {
+					tokens.add(TOKEN_AS);
+
+					String tempAlias = entityName.get(0).getToken().substring(0, 1).toLowerCase();
+					tokens.add(new JpaQueryParsingToken(tempAlias));
+
+					if (this.alias == null && !isSubquery(ctx)) {
+						this.alias = tempAlias;
+					}
 				}
 			}
 		} else if (ctx.subquery() != null) {

--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/JpaQueryParsingToken.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/JpaQueryParsingToken.java
@@ -17,7 +17,6 @@ package org.springframework.data.jpa.repository.query;
 
 import java.util.List;
 import java.util.function.Supplier;
-import java.util.stream.Collectors;
 
 import org.antlr.v4.runtime.Token;
 import org.antlr.v4.runtime.tree.TerminalNode;
@@ -52,6 +51,8 @@ class JpaQueryParsingToken {
 	public static final JpaQueryParsingToken TOKEN_CLOSE_BRACE = new JpaQueryParsingToken("}");
 	public static final JpaQueryParsingToken TOKEN_CLOSE_SQUARE_BRACKET_BRACE = new JpaQueryParsingToken("]}");
 	public static final JpaQueryParsingToken TOKEN_CLOSE_PAREN_BRACE = new JpaQueryParsingToken(")}");
+
+	public static final JpaQueryParsingToken TOKEN_AS = new JpaQueryParsingToken("AS");
 
 	public static final JpaQueryParsingToken TOKEN_DESC = new JpaQueryParsingToken("desc", false);
 

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/HqlQueryTransformerTests.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/HqlQueryTransformerTests.java
@@ -793,6 +793,13 @@ class HqlQueryTransformerTests {
 						"select e from SampleEntity e where function('nativeFunc', ?1) > 'testVal' order by function('nativeFunc', ?1), e.age desc");
 	}
 
+	@Test
+	void countQueryShouldWorkEvenWithoutExplicitAlias() {
+
+		assertCountQuery("FROM BookError WHERE portal = :portal", //
+				"select count(b) FROM BookError AS b WHERE portal = :portal");
+	}
+
 	private void assertCountQuery(String originalQuery, String countQuery) {
 		assertThat(createCountQueryFor(originalQuery)).isEqualTo(countQuery);
 	}


### PR DESCRIPTION
This PR handles create a `count()` query for HQL when there is no declared alias in the FROM clause.

Seeking feedback from @schauder and @mp911de.

Basically, I:

. Grab the name of the entity in the `FROM` clause.
. Grab the first character from that and lowercase it, calling it `tempAlias`.
. Insert a `AS <tempAlias>`.
. Assign this `tempAlias` to the transformer's `alias` so it's used as `count(<tempAlias>)`