### PR TITLE
Drop SpEL support in the query parsers.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-jpa-parent</artifactId>
-	<version>3.1.0-SNAPSHOT</version>
+	<version>3.1.0-gh-2881-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data JPA Parent</name>

--- a/spring-data-envers/pom.xml
+++ b/spring-data-envers/pom.xml
@@ -5,12 +5,12 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-envers</artifactId>
-	<version>3.1.0-SNAPSHOT</version>
+	<version>3.1.0-gh-2881-SNAPSHOT</version>
 
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-jpa-parent</artifactId>
-		<version>3.1.0-SNAPSHOT</version>
+		<version>3.1.0-gh-2881-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-jpa-distribution/pom.xml
+++ b/spring-data-jpa-distribution/pom.xml
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-jpa-parent</artifactId>
-		<version>3.1.0-SNAPSHOT</version>
+		<version>3.1.0-gh-2881-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-jpa/pom.xml
+++ b/spring-data-jpa/pom.xml
@@ -6,7 +6,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-jpa</artifactId>
-	<version>3.1.0-SNAPSHOT</version>
+	<version>3.1.0-gh-2881-SNAPSHOT</version>
 
 	<name>Spring Data JPA</name>
 	<description>Spring Data module for JPA repositories.</description>
@@ -15,7 +15,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-jpa-parent</artifactId>
-		<version>3.1.0-SNAPSHOT</version>
+		<version>3.1.0-gh-2881-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-jpa/src/main/antlr4/org/springframework/data/jpa/repository/query/Hql.g4
+++ b/spring-data-jpa/src/main/antlr4/org/springframework/data/jpa/repository/query/Hql.g4
@@ -620,7 +620,7 @@ variable
 
 parameter
     : prefix=':' identifier
-    | prefix='?' (INTEGER_LITERAL | spelExpression)?
+    | prefix='?' INTEGER_LITERAL?
     ;
 
 entityName
@@ -629,15 +629,7 @@ entityName
 
 identifier
     : reservedWord
-    | spelExpression
     ;
-
-spelExpression
-    : prefix='#{#' identificationVariable ('.' identificationVariable)*  '}' // #{#entityName}
-    | prefix='#{#[' INTEGER_LITERAL ']}' // #{[0]}
-    | prefix='#{' identificationVariable '(' ( stringLiteral | '[' INTEGER_LITERAL ']' )? ')}' // #{escape([0])} | #{escapeCharacter()}
-    ;
-
 
 character
     : CHARACTER

--- a/spring-data-jpa/src/main/antlr4/org/springframework/data/jpa/repository/query/Jpql.g4
+++ b/spring-data-jpa/src/main/antlr4/org/springframework/data/jpa/repository/query/Jpql.g4
@@ -599,7 +599,6 @@ identification_variable
     | ORDER // Gap in the spec requires supporting 'Order' as an entity name
     | COUNT // Gap in the spec requires supporting 'count' as a possible name
     | KEY // Gap in the sepc requires supported 'key' as a possible name
-    | spel_expression // we use various SpEL expressions in our queries
     ;
 
 constructor_name
@@ -702,12 +701,6 @@ single_valued_input_parameter
 
 function_name
     : string_literal
-    ;
-
-spel_expression
-    : prefix='#{#' identification_variable ('.' identification_variable)*  '}' // #{#entityName}
-    | prefix='#{#[' INTLITERAL ']}' // #{[0]}
-    | prefix='#{' identification_variable '(' ( string_literal | '[' INTLITERAL ']' )? ')}' // #{escape([0])} | #{escapeCharacter()}
     ;
 
 character_valued_input_parameter

--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/HqlQueryRenderer.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/HqlQueryRenderer.java
@@ -2222,8 +2222,6 @@ class HqlQueryRenderer extends HqlBaseVisitor<List<JpaQueryParsingToken>> {
 
 			if (ctx.INTEGER_LITERAL() != null) {
 				tokens.add(new JpaQueryParsingToken(ctx.INTEGER_LITERAL()));
-			} else if (ctx.spelExpression() != null) {
-				tokens.addAll(visit(ctx.spelExpression()));
 			}
 		}
 
