### PR TITLE
Remove deprecated constructors from JpaSort

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-jpa-parent</artifactId>
-	<version>3.1.0-SNAPSHOT</version>
+	<version>3.1.0-remove-deprecated-constructors-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data JPA Parent</name>

--- a/spring-data-envers/pom.xml
+++ b/spring-data-envers/pom.xml
@@ -5,12 +5,12 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-envers</artifactId>
-	<version>3.1.0-SNAPSHOT</version>
+	<version>3.1.0-remove-deprecated-constructors-SNAPSHOT</version>
 
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-jpa-parent</artifactId>
-		<version>3.1.0-SNAPSHOT</version>
+		<version>3.1.0-remove-deprecated-constructors-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-jpa-distribution/pom.xml
+++ b/spring-data-jpa-distribution/pom.xml
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-jpa-parent</artifactId>
-		<version>3.1.0-SNAPSHOT</version>
+		<version>3.1.0-remove-deprecated-constructors-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-jpa/pom.xml
+++ b/spring-data-jpa/pom.xml
@@ -6,7 +6,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-jpa</artifactId>
-	<version>3.1.0-SNAPSHOT</version>
+	<version>3.1.0-remove-deprecated-constructors-SNAPSHOT</version>
 
 	<name>Spring Data JPA</name>
 	<description>Spring Data module for JPA repositories.</description>
@@ -15,7 +15,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-jpa-parent</artifactId>
-		<version>3.1.0-SNAPSHOT</version>
+		<version>3.1.0-remove-deprecated-constructors-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/domain/JpaSort.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/domain/JpaSort.java
@@ -15,18 +15,17 @@
  */
 package org.springframework.data.jpa.domain;
 
