### PR TITLE
Improve SimpleJpaRepository.deleteAll() to align with other variants

### DIFF
--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/support/SimpleJpaRepository.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/support/SimpleJpaRepository.java
@@ -279,9 +279,13 @@ public class SimpleJpaRepository<T, ID> implements JpaRepositoryImplementation<T
 	@Transactional
 	public void deleteAll() {
 
-		for (T element : findAll()) {
-			delete(element);
-		}
+		String queryString = String.format(DELETE_ALL_QUERY_STRING, entityInformation.getEntityName());
+
+		Query query = em.createQuery(queryString);
+
+		applyQueryHints(query);
+
+		query.executeUpdate();
 	}
 
 	@Override


### PR DESCRIPTION
Before this commit, `deleteAll()` will load all entities to memory then delete one by one, it is ineffective and not consistent with other variants.