### PR TITLE
Rewrite LIKE with wildcards using CONCAT function.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-jpa-parent</artifactId>
-	<version>3.1.0-SNAPSHOT</version>
+	<version>3.1.0-gh-2939-take2-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data JPA Parent</name>

--- a/spring-data-envers/pom.xml
+++ b/spring-data-envers/pom.xml
@@ -5,12 +5,12 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-envers</artifactId>
-	<version>3.1.0-SNAPSHOT</version>
+	<version>3.1.0-gh-2939-take2-SNAPSHOT</version>
 
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-jpa-parent</artifactId>
-		<version>3.1.0-SNAPSHOT</version>
+		<version>3.1.0-gh-2939-take2-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-jpa-distribution/pom.xml
+++ b/spring-data-jpa-distribution/pom.xml
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-jpa-parent</artifactId>
-		<version>3.1.0-SNAPSHOT</version>
+		<version>3.1.0-gh-2939-take2-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-jpa/pom.xml
+++ b/spring-data-jpa/pom.xml
@@ -6,7 +6,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-jpa</artifactId>
-	<version>3.1.0-SNAPSHOT</version>
+	<version>3.1.0-gh-2939-take2-SNAPSHOT</version>
 
 	<name>Spring Data JPA</name>
 	<description>Spring Data module for JPA repositories.</description>
@@ -15,7 +15,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-jpa-parent</artifactId>
-		<version>3.1.0-SNAPSHOT</version>
+		<version>3.1.0-gh-2939-take2-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/LikeBindingUnitTests.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/LikeBindingUnitTests.java
@@ -84,14 +84,4 @@ class LikeBindingUnitTests {
 		assertThat(binding.hasPosition(1)).isTrue();
 		assertThat(binding.getType()).isEqualTo(Type.CONTAINING);
 	}
-
-	@Test
-	void augmentsValueCorrectly() {
-
-		assertAugmentedValue(Type.CONTAINING, "%value%");
-		assertAugmentedValue(Type.ENDING_WITH, "%value");
-		assertAugmentedValue(Type.STARTING_WITH, "value%");
-
-		assertThat(new LikeParameterBinding(1, Type.CONTAINING).prepare(null)).isNull();
-	}
 }

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/QueryWithNullLikeIntegrationTests.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/QueryWithNullLikeIntegrationTests.java
@@ -15,7 +15,7 @@
  */
 package org.springframework.data.jpa.repository.query;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.*;
 
 import jakarta.persistence.EntityManagerFactory;
 