+import jakarta.persistence.metamodel.Attribute;
+import jakarta.persistence.metamodel.PluralAttribute;
+import org.springframework.data.domain.Sort;
+import org.springframework.lang.Nullable;
+import org.springframework.util.Assert;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
-
-import jakarta.persistence.metamodel.Attribute;
-import jakarta.persistence.metamodel.PluralAttribute;
-
-import org.springframework.data.domain.Sort;
-import org.springframework.lang.Nullable;
-import org.springframework.util.Assert;
 
 /**
  * Sort option for queries that wraps JPA meta-model {@link Attribute}s for sorting.
@@ -35,59 +34,14 @@ import org.springframework.util.Assert;
  * @author Oliver Gierke
  * @author Christoph Strobl
  * @author David Madden
+ * @author Jens Schauder
  */
 public class JpaSort extends Sort {
 
 	private static final long serialVersionUID = 1L;
 
-	/**
-	 * Creates a new {@link JpaSort} for the given attributes with the default sort direction.
-	 *
-	 * @param attributes must not be {@literal null} or empty.
-	 * @deprecated since 2.3, use {@link JpaSort#of(Attribute...)} instead.
-	 */
-	@Deprecated
-	public JpaSort(Attribute<?, ?>... attributes) {
-		this(DEFAULT_DIRECTION, attributes);
-	}
-
-	/**
-	 * Creates a new {@link JpaSort} instance with the given {@link Path}s.
-	 *
-	 * @param paths must not be {@literal null} or empty.
-	 * @deprecated since 2.3, use {@link JpaSort#of(Path...))} instead.
-	 */
-	@Deprecated
-	public JpaSort(Path<?, ?>... paths) {
-		this(DEFAULT_DIRECTION, paths);
-	}
-
-	/**
-	 * Creates a new {@link JpaSort} for the given direction and attributes.
-	 *
-	 * @param direction the sorting direction.
-	 * @param attributes must not be {@literal null} or empty.
-	 * @deprecated since 2.3, use {@link JpaSort#of(Direction, Attribute...)} instead.
-	 */
-	@Deprecated
-	public JpaSort(Direction direction, Attribute<?, ?>... attributes) {
-		this(direction, paths(attributes));
-	}
-
-	/**
-	 * Creates a new {@link JpaSort} for the given direction and {@link Path}s.
-	 *
-	 * @param direction the sorting direction.
-	 * @param paths must not be {@literal null} or empty.
-	 * @deprecated since 2.3, use {@link JpaSort#of(Direction, Path...)} instead.
-	 */
-	@Deprecated
-	public JpaSort(Direction direction, Path<?, ?>... paths) {
-		this(direction, Arrays.asList(paths));
-	}
-
 	private JpaSort(Direction direction, List<Path<?, ?>> paths) {
-		this(Collections.<Order> emptyList(), direction, paths);
+		this(Collections.<Order>emptyList(), direction, paths);
 	}
 
 	private JpaSort(List<Order> orders, @Nullable Direction direction, List<Path<?, ?>> paths) {
@@ -104,7 +58,7 @@ public class JpaSort extends Sort {
 	 * @param attributes must not be {@literal null} or empty.
 	 */
 	public static JpaSort of(Attribute<?, ?>... attributes) {
-		return new JpaSort(attributes);
+		return new JpaSort(DEFAULT_DIRECTION, Arrays.asList(paths(attributes)));
 	}
 
 	/**
@@ -113,33 +67,33 @@ public class JpaSort extends Sort {
 	 * @param paths must not be {@literal null} or empty.
 	 */
 	public static JpaSort of(JpaSort.Path<?, ?>... paths) {
-		return new JpaSort(paths);
+		return new JpaSort(DEFAULT_DIRECTION, Arrays.asList(paths));
 	}
 
 	/**
 	 * Creates a new {@link JpaSort} for the given direction and attributes.
 	 *
-	 * @param direction the sorting direction.
+	 * @param direction  the sorting direction.
 	 * @param attributes must not be {@literal null} or empty.
 	 */
 	public static JpaSort of(Direction direction, Attribute<?, ?>... attributes) {
-		return new JpaSort(direction, attributes);
+		return new JpaSort(direction, Arrays.asList(paths(attributes)));
 	}
 
 	/**
 	 * Creates a new {@link JpaSort} for the given direction and {@link Path}s.
 	 *
 	 * @param direction the sorting direction.
-	 * @param paths must not be {@literal null} or empty.
+	 * @param paths     must not be {@literal null} or empty.
 	 */
 	public static JpaSort of(Direction direction, Path<?, ?>... paths) {
-		return new JpaSort(direction, paths);
+		return new JpaSort(direction, Arrays.asList(paths));
 	}
 
 	/**
 	 * Returns a new {@link JpaSort} with the given sorting criteria added to the current one.
 	 *
-	 * @param direction can be {@literal null}.
+	 * @param direction  can be {@literal null}.
 	 * @param attributes must not be {@literal null}.
 	 * @return
 	 */
@@ -154,7 +108,7 @@ public class JpaSort extends Sort {
 	 * Returns a new {@link JpaSort} with the given sorting criteria added to the current one.
 	 *
 	 * @param direction can be {@literal null}.
-	 * @param paths must not be {@literal null}.
+	 * @param paths     must not be {@literal null}.
 	 * @return
 	 */
 	public JpaSort and(@Nullable Direction direction, Path<?, ?>... paths) {
@@ -173,7 +127,7 @@ public class JpaSort extends Sort {
 	/**
 	 * Returns a new {@link JpaSort} with the given sorting criteria added to the current one.
 	 *
-	 * @param direction can be {@literal null}.
+	 * @param direction  can be {@literal null}.
 	 * @param properties must not be {@literal null} or empty.
 	 * @return
 	 */
@@ -191,7 +145,7 @@ public class JpaSort extends Sort {
 			orders.add(new JpaOrder(direction, property));
 		}
 
-		return new JpaSort(orders, direction, Collections.<Path<?, ?>> emptyList());
+		return new JpaSort(orders, direction, Collections.<Path<?, ?>>emptyList());
 	}
 
 	/**
@@ -262,7 +216,7 @@ public class JpaSort extends Sort {
 	/**
 	 * Creates new unsafe {@link JpaSort} based on given {@link Direction} and properties.
 	 *
-	 * @param direction must not be {@literal null}.
+	 * @param direction  must not be {@literal null}.
 	 * @param properties must not be {@literal null} or empty.
 	 * @return
 	 */
@@ -278,7 +232,7 @@ public class JpaSort extends Sort {
 	/**
 	 * Creates new unsafe {@link JpaSort} based on given {@link Direction} and properties.
 	 *
-	 * @param direction must not be {@literal null}.
+	 * @param direction  must not be {@literal null}.
 	 * @param properties must not be {@literal null} or empty.
 	 * @return
 	 */
@@ -371,7 +325,7 @@ public class JpaSort extends Sort {
 		 * {@link Sort#DEFAULT_DIRECTION}
 		 *
 		 * @param direction can be {@literal null}, will default to {@link Sort#DEFAULT_DIRECTION}.
-		 * @param property must not be {@literal null}.
+		 * @param property  must not be {@literal null}.
 		 */
 		private JpaOrder(@Nullable Direction direction, String property) {
 			this(direction, property, NullHandling.NATIVE);
@@ -381,8 +335,8 @@ public class JpaSort extends Sort {
 		 * Creates a new {@link Order} instance. if order is {@literal null} then order defaults to
 		 * {@link Sort#DEFAULT_DIRECTION}.
 		 *
-		 * @param direction can be {@literal null}, will default to {@link Sort#DEFAULT_DIRECTION}.
-		 * @param property must not be {@literal null}.
+		 * @param direction        can be {@literal null}, will default to {@link Sort#DEFAULT_DIRECTION}.
+		 * @param property         must not be {@literal null}.
 		 * @param nullHandlingHint can be {@literal null}, will default to {@link NullHandling#NATIVE}.
 		 */
 		private JpaOrder(@Nullable Direction direction, String property, NullHandling nullHandlingHint) {
@@ -390,7 +344,7 @@ public class JpaSort extends Sort {
 		}
 
 		private JpaOrder(@Nullable Direction direction, String property, NullHandling nullHandling, boolean ignoreCase,
-				boolean unsafe) {
+						 boolean unsafe) {
 
 			super(direction, property, nullHandling);
 			this.ignoreCase = ignoreCase;

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/support/MailMessageRepositoryIntegrationTests.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/support/MailMessageRepositoryIntegrationTests.java
@@ -79,7 +79,7 @@ class MailMessageRepositoryIntegrationTests {
 		mailMessageRepository.save(message2);
 
 		Page<MailMessage> results = mailMessageRepository.findAll(PageRequest.of(0, 20, //
-				new JpaSort(Direction.ASC, path(MailMessage_.mailSender).dot(MailSender_.name))));
+				JpaSort.of(Direction.ASC, path(MailMessage_.mailSender).dot(MailSender_.name))));
 		List<MailMessage> messages = results.getContent();
 
 		assertThat(messages).hasSize(2);


### PR DESCRIPTION
Since these are public constructors I think we should merge this after the upcoming GA release.