### PR TITLE
Add required native image runtime hint for streaming results.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-jpa-parent</artifactId>
-	<version>3.1.0-SNAPSHOT</version>
+	<version>3.1.x-GH-2848-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data JPA Parent</name>

--- a/spring-data-envers/pom.xml
+++ b/spring-data-envers/pom.xml
@@ -5,12 +5,12 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-envers</artifactId>
-	<version>3.1.0-SNAPSHOT</version>
+	<version>3.1.x-GH-2848-SNAPSHOT</version>
 
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-jpa-parent</artifactId>
-		<version>3.1.0-SNAPSHOT</version>
+		<version>3.1.x-GH-2848-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-jpa-distribution/pom.xml
+++ b/spring-data-jpa-distribution/pom.xml
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-jpa-parent</artifactId>
-		<version>3.1.0-SNAPSHOT</version>
+		<version>3.1.x-GH-2848-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-jpa/pom.xml
+++ b/spring-data-jpa/pom.xml
@@ -6,7 +6,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-jpa</artifactId>
-	<version>3.1.0-SNAPSHOT</version>
+	<version>3.1.x-GH-2848-SNAPSHOT</version>
 
 	<name>Spring Data JPA</name>
 	<description>Spring Data module for JPA repositories.</description>
@@ -15,7 +15,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-jpa-parent</artifactId>
-		<version>3.1.0-SNAPSHOT</version>
+		<version>3.1.x-GH-2848-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/aot/JpaRuntimeHints.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/aot/JpaRuntimeHints.java
@@ -18,7 +18,9 @@ package org.springframework.data.jpa.repository.aot;
 import jakarta.persistence.NamedEntityGraph;
 
 import java.util.Arrays;
+import java.util.Collections;
 
+import org.springframework.aot.hint.ExecutableMode;
 import org.springframework.aot.hint.MemberCategory;
 import org.springframework.aot.hint.RuntimeHints;
 import org.springframework.aot.hint.RuntimeHintsRegistrar;
@@ -75,6 +77,12 @@ class JpaRuntimeHints implements RuntimeHintsRegistrar {
 					hint -> hint.withMembers(MemberCategory.INVOKE_PUBLIC_CONSTRUCTORS, MemberCategory.INVOKE_PUBLIC_METHODS)
 							.onReachableType(QuerydslPredicateExecutor.class));
 		}
+
+		// streaming results requires reflective access to jakarta.persistence.Query#getResultAsStream
+		hints.reflection().registerType(jakarta.persistence.Query.class, MemberCategory.INTROSPECT_PUBLIC_METHODS);
+		hints.reflection().registerType(jakarta.persistence.Query.class, hint -> {
+			hint.withMethod("getResultStream", Collections.emptyList(), ExecutableMode.INVOKE);
+		});
 
 		hints.reflection().registerType(NamedEntityGraph.class,
 				hint -> hint.onReachableType(EntityGraph.class).withMembers(MemberCategory.INVOKE_PUBLIC_METHODS));


### PR DESCRIPTION
This commit makes sure we're able to invoke the method required for streaming results.

Closes: #2848

Should be backported to _3.0.x_