@@ -98,6 +98,40 @@ class QueryWithNullLikeIntegrationTests {
 	void customQueryWithNullMatch() {
 
 		List<EmployeeWithName> Employees = repository.customQueryWithNullableParam(null);
+
+		assertThat(Employees).extracting(EmployeeWithName::getName).isEmpty();
+	}
+
+	@Test
+	void customQueryWithMultipleMatchInNative() {
+
+		List<EmployeeWithName> Employees = repository.customQueryWithNullableParamInNative("Baggins");
+
+		assertThat(Employees).extracting(EmployeeWithName::getName).containsExactlyInAnyOrder("Frodo Baggins",
+				"Bilbo Baggins");
+	}
+
+	@Test
+	void customQueryWithSingleMatchInNative() {
+
+		List<EmployeeWithName> Employees = repository.customQueryWithNullableParamInNative("Frodo");
+
+		assertThat(Employees).extracting(EmployeeWithName::getName).containsExactlyInAnyOrder("Frodo Baggins");
+	}
+
+	@Test
+	void customQueryWithEmptyStringMatchInNative() {
+
+		List<EmployeeWithName> Employees = repository.customQueryWithNullableParamInNative("");
+
+		assertThat(Employees).extracting(EmployeeWithName::getName).containsExactlyInAnyOrder("Frodo Baggins",
+				"Bilbo Baggins");
+	}
+
+	@Test
+	void customQueryWithNullMatchInNative() {
+
+		List<EmployeeWithName> Employees = repository.customQueryWithNullableParamInNative(null);
 
 		assertThat(Employees).extracting(EmployeeWithName::getName).isEmpty();
 	}
@@ -234,6 +268,9 @@ class QueryWithNullLikeIntegrationTests {
 
 		@Query("select e from EmployeeWithName e where e.name like %:partialName%")
 		List<EmployeeWithName> customQueryWithNullableParam(@Nullable @Param("partialName") String partialName);
+
+		@Query(value = "select * from EmployeeWithName as e where e.name like %:partialName%", nativeQuery = true)
+		List<EmployeeWithName> customQueryWithNullableParamInNative(@Nullable @Param("partialName") String partialName);
 
 		List<EmployeeWithName> findByNameStartsWith(@Nullable String partialName);
 

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/StringQueryUnitTests.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/StringQueryUnitTests.java
@@ -65,7 +65,7 @@ class StringQueryUnitTests {
 
 		assertThat(query.hasParameterBindings()).isTrue();
 		assertThat(query.getQueryString())
-				.isEqualTo("select u from User u where u.firstname like ?1 or u.lastname like ?2");
+				.isEqualTo("select u from User u where u.firstname like CONCAT('%',?1,'%') or u.lastname like CONCAT('%',?2)");
 
 		List<ParameterBinding> bindings = query.getParameterBindings();
 		assertThat(bindings).hasSize(2);
@@ -87,7 +87,7 @@ class StringQueryUnitTests {
 		StringQuery query = new StringQuery("select u from User u where u.firstname like %:firstname", true);
 
 		assertThat(query.hasParameterBindings()).isTrue();
-		assertThat(query.getQueryString()).isEqualTo("select u from User u where u.firstname like :firstname");
+		assertThat(query.getQueryString()).isEqualTo("select u from User u where u.firstname like CONCAT('%',:firstname)");
 
 		List<ParameterBinding> bindings = query.getParameterBindings();
 		assertThat(bindings).hasSize(1);
@@ -199,8 +199,9 @@ class StringQueryUnitTests {
 		assertNamedBinding(LikeParameterBinding.class, "escapedWord", bindings.get(0));
 		assertNamedBinding(ParameterBinding.class, "word", bindings.get(1));
 
-		assertThat(query.getQueryString()).isEqualTo("SELECT a FROM Article a WHERE a.overview LIKE :escapedWord ESCAPE '~'"
-				+ " OR a.content LIKE :escapedWord ESCAPE '~' OR a.title = :word ORDER BY a.articleId DESC");
+		assertThat(query.getQueryString())
+				.isEqualTo("SELECT a FROM Article a WHERE a.overview LIKE CONCAT('%',:escapedWord,'%') ESCAPE '~'"
+						+ " OR a.content LIKE CONCAT('%',:escapedWord,'%') ESCAPE '~' OR a.title = :word ORDER BY a.articleId DESC");
 	}
 
 	@Test // DATAJPA-483


### PR DESCRIPTION
Since queries like `select e from Employee e where e.name like %:name%` as well as `select * from Employee AS e where e.name like %:name%` both result in the wildcards being pulled out and migrated to the bindings, I have tuned that action to instead replace them with a `CONCAT` function.

`CONCAT` appears to be supported on all major relational databases as well as on all JPA providers.

This means we can eliminate the race condition that arises when you use the same binding more than once, and only one of them has a wildcard.

And because this doesn't impact any public-facing APIs nor does it involve the query parser, I believe this PR is a candidate for backporting to `3.0.x` as well as `2.7.x.`

I took the liberty of introducing a warning in the log files that can alert users to this, tipping them off that it may be to their advantage to rewrite their custom query using the same pattern, in case this feature is no longer supported in the future. If you think this is unneeded, we can remove it. However, I think it's fair to nudge people to in fact rewrite their queries and make them more standard.