@@ -2251,55 +2249,9 @@ class HqlQueryRenderer extends HqlBaseVisitor<List<JpaQueryParsingToken>> {
 
 		if (ctx.reservedWord() != null) {
 			return visit(ctx.reservedWord());
-		} else if (ctx.spelExpression() != null) {
-			return visit(ctx.spelExpression());
 		} else {
 			return List.of();
 		}
-	}
-
-	@Override
-	public List<JpaQueryParsingToken> visitSpelExpression(HqlParser.SpelExpressionContext ctx) {
-
-		List<JpaQueryParsingToken> tokens = new ArrayList<>();
-
-		if (ctx.prefix.equals("#{#")) { // #{#entityName}
-
-			tokens.add(new JpaQueryParsingToken(ctx.prefix));
-
-			ctx.identificationVariable().forEach(identificationVariableContext -> {
-				tokens.addAll(visit(identificationVariableContext));
-				tokens.add(TOKEN_DOT);
-			});
-			CLIP(tokens);
-
-			tokens.add(TOKEN_CLOSE_BRACE);
-
-		} else if (ctx.prefix.equals("#{#[")) { // #{[0]}
-
-			tokens.add(new JpaQueryParsingToken(ctx.prefix));
-			tokens.add(new JpaQueryParsingToken(ctx.INTEGER_LITERAL()));
-			tokens.add(TOKEN_CLOSE_SQUARE_BRACKET_BRACE);
-
-		} else if (ctx.prefix.equals("#{")) {// #{escape([0])} or #{escape('foo')}
-
-			tokens.add(new JpaQueryParsingToken(ctx.prefix));
-			tokens.addAll(visit(ctx.identificationVariable(0)));
-			tokens.add(TOKEN_OPEN_PAREN);
-
-			if (ctx.stringLiteral() != null) {
-				tokens.addAll(visit(ctx.stringLiteral()));
-			} else if (ctx.INTEGER_LITERAL() != null) {
-
-				tokens.add(TOKEN_OPEN_SQUARE_BRACKET);
-				tokens.add(new JpaQueryParsingToken(ctx.INTEGER_LITERAL()));
-				tokens.add(TOKEN_CLOSE_SQUARE_BRACKET);
-			}
-
-			tokens.add(TOKEN_CLOSE_PAREN_BRACE);
-		}
-
-		return tokens;
 	}
 
 	@Override

--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/JpqlQueryRenderer.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/JpqlQueryRenderer.java
@@ -2124,8 +2124,6 @@ class JpqlQueryRenderer extends JpqlBaseVisitor<List<JpaQueryParsingToken>> {
 			return List.of(new JpaQueryParsingToken(ctx.ORDER()));
 		} else if (ctx.KEY() != null) {
 			return List.of(new JpaQueryParsingToken(ctx.KEY()));
-		} else if (ctx.spel_expression() != null) {
-			return visit(ctx.spel_expression());
 		} else {
 			return List.of();
 		}
@@ -2320,48 +2318,6 @@ class JpqlQueryRenderer extends JpqlBaseVisitor<List<JpaQueryParsingToken>> {
 	@Override
 	public List<JpaQueryParsingToken> visitFunction_name(JpqlParser.Function_nameContext ctx) {
 		return visit(ctx.string_literal());
-	}
-
-	@Override
-	public List<JpaQueryParsingToken> visitSpel_expression(JpqlParser.Spel_expressionContext ctx) {
-
-		List<JpaQueryParsingToken> tokens = new ArrayList<>();
-
-		if (ctx.prefix.equals("#{#")) { // #{#entityName}
-
-			tokens.add(new JpaQueryParsingToken(ctx.prefix));
-			ctx.identification_variable().forEach(identificationVariableContext -> {
-				tokens.addAll(visit(identificationVariableContext));
-				tokens.add(TOKEN_DOT);
-			});
-			CLIP(tokens);
-			tokens.add(TOKEN_CLOSE_BRACE);
-
-		} else if (ctx.prefix.equals("#{#[")) { // #{[0]}
-
-			tokens.add(new JpaQueryParsingToken(ctx.prefix));
-			tokens.add(new JpaQueryParsingToken(ctx.INTLITERAL()));
-			tokens.add(TOKEN_CLOSE_SQUARE_BRACKET_BRACE);
-
-		} else if (ctx.prefix.equals("#{")) {// #{escape([0])} or #{escape('foo')}
-
-			tokens.add(new JpaQueryParsingToken(ctx.prefix));
-			tokens.addAll(visit(ctx.identification_variable(0)));
-			tokens.add(TOKEN_OPEN_PAREN);
-
-			if (ctx.string_literal() != null) {
-				tokens.addAll(visit(ctx.string_literal()));
-			} else if (ctx.INTLITERAL() != null) {
-
-				tokens.add(TOKEN_OPEN_SQUARE_BRACKET);
-				tokens.add(new JpaQueryParsingToken(ctx.INTLITERAL()));
-				tokens.add(TOKEN_CLOSE_SQUARE_BRACKET);
-			}
-
-			tokens.add(TOKEN_CLOSE_PAREN_BRACE);
-		}
-
-		return tokens;
 	}
 
 	@Override


### PR DESCRIPTION
Thanks to count query derivation being delayed until beyond the point where SpEL expressions are evaluated, there is no longer a need to parse SpEL expressions. 