### PR TITLE
Remove hard dependency on Hibernate for stored procedures

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-jpa</artifactId>
-	<version>2.7.12-SNAPSHOT</version>
+	<version>2.7.12-gh-2902-SNAPSHOT</version>
 
 	<name>Spring Data JPA</name>
 	<description>Spring Data module for JPA repositories.</description>

--- a/src/main/java/org/springframework/data/jpa/provider/HibernateJpaParametersParameterAccessor.java
+++ b/src/main/java/org/springframework/data/jpa/provider/HibernateJpaParametersParameterAccessor.java
@@ -68,4 +68,21 @@ class HibernateJpaParametersParameterAccessor extends JpaParametersParameterAcce
 		}
 		return new TypedParameterValue(type, null);
 	}
+
+	/**
+	 * Utility method to potentially unwrap {@link TypedParameterValue}s. For certain operations, Hibernate doesn't
+	 * properly support them, so we must unwrap them before passing through.
+	 *
+	 * @param extractedValue
+	 * @return the value behind a {@link TypedParameterValue}
+	 */
+	@Override
+	public Object potentiallyUnwrap(Object extractedValue) {
+
+		if (extractedValue instanceof TypedParameterValue) {
+			return ((TypedParameterValue) extractedValue).getValue();
+		} else {
+			return extractedValue;
+		}
+	}
 }

--- a/src/main/java/org/springframework/data/jpa/repository/query/JpaParametersParameterAccessor.java
+++ b/src/main/java/org/springframework/data/jpa/repository/query/JpaParametersParameterAccessor.java
@@ -45,6 +45,17 @@ public class JpaParametersParameterAccessor extends ParametersParameterAccessor 
 		return super.getValue(parameter.getIndex());
 	}
 
+	/**
+	 * Utility method to potentially unwrap certain provider-specific types. For general JPA, there are none, so it's a pass-through.
+	 *
+	 * @param extractedValue
+	 * @return the same value passed in
+	 */
+	@Nullable
+	public Object potentiallyUnwrap(Object extractedValue) {
+		return extractedValue;
+	}
+
 	@Override
 	public Object[] getValues() {
 		return super.getValues();

--- a/src/main/java/org/springframework/data/jpa/repository/query/QueryParameterSetter.java
+++ b/src/main/java/org/springframework/data/jpa/repository/query/QueryParameterSetter.java
@@ -27,6 +27,7 @@ import java.util.function.Function;
 
 import javax.persistence.Parameter;
 import javax.persistence.Query;
+import javax.persistence.StoredProcedureQuery;
 import javax.persistence.TemporalType;
 import javax.persistence.criteria.ParameterExpression;
 
@@ -83,7 +84,15 @@ interface QueryParameterSetter {
 		public void setParameter(BindableQuery query, JpaParametersParameterAccessor accessor,
 				ErrorHandling errorHandling) {
 
-			final Object value = valueExtractor.apply(accessor);
+			final Object value;
+
+			if (query.getQuery() instanceof StoredProcedureQuery) {
+
+				Object extractedValue = valueExtractor.apply(accessor);
+				value = accessor.potentiallyUnwrap(extractedValue);
+			} else {
+				value = valueExtractor.apply(accessor);
+			}
 
 			if (temporalType != null) {
 

--- a/src/main/java/org/springframework/data/jpa/repository/query/QueryParameterSetter.java
+++ b/src/main/java/org/springframework/data/jpa/repository/query/QueryParameterSetter.java
@@ -15,7 +15,7 @@
  */
 package org.springframework.data.jpa.repository.query;
 
-import static org.springframework.data.jpa.repository.query.QueryParameterSetter.ErrorHandling.LENIENT;
+import static org.springframework.data.jpa.repository.query.QueryParameterSetter.ErrorHandling.*;
 
 import java.lang.reflect.Proxy;
 import java.util.Collections;
@@ -27,13 +27,11 @@ import java.util.function.Function;
 
 import javax.persistence.Parameter;
 import javax.persistence.Query;
-import javax.persistence.StoredProcedureQuery;
 import javax.persistence.TemporalType;
 import javax.persistence.criteria.ParameterExpression;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.hibernate.jpa.TypedParameterValue;
 import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
 
@@ -85,21 +83,7 @@ interface QueryParameterSetter {
 		public void setParameter(BindableQuery query, JpaParametersParameterAccessor accessor,
 				ErrorHandling errorHandling) {
 
-			final Object value;
-
-			// TODO: When https://github.com/hibernate/hibernate-orm/pull/5438 is merged we should be able to drop this.
-			if (query.getQuery() instanceof StoredProcedureQuery) {
-
-				Object extractedValue = valueExtractor.apply(accessor);
-
-				if (extractedValue instanceof TypedParameterValue) {
-					value = ((TypedParameterValue) extractedValue).getValue();
-				} else {
-					value = extractedValue;
-				}
-			} else {
-				value = valueExtractor.apply(accessor);
-			}
+			final Object value = valueExtractor.apply(accessor);
 
 			if (temporalType != null) {
 


### PR DESCRIPTION
When performing stored procedures, Hibernate's `TypedParameterValue` must be handled properly so that it doesn't break when someone instead uses EclipseLink.