### PR TITLE
Revise String Query `ParameterBinding`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-jpa-parent</artifactId>
-	<version>3.2.0-SNAPSHOT</version>
+	<version>3.2.0-GH-3041-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data JPA Parent</name>

--- a/spring-data-envers/pom.xml
+++ b/spring-data-envers/pom.xml
@@ -5,12 +5,12 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-envers</artifactId>
-	<version>3.2.0-SNAPSHOT</version>
+	<version>3.2.0-GH-3041-SNAPSHOT</version>
 
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-jpa-parent</artifactId>
-		<version>3.2.0-SNAPSHOT</version>
+		<version>3.2.0-GH-3041-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-jpa-distribution/pom.xml
+++ b/spring-data-jpa-distribution/pom.xml
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-jpa-parent</artifactId>
-		<version>3.2.0-SNAPSHOT</version>
+		<version>3.2.0-GH-3041-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-jpa/pom.xml
+++ b/spring-data-jpa/pom.xml
@@ -6,7 +6,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-jpa</artifactId>
-	<version>3.2.0-SNAPSHOT</version>
+	<version>3.2.0-GH-3041-SNAPSHOT</version>
 
 	<name>Spring Data JPA</name>
 	<description>Spring Data module for JPA repositories.</description>
@@ -15,7 +15,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-jpa-parent</artifactId>
-		<version>3.2.0-SNAPSHOT</version>
+		<version>3.2.0-GH-3041-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/provider/PersistenceProvider.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/provider/PersistenceProvider.java
@@ -327,14 +327,15 @@ public enum PersistenceProvider implements QueryExtractor, ProxyIdAccessor, Quer
 	}
 
 	/**
-	 * Because Hibernate's {@literal TypedParameterValue} is only used to wrap a {@literal null}, swap it out with an
-	 * empty string for query creation.
+	 * Because Hibernate's {@literal TypedParameterValue} is only used to wrap a {@literal null}, swap it out with
+	 * {@code null} for query creation.
 	 *
 	 * @param value
 	 * @return the original value or null.
 	 * @since 3.0
 	 */
-	public static Object unwrapTypedParameterValue(Object value) {
+	@Nullable
+	public static Object unwrapTypedParameterValue(@Nullable Object value) {
 
 		return typedParameterValueClass != null && typedParameterValueClass.isInstance(value) //
 				? null //

--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/DeclaredQuery.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/DeclaredQuery.java
@@ -71,9 +71,9 @@ interface DeclaredQuery {
 	boolean isDefaultProjection();
 
 	/**
-	 * Returns the {@link StringQuery.ParameterBinding}s registered.
+	 * Returns the {@link ParameterBinding}s registered.
 	 */
-	List<StringQuery.ParameterBinding> getParameterBindings();
+	List<ParameterBinding> getParameterBindings();
 
 	/**
 	 * Creates a new {@literal DeclaredQuery} representing a count query, i.e. a query returning the number of rows to be

--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/EmptyDeclaredQuery.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/EmptyDeclaredQuery.java
@@ -60,7 +60,7 @@ class EmptyDeclaredQuery implements DeclaredQuery {
 	}
 
 	@Override
-	public List<StringQuery.ParameterBinding> getParameterBindings() {
+	public List<ParameterBinding> getParameterBindings() {
 		return Collections.emptyList();
 	}
 

--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/ParameterBinderFactory.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/ParameterBinderFactory.java
@@ -46,10 +46,11 @@ class ParameterBinderFactory {
 
 		Assert.notNull(parameters, "JpaParameters must not be null");
 
+		QueryParameterSetterFactory likeFactory = QueryParameterSetterFactory.forLikeRewrite(parameters);
 		QueryParameterSetterFactory setterFactory = QueryParameterSetterFactory.basic(parameters);
 		List<ParameterBinding> bindings = getBindings(parameters);
 
-		return new ParameterBinder(parameters, createSetters(bindings, setterFactory));
+		return new ParameterBinder(parameters, createSetters(bindings, likeFactory, setterFactory));
 	}
 
 	/**
@@ -95,9 +96,12 @@ class ParameterBinderFactory {
 		List<ParameterBinding> bindings = query.getParameterBindings();
 		QueryParameterSetterFactory expressionSetterFactory = QueryParameterSetterFactory.parsing(parser,
 				evaluationContextProvider, parameters);
+
+		QueryParameterSetterFactory like = QueryParameterSetterFactory.forLikeRewrite(parameters);
 		QueryParameterSetterFactory basicSetterFactory = QueryParameterSetterFactory.basic(parameters);
 
-		return new ParameterBinder(parameters, createSetters(bindings, query, expressionSetterFactory, basicSetterFactory),
+		return new ParameterBinder(parameters,
+				createSetters(bindings, query, expressionSetterFactory, like, basicSetterFactory),
 				!query.usesPaging());
 	}
 

--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/ParameterBinding.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/ParameterBinding.java
@@ -1,0 +1,582 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.jpa.repository.query;
+
+import static org.springframework.util.ObjectUtils.*;
+
+import java.lang.reflect.Array;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+
+import org.springframework.data.jpa.provider.PersistenceProvider;
+import org.springframework.data.jpa.repository.query.JpaParameters.JpaParameter;
+import org.springframework.data.repository.query.parser.Part.Type;
+import org.springframework.lang.Nullable;
+import org.springframework.util.Assert;
+import org.springframework.util.ObjectUtils;
+import org.springframework.util.StringUtils;
+
+/**
+ * A generic parameter binding with name or position information.
+ *
+ * @author Thomas Darimont
+ * @author Mark Paluch
+ */
+class ParameterBinding {
+
+	private final BindingIdentifier identifier;
+	private final ParameterOrigin origin;
+
+	/**
+	 * Creates a new {@link ParameterBinding} for the parameter with the given identifier and origin.
+	 *
+	 * @param identifier of the parameter, must not be {@literal null}.
+	 * @param origin the origin of the parameter (expression or method argument)
+	 */
+	ParameterBinding(BindingIdentifier identifier, ParameterOrigin origin) {
+
+		Assert.notNull(identifier, "BindingIdentifier must not be null");
+		Assert.notNull(origin, "ParameterOrigin must not be null");
+
+		this.identifier = identifier;
+		this.origin = origin;
+	}
+
+	public BindingIdentifier getIdentifier() {
+		return identifier;
+	}
+
+	public ParameterOrigin getOrigin() {
+		return origin;
+	}
+
+	/**
+	 * @return the name if available or {@literal null}.
+	 */
+	@Nullable
+	public String getName() {
+		return identifier.hasName() ? identifier.getName() : null;
+	}
+
+	/**
+	 * @return the name
+	 * @throws IllegalStateException if the name is not available.
+	 * @since 2.0
+	 */
+	String getRequiredName() throws IllegalStateException {
+
+		String name = getName();
+
+		if (name != null) {
+			return name;
+		}
+
+		throw new IllegalStateException(String.format("Required name for %s not available", this));
+	}
+
+	/**
+	 * @return the position if available or {@literal null}.
+	 */
+	@Nullable
+	Integer getPosition() {
+		return identifier.hasPosition() ? identifier.getPosition() : null;
+	}
+
+	/**
+	 * @return the position
+	 * @throws IllegalStateException if the position is not available.
+	 * @since 2.0
+	 */
+	int getRequiredPosition() throws IllegalStateException {
+
+		Integer position = getPosition();
+
+		if (position != null) {
+			return position;
+		}
+
+		throw new IllegalStateException(String.format("Required position for %s not available", this));
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o)
+			return true;
+		if (o == null || getClass() != o.getClass())
+			return false;
+
+		ParameterBinding that = (ParameterBinding) o;
+
+		if (!nullSafeEquals(identifier, that.identifier)) {
+			return false;
+		}
+		return nullSafeEquals(origin, that.origin);
+	}
+
+	@Override
+	public int hashCode() {
+		int result = nullSafeHashCode(identifier);
+		result = 31 * result + nullSafeHashCode(origin);
+		return result;
+	}
+
+	@Override
+	public String toString() {
+		return String.format("ParameterBinding [identifier: %s, origin: %s]", identifier, origin);
+	}
+
+	/**
+	 * @param valueToBind value to prepare
+	 */
+	@Nullable
+	public Object prepare(@Nullable Object valueToBind) {
+		return valueToBind;
+	}
+
+	/**
+	 * Check whether the {@code other} binding uses the same bind target.
+	 *
+	 * @param other
+	 * @return
+	 */
+	public boolean bindsTo(ParameterBinding other) {
+
+		if (identifier.hasName() && other.identifier.hasName()) {
+			if (identifier.getName().equals(other.identifier.getName())) {
+				return true;
+			}
+		}
+
+		if (identifier.hasPosition() && other.identifier.hasPosition()) {
+			if (identifier.getPosition() == other.identifier.getPosition()) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * Represents a {@link ParameterBinding} in a JPQL query augmented with instructions of how to apply a parameter as an
+	 * {@code IN} parameter.
+	 *
+	 * @author Thomas Darimont
+	 */
+	static class InParameterBinding extends ParameterBinding {
+
+		/**
+		 * Creates a new {@link InParameterBinding} for the parameter with the given name.
+		 */
+		InParameterBinding(BindingIdentifier identifier, ParameterOrigin origin) {
+			super(identifier, origin);
+		}
+
+		@Override
+		public Object prepare(@Nullable Object value) {
+
+			if (!ObjectUtils.isArray(value)) {
+				return value;
+			}
+
+			int length = Array.getLength(value);
+			Collection<Object> result = new ArrayList<>(length);
+
+			for (int i = 0; i < length; i++) {
+				result.add(Array.get(value, i));
+			}
+
+			return result;
+		}
+	}
+
+	/**
+	 * Represents a parameter binding in a JPQL query augmented with instructions of how to apply a parameter as LIKE
+	 * parameter. This allows expressions like {@code …like %?1} in the JPQL query, which is not allowed by plain JPA.
+	 *
+	 * @author Oliver Gierke
+	 * @author Thomas Darimont
+	 */
+	static class LikeParameterBinding extends ParameterBinding {
+
+		private static final List<Type> SUPPORTED_TYPES = Arrays.asList(Type.CONTAINING, Type.STARTING_WITH,
+				Type.ENDING_WITH, Type.LIKE);
+
+		private final Type type;
+
+		/**
+		 * Creates a new {@link LikeParameterBinding} for the parameter with the given name and {@link Type} and parameter
+		 * binding input.
+		 *
+		 * @param identifier must not be {@literal null} or empty.
+		 * @param type must not be {@literal null}.
+		 */
+		LikeParameterBinding(BindingIdentifier identifier, ParameterOrigin origin, Type type) {
+
+			super(identifier, origin);
+
+			Assert.notNull(type, "Type must not be null");
+
+			Assert.isTrue(SUPPORTED_TYPES.contains(type),
+					String.format("Type must be one of %s", StringUtils.collectionToCommaDelimitedString(SUPPORTED_TYPES)));
+
+			this.type = type;
+		}
+
+		/**
+		 * Returns the {@link Type} of the binding.
+		 *
+		 * @return the type
+		 */
+		public Type getType() {
+			return type;
+		}
+
+		/**
+		 * Extracts the raw value properly.
+		 */
+		@Nullable
+		@Override
+		public Object prepare(@Nullable Object value) {
+
+			Object unwrapped = PersistenceProvider.unwrapTypedParameterValue(value);
+			if (unwrapped == null) {
+				return null;
+			}
+
+			return switch (type) {
+				case STARTING_WITH -> String.format("%s%%", unwrapped);
+				case ENDING_WITH -> String.format("%%%s", unwrapped);
+				case CONTAINING -> String.format("%%%s%%", unwrapped);
+				default -> unwrapped;
+			};
+		}
+
+		@Override
+		public boolean equals(Object obj) {
+
+			if (!(obj instanceof LikeParameterBinding)) {
+				return false;
+			}
+
+			LikeParameterBinding that = (LikeParameterBinding) obj;
+
+			return super.equals(obj) && this.type.equals(that.type);
+		}
+
+		@Override
+		public int hashCode() {
+
+			int result = super.hashCode();
+
+			result += nullSafeHashCode(this.type);
+
+			return result;
+		}
+
+		@Override
+		public String toString() {
+			return String.format("LikeBinding [identifier: %s, origin: %s, type: %s]", getIdentifier(), getOrigin(),
+					getType());
+		}
+
+		/**
+		 * Extracts the like {@link Type} from the given JPA like expression.
+		 *
+		 * @param expression must not be {@literal null} or empty.
+		 */
+		static Type getLikeTypeFrom(String expression) {
+
+			Assert.hasText(expression, "Expression must not be null or empty");
+
+			if (expression.matches("%.*%")) {
+				return Type.CONTAINING;
+			}
+
+			if (expression.startsWith("%")) {
+				return Type.ENDING_WITH;
+			}
+
+			if (expression.endsWith("%")) {
+				return Type.STARTING_WITH;
+			}
+
+			return Type.LIKE;
+		}
+	}
+
+	static class ParameterImpl<T> implements jakarta.persistence.Parameter<T> {
+
+		private final BindingIdentifier identifier;
+		private final Class<T> parameterType;
+
+		/**
+		 * Creates a new {@link ParameterImpl} for the given {@link JpaParameter} and {@link ParameterBinding}.
+		 *
+		 * @param parameter can be {@literal null}.
+		 * @param binding must not be {@literal null}.
+		 * @return a {@link jakarta.persistence.Parameter} object based on the information from the arguments.
+		 */
+		static jakarta.persistence.Parameter<?> of(@Nullable JpaParameter parameter, ParameterBinding binding) {
+
+			Class<?> type = parameter == null ? Object.class : parameter.getType();
+
+			return new ParameterImpl<>(binding.getIdentifier(), type);
+		}
+
+		public ParameterImpl(BindingIdentifier identifier, Class<T> parameterType) {
+			this.identifier = identifier;
+			this.parameterType = parameterType;
+		}
+
+		@Nullable
+		@Override
+		public String getName() {
+			return identifier.hasName() ? identifier.getName() : null;
+		}
+
+		@Nullable
+		@Override
+		public Integer getPosition() {
+			return identifier.hasPosition() ? identifier.getPosition() : null;
+		}
+
+		@Override
+		public Class<T> getParameterType() {
+			return parameterType;
+		}
+
+	}
+
+	/**
+	 * Identifies a binding parameter by name, position or both. Used to bind parameters to a query or to describe a
+	 * {@link MethodInvocationArgument} origin.
+	 */
+	sealed interface BindingIdentifier permits Named,Indexed,NamedAndIndexed {
+
+		/**
+		 * Creates an identifier for the given {@code name}.
+		 *
+		 * @param name
+		 * @return
+		 */
+		static BindingIdentifier of(String name) {
+
+			Assert.hasText(name, "Name must not be empty");
+
+			return new Named(name);
+		}
+
+		/**
+		 * Creates an identifier for the given {@code position}.
+		 *
+		 * @param position 1-based index.
+		 * @return
+		 */
+		static BindingIdentifier of(int position) {
+
+			Assert.isTrue(position > 0, "Index position must be greater zero");
+
+			return new Indexed(position);
+		}
+
+		/**
+		 * Creates an identifier for the given {@code name} and {@code position}.
+		 *
+		 * @param name
+		 * @return
+		 */
+		static BindingIdentifier of(String name, int position) {
+
+			Assert.hasText(name, "Name must not be empty");
+
+			return new NamedAndIndexed(name, position);
+		}
+
+		/**
+		 * @return {@code true} if the binding is associated with a name.
+		 */
+		default boolean hasName() {
+			return false;
+		}
+
+		/**
+		 * @return {@code true} if the binding is associated with a position index.
+		 */
+		default boolean hasPosition() {
+			return false;
+		}
+
+		/**
+		 * Returns the binding name {@link #hasName() if present} or throw {@link IllegalStateException} if no name
+		 * associated.
+		 *
+		 * @return the binding name.
+		 */
+		default String getName() {
+			throw new IllegalStateException("No name associated");
+		}
+
+		/**
+		 * Returns the binding name {@link #hasPosition() if present} or throw {@link IllegalStateException} if no position
+		 * associated.
+		 *
+		 * @return the binding position.
+		 */
+		default int getPosition() {
+			throw new IllegalStateException("No position associated");
+		}
+	}
+
+	private record Named(String name) implements BindingIdentifier {
+
+		@Override
+		public boolean hasName() {
+			return true;
+		}
+
+		@Override
+		public String getName() {
+			return name();
+		}
+	}
+
+	private record Indexed(int position) implements BindingIdentifier {
+
+		@Override
+		public boolean hasPosition() {
+			return true;
+		}
+
+		@Override
+		public int getPosition() {
+			return position();
+		}
+	}
+
+	private record NamedAndIndexed(String name, int position) implements BindingIdentifier {
+
+		@Override
+		public boolean hasName() {
+			return true;
+		}
+
+		@Override
+		public String getName() {
+			return name();
+		}
+
+		@Override
+		public boolean hasPosition() {
+			return true;
+		}
+
+		@Override
+		public int getPosition() {
+			return position();
+		}
+	}
+
+	/**
+	 * Value type hierarchy to describe where a binding parameter comes from, either method call or an expression.
+	 */
+	sealed interface ParameterOrigin permits Expression,MethodInvocationArgument {
+
+		/**
+		 * Creates a {@link Expression} for the given {@code expression} string.
+		 *
+		 * @param expression must not be {@literal null}.
+		 * @return {@link Expression} for the given {@code expression} string.
+		 */
+		static Expression ofExpression(String expression) {
+			return new Expression(expression);
+		}
+
+		/**
+		 * Creates a {@link MethodInvocationArgument} object for {@code name} and {@code position}. Either the name or the
+		 * position must be given,
+		 *
+		 * @param name the parameter name from the method invocation, can be {@literal null}.
+		 * @param position the parameter position (1-based) from the method invocation, can be {@literal null}.
+		 * @return {@link MethodInvocationArgument} object for {@code name} and {@code position}
+		 */
+		static MethodInvocationArgument ofParameter(@Nullable String name, @Nullable Integer position) {
+
+			BindingIdentifier identifier;
+			if (!ObjectUtils.isEmpty(name) && position != null) {
+				identifier = BindingIdentifier.of(name, position);
+			} else if (!ObjectUtils.isEmpty(name)) {
+				identifier = BindingIdentifier.of(name);
+			} else {
+				identifier = BindingIdentifier.of(position);
+			}
+
+			return ofParameter(identifier);
+		}
+
+		/**
+		 * Creates a {@link MethodInvocationArgument} using {@link BindingIdentifier}.
+		 *
+		 * @param identifier must not be {@literal null}.
+		 * @return {@link MethodInvocationArgument} for {@link BindingIdentifier}.
+		 */
+		static MethodInvocationArgument ofParameter(BindingIdentifier identifier) {
+
+			return new MethodInvocationArgument(identifier);
+		}
+
+		boolean isMethodArgument();
+
+		boolean isExpression();
+	}
+
+	/**
+	 * Value object capturing the expression of which a binding parameter originates.
+	 *
+	 * @param expression
+	 */
+	public record Expression(String expression) implements ParameterOrigin {
+
+		@Override
+		public boolean isMethodArgument() {
+			return false;
+		}
+
+		@Override
+		public boolean isExpression() {
+			return true;
+		}
+	}
+
+	/**
+	 * Value object capturing the method invocation parameter reference.
+	 *
+	 * @param identifier
+	 */
+	public record MethodInvocationArgument(BindingIdentifier identifier) implements ParameterOrigin {
+
+		@Override
+		public boolean isMethodArgument() {
+			return true;
+		}
+
+		@Override
+		public boolean isExpression() {
+			return false;
+		}
+	}
+}

--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/QueryParameterSetter.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/QueryParameterSetter.java
@@ -109,7 +109,7 @@ interface QueryParameterSetter {
 
 			} else {
 
-				final Object value = valueExtractor.apply(accessor);
+				Object value = valueExtractor.apply(accessor);
 
 				if (parameter instanceof ParameterExpression) {
 					errorHandling.execute(() -> query.setParameter((Parameter<Object>) parameter, value));

--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/QueryParameterSetterFactory.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/QueryParameterSetterFactory.java
@@ -24,7 +24,6 @@ import java.util.function.Function;
 import org.springframework.data.jpa.repository.query.JpaParameters.JpaParameter;
 import org.springframework.data.jpa.repository.query.ParameterBinding.BindingIdentifier;
 import org.springframework.data.jpa.repository.query.ParameterBinding.MethodInvocationArgument;
-import org.springframework.data.jpa.repository.query.ParameterBinding.ParameterImpl;
 import org.springframework.data.jpa.repository.query.ParameterMetadataProvider.ParameterMetadata;
 import org.springframework.data.jpa.repository.query.QueryParameterSetter.NamedOrIndexedQueryParameterSetter;
 import org.springframework.data.repository.query.Parameter;
@@ -321,6 +320,49 @@ abstract class QueryParameterSetterFactory {
 				JpaParametersParameterAccessor accessor) {
 			return metadata.prepare(accessor.getValue(parameter));
 		}
+	}
+
+	static class ParameterImpl<T> implements jakarta.persistence.Parameter<T> {
+
+		private final BindingIdentifier identifier;
+		private final Class<T> parameterType;
+
+		/**
+		 * Creates a new {@link ParameterImpl} for the given {@link JpaParameter} and {@link ParameterBinding}.
+		 *
+		 * @param parameter can be {@literal null}.
+		 * @param binding must not be {@literal null}.
+		 * @return a {@link jakarta.persistence.Parameter} object based on the information from the arguments.
+		 */
+		static jakarta.persistence.Parameter<?> of(@Nullable JpaParameter parameter, ParameterBinding binding) {
+
+			Class<?> type = parameter == null ? Object.class : parameter.getType();
+
+			return new ParameterImpl<>(binding.getIdentifier(), type);
+		}
+
+		public ParameterImpl(BindingIdentifier identifier, Class<T> parameterType) {
+			this.identifier = identifier;
+			this.parameterType = parameterType;
+		}
+
+		@Nullable
+		@Override
+		public String getName() {
+			return identifier.hasName() ? identifier.getName() : null;
+		}
+
+		@Nullable
+		@Override
+		public Integer getPosition() {
+			return identifier.hasPosition() ? identifier.getPosition() : null;
+		}
+
+		@Override
+		public Class<T> getParameterType() {
+			return parameterType;
+		}
+
 	}
 
 }

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/UserRepositoryTests.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/UserRepositoryTests.java
@@ -978,6 +978,9 @@ class UserRepositoryTests {
 
 		assertThat(repository.findByFirstnameLikeNamed("Da")).containsOnly(thirdUser);
 		assertThat(repository.findByFirstnameLikeNamed("in")).containsOnly(fourthUser);
+
+		assertThat(repository.findByFirstnameLikePositional("Da")).containsOnly(thirdUser);
+		assertThat(repository.findByFirstnameLikePositional("in")).containsOnly(fourthUser);
 	}
 
 	@Test // DATAJPA-231

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/UserRepositoryTests.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/UserRepositoryTests.java
@@ -971,14 +971,13 @@ class UserRepositoryTests {
 		assertThat(result).containsOnly(thirdUser);
 	}
 
-	@Test // DATAJPA-292
+	@Test // DATAJPA-292, GH-3041
 	void executesManualQueryWithNamedLikeExpressionCorrectly() {
 
 		flushTestUsers();
 
-		List<User> result = repository.findByFirstnameLikeNamed("Da");
-
-		assertThat(result).containsOnly(thirdUser);
+		assertThat(repository.findByFirstnameLikeNamed("Da")).containsOnly(thirdUser);
+		assertThat(repository.findByFirstnameLikeNamed("in")).containsOnly(fourthUser);
 	}
 
 	@Test // DATAJPA-231

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/ExpressionBasedStringQueryUnitTests.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/ExpressionBasedStringQueryUnitTests.java
@@ -18,6 +18,8 @@ package org.springframework.data.jpa.repository.query;
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
+import java.util.List;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -25,6 +27,8 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
+import org.springframework.data.jpa.repository.query.ParameterBinding.LikeParameterBinding;
+import org.springframework.data.repository.query.parser.Part.Type;
 import org.springframework.expression.spel.standard.SpelExpressionParser;
 
 /**
@@ -101,6 +105,7 @@ class ExpressionBasedStringQueryUnitTests {
 						+ "AND (n.updatedAt >= ?#{#networkRequest.updatedTime.startDateTime}) AND (n.updatedAt <=?#{#networkRequest.updatedTime.endDateTime})",
 				metadata, SPEL_PARSER, true);
 
+		System.out.println(query.getQueryString());
 		assertThat(query.isNativeQuery()).isFalse();
 	}
 
@@ -119,4 +124,55 @@ class ExpressionBasedStringQueryUnitTests {
 
 		assertThat(query.isNativeQuery()).isTrue();
 	}
+
+	@Test // GH-3041
+	void namedExpressionsShouldCreateLikeBindings() {
+
+		StringQuery query = new ExpressionBasedStringQuery(
+				"select u from User u where u.firstname like %:#{foo} or u.firstname like :#{foo}%", metadata, SPEL_PARSER,
+				false);
+
+		assertThat(query.hasParameterBindings()).isTrue();
+		assertThat(query.getQueryString()).isEqualTo(
+				"select u from User u where u.firstname like :__$synthetic$__1 or u.firstname like :__$synthetic$__2");
+
+		List<ParameterBinding> bindings = query.getParameterBindings();
+		assertThat(bindings).hasSize(2);
+
+		LikeParameterBinding binding = (LikeParameterBinding) bindings.get(0);
+		assertThat(binding).isNotNull();
+		assertThat(binding.getName()).isEqualTo("__$synthetic$__1");
+		assertThat(binding.getType()).isEqualTo(Type.ENDING_WITH);
+
+		binding = (LikeParameterBinding) bindings.get(1);
+		assertThat(binding).isNotNull();
+		assertThat(binding.getName()).isEqualTo("__$synthetic$__2");
+		assertThat(binding.getType()).isEqualTo(Type.STARTING_WITH);
+	}
+
+	@Test // GH-3041
+	void indexedExpressionsShouldCreateLikeBindings() {
+
+		StringQuery query = new ExpressionBasedStringQuery(
+				"select u from User u where u.firstname like %?#{foo} or u.firstname like ?#{foo}%", metadata, SPEL_PARSER,
+				false);
+
+		assertThat(query.hasParameterBindings()).isTrue();
+		assertThat(query.getQueryString())
+				.isEqualTo("select u from User u where u.firstname like ?1 or u.firstname like ?2");
+
+		List<ParameterBinding> bindings = query.getParameterBindings();
+		assertThat(bindings).hasSize(2);
+
+		LikeParameterBinding binding = (LikeParameterBinding) bindings.get(0);
+		assertThat(binding).isNotNull();
+		assertThat(binding.getPosition()).isEqualTo(1);
+		assertThat(binding.getType()).isEqualTo(Type.ENDING_WITH);
+
+		binding = (LikeParameterBinding) bindings.get(1);
+		assertThat(binding).isNotNull();
+		assertThat(binding.getPosition()).isEqualTo(2);
+		assertThat(binding.getType()).isEqualTo(Type.STARTING_WITH);
+	}
+
 }

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/LikeBindingUnitTests.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/LikeBindingUnitTests.java
@@ -18,7 +18,9 @@ package org.springframework.data.jpa.repository.query;
 import static org.assertj.core.api.Assertions.*;
 
 import org.junit.jupiter.api.Test;
-import org.springframework.data.jpa.repository.query.StringQuery.LikeParameterBinding;
+import org.springframework.data.jpa.repository.query.ParameterBinding.BindingIdentifier;
+import org.springframework.data.jpa.repository.query.ParameterBinding.LikeParameterBinding;
+import org.springframework.data.jpa.repository.query.ParameterBinding.ParameterOrigin;
 import org.springframework.data.repository.query.parser.Part.Type;
 
 /**
@@ -32,57 +34,39 @@ class LikeBindingUnitTests {
 
 	private static void assertAugmentedValue(Type type, Object value) {
 
-		LikeParameterBinding binding = new LikeParameterBinding("foo", "foo", type);
+		LikeParameterBinding binding = new LikeParameterBinding(BindingIdentifier.of("foo"),
+				ParameterOrigin.ofExpression("foo"), type);
 		assertThat(binding.prepare("value")).isEqualTo(value);
 	}
 
 	@Test
 	void rejectsNullName() {
-		assertThatIllegalArgumentException().isThrownBy(() -> new LikeParameterBinding(null, "", Type.CONTAINING));
+		assertThatIllegalArgumentException()
+				.isThrownBy(() -> new LikeParameterBinding(null, ParameterOrigin.ofExpression(""), Type.CONTAINING));
 	}
 
 	@Test
 	void rejectsEmptyName() {
-		assertThatIllegalArgumentException().isThrownBy(() -> new LikeParameterBinding("", "", Type.CONTAINING));
+		assertThatIllegalArgumentException().isThrownBy(
+				() -> new LikeParameterBinding(BindingIdentifier.of(""), ParameterOrigin.ofExpression(""), Type.CONTAINING));
 	}
 
 	@Test
 	void rejectsNullType() {
-		assertThatIllegalArgumentException().isThrownBy(() -> new LikeParameterBinding("foo", "foo", null));
+		assertThatIllegalArgumentException().isThrownBy(
+				() -> new LikeParameterBinding(BindingIdentifier.of("foo"), ParameterOrigin.ofExpression("foo"), null));
 	}
 
 	@Test
 	void rejectsInvalidType() {
-		assertThatIllegalArgumentException().isThrownBy(() -> new LikeParameterBinding("foo", "foo", Type.SIMPLE_PROPERTY));
+		assertThatIllegalArgumentException().isThrownBy(() -> new LikeParameterBinding(BindingIdentifier.of("foo"),
+				ParameterOrigin.ofExpression("foo"), Type.SIMPLE_PROPERTY));
 	}
 
 	@Test
 	void rejectsInvalidPosition() {
-		assertThatIllegalArgumentException().isThrownBy(() -> new LikeParameterBinding(0, Type.CONTAINING));
-	}
-
-	@Test
-	void setsUpInstanceForName() {
-
-		LikeParameterBinding binding = new LikeParameterBinding("foo", "foo", Type.CONTAINING);
-
-		assertThat(binding.hasName("foo")).isTrue();
-		assertThat(binding.hasName("bar")).isFalse();
-		assertThat(binding.hasName(null)).isFalse();
-		assertThat(binding.hasPosition(0)).isFalse();
-		assertThat(binding.getType()).isEqualTo(Type.CONTAINING);
-	}
-
-	@Test
-	void setsUpInstanceForIndex() {
-
-		LikeParameterBinding binding = new LikeParameterBinding(1, Type.CONTAINING);
-
-		assertThat(binding.hasName("foo")).isFalse();
-		assertThat(binding.hasName(null)).isFalse();
-		assertThat(binding.hasPosition(0)).isFalse();
-		assertThat(binding.hasPosition(1)).isTrue();
-		assertThat(binding.getType()).isEqualTo(Type.CONTAINING);
+		assertThatIllegalArgumentException().isThrownBy(
+				() -> new LikeParameterBinding(BindingIdentifier.of(0), ParameterOrigin.ofExpression(""), Type.CONTAINING));
 	}
 
 	@Test
@@ -92,6 +76,7 @@ class LikeBindingUnitTests {
 		assertAugmentedValue(Type.ENDING_WITH, "%value");
 		assertAugmentedValue(Type.STARTING_WITH, "value%");
 
-		assertThat(new LikeParameterBinding(1, Type.CONTAINING).prepare(null)).isNull();
+		assertThat(new LikeParameterBinding(BindingIdentifier.of(1), ParameterOrigin.ofParameter(null, 1), Type.CONTAINING)
+				.prepare(null)).isNull();
 	}
 }

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/LikeBindingUnitTests.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/LikeBindingUnitTests.java
@@ -32,28 +32,28 @@ class LikeBindingUnitTests {
 
 	private static void assertAugmentedValue(Type type, Object value) {
 
-		LikeParameterBinding binding = new LikeParameterBinding("foo", type);
+		LikeParameterBinding binding = new LikeParameterBinding("foo", "foo", type);
 		assertThat(binding.prepare("value")).isEqualTo(value);
 	}
 
 	@Test
 	void rejectsNullName() {
-		assertThatIllegalArgumentException().isThrownBy(() -> new LikeParameterBinding(null, Type.CONTAINING));
+		assertThatIllegalArgumentException().isThrownBy(() -> new LikeParameterBinding(null, "", Type.CONTAINING));
 	}
 
 	@Test
 	void rejectsEmptyName() {
-		assertThatIllegalArgumentException().isThrownBy(() -> new LikeParameterBinding("", Type.CONTAINING));
+		assertThatIllegalArgumentException().isThrownBy(() -> new LikeParameterBinding("", "", Type.CONTAINING));
 	}
 
 	@Test
 	void rejectsNullType() {
-		assertThatIllegalArgumentException().isThrownBy(() -> new LikeParameterBinding("foo", null));
+		assertThatIllegalArgumentException().isThrownBy(() -> new LikeParameterBinding("foo", "foo", null));
 	}
 
 	@Test
 	void rejectsInvalidType() {
-		assertThatIllegalArgumentException().isThrownBy(() -> new LikeParameterBinding("foo", Type.SIMPLE_PROPERTY));
+		assertThatIllegalArgumentException().isThrownBy(() -> new LikeParameterBinding("foo", "foo", Type.SIMPLE_PROPERTY));
 	}
 
 	@Test
@@ -64,7 +64,7 @@ class LikeBindingUnitTests {
 	@Test
 	void setsUpInstanceForName() {
 
-		LikeParameterBinding binding = new LikeParameterBinding("foo", Type.CONTAINING);
+		LikeParameterBinding binding = new LikeParameterBinding("foo", "foo", Type.CONTAINING);
 
 		assertThat(binding.hasName("foo")).isTrue();
 		assertThat(binding.hasName("bar")).isFalse();
@@ -83,5 +83,15 @@ class LikeBindingUnitTests {
 		assertThat(binding.hasPosition(0)).isFalse();
 		assertThat(binding.hasPosition(1)).isTrue();
 		assertThat(binding.getType()).isEqualTo(Type.CONTAINING);
+	}
+
+	@Test
+	void augmentsValueCorrectly() {
+
+		assertAugmentedValue(Type.CONTAINING, "%value%");
+		assertAugmentedValue(Type.ENDING_WITH, "%value");
+		assertAugmentedValue(Type.STARTING_WITH, "value%");
+
+		assertThat(new LikeParameterBinding(1, Type.CONTAINING).prepare(null)).isNull();
 	}
 }

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/QueryParameterSetterFactoryUnitTests.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/QueryParameterSetterFactoryUnitTests.java
@@ -25,9 +25,8 @@ import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
-
 import org.springframework.data.jpa.repository.query.JpaParameters.JpaParameter;
-import org.springframework.data.jpa.repository.query.StringQuery.ParameterBinding;
+import org.springframework.data.jpa.repository.query.ParameterBinding.ParameterOrigin;
 
 /**
  * Unit tests for {@link QueryParameterSetterFactory}.
@@ -60,6 +59,8 @@ class QueryParameterSetterFactoryUnitTests {
 	@Test // DATAJPA-1058
 	void exceptionWhenQueryContainNamedParametersAndMethodParametersAreNotNamed() {
 
+		when(binding.getOrigin()).thenReturn(ParameterOrigin.ofParameter("NamedParameter", 1));
+
 		assertThatExceptionOfType(IllegalStateException.class) //
 				.isThrownBy(() -> setterFactory.create(binding, DeclaredQuery.of("from Employee e where e.name = :NamedParameter", false))) //
 				.withMessageContaining("Java 8") //
@@ -76,6 +77,7 @@ class QueryParameterSetterFactoryUnitTests {
 
 		// one argument present in the method signature
 		when(binding.getRequiredPosition()).thenReturn(1);
+		when(binding.getOrigin()).thenReturn(ParameterOrigin.ofParameter(null, 1));
 
 		assertThatExceptionOfType(IllegalArgumentException.class) //
 				.isThrownBy(() -> setterFactory.create(binding, DeclaredQuery.of("from Employee e where e.name = :NamedParameter", false))) //
@@ -90,6 +92,7 @@ class QueryParameterSetterFactoryUnitTests {
 
 		// one argument present in the method signature
 		when(binding.getRequiredPosition()).thenReturn(1);
+		when(binding.getOrigin()).thenReturn(ParameterOrigin.ofParameter(null, 1));
 
 		assertThatExceptionOfType(IllegalArgumentException.class) //
 				.isThrownBy(() -> setterFactory.create(binding, DeclaredQuery.of("from Employee e where e.name = ?1", false))) //

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/StringQueryUnitTests.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/StringQueryUnitTests.java
@@ -22,9 +22,9 @@ import java.util.List;
 
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.springframework.data.jpa.repository.query.StringQuery.InParameterBinding;
-import org.springframework.data.jpa.repository.query.StringQuery.LikeParameterBinding;
-import org.springframework.data.jpa.repository.query.StringQuery.ParameterBinding;
+import org.springframework.data.jpa.repository.query.ParameterBinding.Expression;
+import org.springframework.data.jpa.repository.query.ParameterBinding.InParameterBinding;
+import org.springframework.data.jpa.repository.query.ParameterBinding.LikeParameterBinding;
 import org.springframework.data.repository.query.parser.Part.Type;
 
 /**
@@ -55,7 +55,7 @@ class StringQueryUnitTests {
 		LikeParameterBinding binding = (LikeParameterBinding) bindings.get(0);
 		assertThat(binding.getType()).isEqualTo(Type.LIKE);
 
-		assertThat(binding.hasName("firstname")).isTrue();
+		assertThat(binding.getName()).isEqualTo("firstname");
 	}
 
 	@Test // DATAJPA-292
@@ -73,12 +73,12 @@ class StringQueryUnitTests {
 
 		LikeParameterBinding binding = (LikeParameterBinding) bindings.get(0);
 		assertThat(binding).isNotNull();
-		assertThat(binding.hasPosition(1)).isTrue();
+		assertThat(binding.getRequiredPosition()).isEqualTo(1);
 		assertThat(binding.getType()).isEqualTo(Type.CONTAINING);
 
 		binding = (LikeParameterBinding) bindings.get(1);
 		assertThat(binding).isNotNull();
-		assertThat(binding.hasPosition(2)).isTrue();
+		assertThat(binding.getRequiredPosition()).isEqualTo(2);
 		assertThat(binding.getType()).isEqualTo(Type.ENDING_WITH);
 	}
 
@@ -95,7 +95,7 @@ class StringQueryUnitTests {
 
 		LikeParameterBinding binding = (LikeParameterBinding) bindings.get(0);
 		assertThat(binding).isNotNull();
-		assertThat(binding.hasName("firstname")).isTrue();
+		assertThat(binding.getRequiredName()).isEqualTo("firstname");
 		assertThat(binding.getType()).isEqualTo(Type.ENDING_WITH);
 	}
 
@@ -114,12 +114,12 @@ class StringQueryUnitTests {
 
 		LikeParameterBinding binding = (LikeParameterBinding) bindings.get(0);
 		assertThat(binding).isNotNull();
-		assertThat(binding.hasName("firstname")).isTrue();
+		assertThat(binding.getName()).isEqualTo("firstname");
 		assertThat(binding.getType()).isEqualTo(Type.ENDING_WITH);
 
 		binding = (LikeParameterBinding) bindings.get(1);
 		assertThat(binding).isNotNull();
-		assertThat(binding.hasName("firstname_1")).isTrue();
+		assertThat(binding.getName()).isEqualTo("firstname_1");
 		assertThat(binding.getType()).isEqualTo(Type.STARTING_WITH);
 	}
 
@@ -139,12 +139,12 @@ class StringQueryUnitTests {
 
 		LikeParameterBinding binding = (LikeParameterBinding) bindings.get(0);
 		assertThat(binding).isNotNull();
-		assertThat(binding.hasName("firstname")).isTrue();
+		assertThat(binding.getName()).isEqualTo("firstname");
 		assertThat(binding.getType()).isEqualTo(Type.ENDING_WITH);
 
 		binding = (LikeParameterBinding) bindings.get(1);
 		assertThat(binding).isNotNull();
-		assertThat(binding.hasName("firstname_1")).isTrue();
+		assertThat(binding.getName()).isEqualTo("firstname_1");
 		assertThat(binding.getType()).isEqualTo(Type.CONTAINING);
 	}
 
@@ -342,8 +342,8 @@ class StringQueryUnitTests {
 		String queryString = query.getQueryString();
 
 		assertThat(queryString).isEqualTo("select a from A a where a.b in ?1 and a.c in ?2");
-		assertThat(query.getParameterBindings().get(0).getExpression()).isEqualTo("#bs");
-		assertThat(query.getParameterBindings().get(1).getExpression()).isEqualTo("#cs");
+		assertThat(((Expression) query.getParameterBindings().get(0).getOrigin()).expression()).isEqualTo("#bs");
+		assertThat(((Expression) query.getParameterBindings().get(1).getOrigin()).expression()).isEqualTo("#cs");
 	}
 
 	@Test // DATAJPA-864
@@ -380,7 +380,7 @@ class StringQueryUnitTests {
 		for (ParameterBinding binding : bindings) {
 			assertThat(binding.getName()).isNotNull();
 			assertThat(query.getQueryString()).contains(binding.getName());
-			assertThat(binding.getExpression()).isEqualTo("#exp");
+			assertThat(((Expression) binding.getOrigin()).expression()).isEqualTo("#exp");
 		}
 	}
 
@@ -612,7 +612,7 @@ class StringQueryUnitTests {
 
 		assertThat(bindingType.isInstance(expectedBinding)).isTrue();
 		assertThat(expectedBinding).isNotNull();
-		assertThat(expectedBinding.hasPosition(position)).isTrue();
+		assertThat(expectedBinding.getPosition()).isEqualTo(position);
 	}
 
 	private void assertNamedBinding(Class<? extends ParameterBinding> bindingType, String parameterName,
@@ -620,6 +620,6 @@ class StringQueryUnitTests {
 
 		assertThat(bindingType.isInstance(expectedBinding)).isTrue();
 		assertThat(expectedBinding).isNotNull();
-		assertThat(expectedBinding.hasName(parameterName)).isTrue();
+		assertThat(expectedBinding.getName()).isEqualTo(parameterName);
 	}
 }

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/StringQueryUnitTests.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/StringQueryUnitTests.java
@@ -22,9 +22,12 @@ import java.util.List;
 
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.springframework.data.jpa.repository.query.ParameterBinding.BindingIdentifier;
 import org.springframework.data.jpa.repository.query.ParameterBinding.Expression;
 import org.springframework.data.jpa.repository.query.ParameterBinding.InParameterBinding;
 import org.springframework.data.jpa.repository.query.ParameterBinding.LikeParameterBinding;
+import org.springframework.data.jpa.repository.query.ParameterBinding.MethodInvocationArgument;
+import org.springframework.data.jpa.repository.query.ParameterBinding.ParameterOrigin;
 import org.springframework.data.repository.query.parser.Part.Type;
 
 /**
@@ -82,7 +85,33 @@ class StringQueryUnitTests {
 		assertThat(binding.getType()).isEqualTo(Type.ENDING_WITH);
 	}
 
-	@Test // DATAJPA-292
+	@Test // DATAJPA-292, GH-3041
+	void detectsAnonymousLikeBindings() {
+
+		StringQuery query = new StringQuery(
+				"select u from User u where u.firstname like %?% or u.lastname like %? or u.lastname=?", true);
+
+		assertThat(query.hasParameterBindings()).isTrue();
+		assertThat(query.getQueryString())
+				.isEqualTo("select u from User u where u.firstname like ? or u.lastname like ? or u.lastname=?");
+
+		List<ParameterBinding> bindings = query.getParameterBindings();
+		assertThat(bindings).hasSize(3);
+
+		LikeParameterBinding binding = (LikeParameterBinding) bindings.get(0);
+		assertThat(binding).isNotNull();
+		assertThat(binding.getOrigin()).isEqualTo(ParameterOrigin.ofParameter(1));
+		assertThat(binding.getRequiredPosition()).isEqualTo(1);
+		assertThat(binding.getType()).isEqualTo(Type.CONTAINING);
+
+		binding = (LikeParameterBinding) bindings.get(1);
+		assertThat(binding).isNotNull();
+		assertThat(binding.getOrigin()).isEqualTo(ParameterOrigin.ofParameter(2));
+		assertThat(binding.getRequiredPosition()).isEqualTo(2);
+		assertThat(binding.getType()).isEqualTo(Type.ENDING_WITH);
+	}
+
+	@Test // DATAJPA-292, GH-3041
 	void detectsNamedLikeBindings() {
 
 		StringQuery query = new StringQuery("select u from User u where u.firstname like %:firstname", true);
@@ -99,18 +128,20 @@ class StringQueryUnitTests {
 		assertThat(binding.getType()).isEqualTo(Type.ENDING_WITH);
 	}
 
-	@Test // DATAJPA-292
+	@Test // GH-3041
 	void rewritesNamedLikeToUniqueParametersIfNecessary() {
 
 		StringQuery query = new StringQuery(
-				"select u from User u where u.firstname like %:firstname or u.firstname like :firstname%", true);
+				"select u from User u where u.firstname like %:firstname or u.firstname like :firstname% or u.firstname = :firstname",
+				true);
 
 		assertThat(query.hasParameterBindings()).isTrue();
 		assertThat(query.getQueryString())
-				.isEqualTo("select u from User u where u.firstname like :firstname or u.firstname like :firstname_1");
+				.isEqualTo(
+						"select u from User u where u.firstname like :firstname or u.firstname like :firstname_1 or u.firstname = :firstname_2");
 
 		List<ParameterBinding> bindings = query.getParameterBindings();
-		assertThat(bindings).hasSize(2);
+		assertThat(bindings).hasSize(3);
 
 		LikeParameterBinding binding = (LikeParameterBinding) bindings.get(0);
 		assertThat(binding).isNotNull();
@@ -123,8 +154,22 @@ class StringQueryUnitTests {
 		assertThat(binding.getType()).isEqualTo(Type.STARTING_WITH);
 	}
 
-	@Test // DATAJPA-292
-	void reusesLikeBindingsWherePossible() {
+	@Test // GH-3041
+	void rewritesPositionalLikeToUniqueParametersIfNecessary() {
+
+		StringQuery query = new StringQuery(
+				"select u from User u where u.firstname like %?1 or u.firstname like ?1% or u.firstname = ?1", true);
+
+		assertThat(query.hasParameterBindings()).isTrue();
+		assertThat(query.getQueryString())
+				.isEqualTo("select u from User u where u.firstname like ?1 or u.firstname like ?2 or u.firstname = ?3");
+
+		List<ParameterBinding> bindings = query.getParameterBindings();
+		assertThat(bindings).hasSize(3);
+	}
+
+	@Test // GH-3041
+	void reusesNamedLikeBindingsWherePossible() {
 
 		StringQuery query = new StringQuery(
 				"select u from User u where u.firstname like %:firstname or u.firstname like %:firstname% or u.firstname like %:firstname% or u.firstname like %:firstname",
@@ -134,18 +179,51 @@ class StringQueryUnitTests {
 		assertThat(query.getQueryString()).isEqualTo(
 				"select u from User u where u.firstname like :firstname or u.firstname like :firstname_1 or u.firstname like :firstname_1 or u.firstname like :firstname");
 
+
+		query = new StringQuery("select u from User u where u.firstname like %:firstname or u.firstname =:firstname", true);
+
+		assertThat(query.hasParameterBindings()).isTrue();
+		assertThat(query.getQueryString())
+				.isEqualTo("select u from User u where u.firstname like :firstname or u.firstname =:firstname_1");
+	}
+
+	@Test // GH-3041
+	void reusesPositionalLikeBindingsWherePossible() {
+
+		StringQuery query = new StringQuery(
+				"select u from User u where u.firstname like %?1 or u.firstname like %?1% or u.firstname like %?1% or u.firstname like %?1",
+				false);
+
+		assertThat(query.hasParameterBindings()).isTrue();
+		assertThat(query.getQueryString()).isEqualTo(
+				"select u from User u where u.firstname like ?1 or u.firstname like ?2 or u.firstname like ?2 or u.firstname like ?1");
+
+		query = new StringQuery("select u from User u where u.firstname like %?1 or u.firstname =?1", false);
+
+		assertThat(query.hasParameterBindings()).isTrue();
+		assertThat(query.getQueryString()).isEqualTo("select u from User u where u.firstname like ?1 or u.firstname =?2");
+	}
+
+	@Test // GH-3041
+	void shouldRewritePositionalBindingsWithParameterReuse() {
+
+		StringQuery query = new StringQuery(
+				"select u from User u where u.firstname like ?2 or u.firstname like %?2% or u.firstname like %?1% or u.firstname like %?1 OR u.firstname like ?1",
+				false);
+
+		assertThat(query.hasParameterBindings()).isTrue();
+		assertThat(query.getQueryString()).isEqualTo(
+				"select u from User u where u.firstname like ?2 or u.firstname like ?3 or u.firstname like ?1 or u.firstname like ?4 OR u.firstname like ?5");
+
 		List<ParameterBinding> bindings = query.getParameterBindings();
-		assertThat(bindings).hasSize(2);
+		assertThat(bindings).hasSize(5);
 
-		LikeParameterBinding binding = (LikeParameterBinding) bindings.get(0);
-		assertThat(binding).isNotNull();
-		assertThat(binding.getName()).isEqualTo("firstname");
-		assertThat(binding.getType()).isEqualTo(Type.ENDING_WITH);
-
-		binding = (LikeParameterBinding) bindings.get(1);
-		assertThat(binding).isNotNull();
-		assertThat(binding.getName()).isEqualTo("firstname_1");
-		assertThat(binding.getType()).isEqualTo(Type.CONTAINING);
+		assertThat(bindings).extracting(ParameterBinding::getRequiredPosition).containsOnly(1, 2, 3, 4, 5);
+		assertThat(bindings).extracting(ParameterBinding::getOrigin) //
+				.map(MethodInvocationArgument.class::cast) //
+				.map(MethodInvocationArgument::identifier) //
+				.map(BindingIdentifier::getPosition) //
+				.containsOnly(1, 2);
 	}
 
 	@Test // DATAJPA-461
@@ -218,12 +296,6 @@ class StringQueryUnitTests {
 	@Test // DATAJPA-373
 	void handlesMultipleNamedLikeBindingsCorrectly() {
 		new StringQuery("select u from User u where u.firstname like %:firstname or foo like :bar", true);
-	}
-
-	@Test // DATAJPA-292, DATAJPA-362
-	void rejectsDifferentBindingsForRepeatedParameter() {
-		assertThatIllegalArgumentException().isThrownBy(
-				() -> new StringQuery("select u from User u where u.firstname like %?1 and u.lastname like ?1%", true));
 	}
 
 	@Test // DATAJPA-461
@@ -307,12 +379,6 @@ class StringQueryUnitTests {
 
 		assertThat(bindings).hasSize(1);
 		assertNamedBinding(InParameterBinding.class, "ab1babc생일233", bindings.get(0));
-	}
-
-	@Test // DATAJPA-362
-	void rejectsDifferentBindingsForRepeatedParameter2() {
-		assertThatIllegalArgumentException().isThrownBy(
-				() -> new StringQuery("select u from User u where u.firstname like ?1 and u.lastname like %?1", true));
 	}
 
 	@Test // DATAJPA-712
@@ -503,6 +569,8 @@ class StringQueryUnitTests {
 
 		assertThat(new StringQuery("from Something something where something = ?", false).usesJdbcStyleParameters())
 				.isTrue();
+		assertThat(new StringQuery("from Something something where something =?", false).usesJdbcStyleParameters())
+				.isTrue();
 
 		List<String> testQueries = Arrays.asList( //
 				"from Something something where something = ?1", //
@@ -514,6 +582,7 @@ class StringQueryUnitTests {
 
 			assertThat(new StringQuery(testQuery, false) //
 					.usesJdbcStyleParameters()) //
+							.describedAs(testQuery)
 							.describedAs(testQuery) //
 							.isFalse();
 		}

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/StringQueryUnitTests.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/StringQueryUnitTests.java
@@ -36,6 +36,7 @@ import org.springframework.data.repository.query.parser.Part.Type;
  * @author Nils Borrmann
  * @author Andriy Redko
  * @author Diego Krupitza
+ * @author Mark Paluch
  */
 class StringQueryUnitTests {
 
@@ -65,7 +66,7 @@ class StringQueryUnitTests {
 
 		assertThat(query.hasParameterBindings()).isTrue();
 		assertThat(query.getQueryString())
-				.isEqualTo("select u from User u where u.firstname like CONCAT('%',?1,'%') or u.lastname like CONCAT('%',?2)");
+				.isEqualTo("select u from User u where u.firstname like ?1 or u.lastname like ?2");
 
 		List<ParameterBinding> bindings = query.getParameterBindings();
 		assertThat(bindings).hasSize(2);
@@ -87,7 +88,7 @@ class StringQueryUnitTests {
 		StringQuery query = new StringQuery("select u from User u where u.firstname like %:firstname", true);
 
 		assertThat(query.hasParameterBindings()).isTrue();
-		assertThat(query.getQueryString()).isEqualTo("select u from User u where u.firstname like CONCAT('%',:firstname)");
+		assertThat(query.getQueryString()).isEqualTo("select u from User u where u.firstname like :firstname");
 
 		List<ParameterBinding> bindings = query.getParameterBindings();
 		assertThat(bindings).hasSize(1);
@@ -96,6 +97,55 @@ class StringQueryUnitTests {
 		assertThat(binding).isNotNull();
 		assertThat(binding.hasName("firstname")).isTrue();
 		assertThat(binding.getType()).isEqualTo(Type.ENDING_WITH);
+	}
+
+	@Test // DATAJPA-292
+	void rewritesNamedLikeToUniqueParametersIfNecessary() {
+
+		StringQuery query = new StringQuery(
+				"select u from User u where u.firstname like %:firstname or u.firstname like :firstname%", true);
+
+		assertThat(query.hasParameterBindings()).isTrue();
+		assertThat(query.getQueryString())
+				.isEqualTo("select u from User u where u.firstname like :firstname or u.firstname like :firstname_1");
+
+		List<ParameterBinding> bindings = query.getParameterBindings();
+		assertThat(bindings).hasSize(2);
+
+		LikeParameterBinding binding = (LikeParameterBinding) bindings.get(0);
+		assertThat(binding).isNotNull();
+		assertThat(binding.hasName("firstname")).isTrue();
+		assertThat(binding.getType()).isEqualTo(Type.ENDING_WITH);
+
+		binding = (LikeParameterBinding) bindings.get(1);
+		assertThat(binding).isNotNull();
+		assertThat(binding.hasName("firstname_1")).isTrue();
+		assertThat(binding.getType()).isEqualTo(Type.STARTING_WITH);
+	}
+
+	@Test // DATAJPA-292
+	void reusesLikeBindingsWherePossible() {
+
+		StringQuery query = new StringQuery(
+				"select u from User u where u.firstname like %:firstname or u.firstname like %:firstname% or u.firstname like %:firstname% or u.firstname like %:firstname",
+				true);
+
+		assertThat(query.hasParameterBindings()).isTrue();
+		assertThat(query.getQueryString()).isEqualTo(
+				"select u from User u where u.firstname like :firstname or u.firstname like :firstname_1 or u.firstname like :firstname_1 or u.firstname like :firstname");
+
+		List<ParameterBinding> bindings = query.getParameterBindings();
+		assertThat(bindings).hasSize(2);
+
+		LikeParameterBinding binding = (LikeParameterBinding) bindings.get(0);
+		assertThat(binding).isNotNull();
+		assertThat(binding.hasName("firstname")).isTrue();
+		assertThat(binding.getType()).isEqualTo(Type.ENDING_WITH);
+
+		binding = (LikeParameterBinding) bindings.get(1);
+		assertThat(binding).isNotNull();
+		assertThat(binding.hasName("firstname_1")).isTrue();
+		assertThat(binding.getType()).isEqualTo(Type.CONTAINING);
 	}
 
 	@Test // DATAJPA-461
@@ -199,9 +249,8 @@ class StringQueryUnitTests {
 		assertNamedBinding(LikeParameterBinding.class, "escapedWord", bindings.get(0));
 		assertNamedBinding(ParameterBinding.class, "word", bindings.get(1));
 
-		assertThat(query.getQueryString())
-				.isEqualTo("SELECT a FROM Article a WHERE a.overview LIKE CONCAT('%',:escapedWord,'%') ESCAPE '~'"
-						+ " OR a.content LIKE CONCAT('%',:escapedWord,'%') ESCAPE '~' OR a.title = :word ORDER BY a.articleId DESC");
+		assertThat(query.getQueryString()).isEqualTo("SELECT a FROM Article a WHERE a.overview LIKE :escapedWord ESCAPE '~'"
+				+ " OR a.content LIKE :escapedWord ESCAPE '~' OR a.title = :word ORDER BY a.articleId DESC");
 	}
 
 	@Test // DATAJPA-483
@@ -273,6 +322,17 @@ class StringQueryUnitTests {
 		String queryString = query.getQueryString();
 
 		assertThat(queryString).isEqualTo("select a from A a where a.b in :__$synthetic$__1 and a.c in :__$synthetic$__2");
+	}
+
+	@Test // DATAJPA-712
+	void shouldReplaceExpressionWithLikeParameters() {
+
+		StringQuery query = new StringQuery(
+				"select a from A a where a.b LIKE :#{#filter.login}% and a.c LIKE %:#{#filter.login}", true);
+		String queryString = query.getQueryString();
+
+		assertThat(queryString)
+				.isEqualTo("select a from A a where a.b LIKE :__$synthetic$__1 and a.c LIKE :__$synthetic$__2");
 	}
 
 	@Test // DATAJPA-712

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/sample/UserRepository.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/sample/UserRepository.java
@@ -165,8 +165,8 @@ public interface UserRepository extends JpaRepository<User, Integer>, JpaSpecifi
 	@Query("select u from User u where u.firstname like ?1%")
 	List<User> findByFirstnameLike(String firstname);
 
-	// DATAJPA-292
-	@Query("select u from User u where u.firstname like :firstname%")
+	// DATAJPA-292, GH-3041
+	@Query("select u from User u where u.firstname like :firstname% or u.firstname like %:firstname")
 	List<User> findByFirstnameLikeNamed(@Param("firstname") String firstname);
 
 	/**

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/sample/UserRepository.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/sample/UserRepository.java
@@ -169,6 +169,10 @@ public interface UserRepository extends JpaRepository<User, Integer>, JpaSpecifi
 	@Query("select u from User u where u.firstname like :firstname% or u.firstname like %:firstname")
 	List<User> findByFirstnameLikeNamed(@Param("firstname") String firstname);
 
+	// DATAJPA-292, GH-3041
+	@Query("select u from User u where u.firstname like ?1% or u.firstname like %?1")
+	List<User> findByFirstnameLikePositional(String firstname);
+
 	/**
 	 * Manipulating query to set all {@link User}'s names to the given one.
 	 *


### PR DESCRIPTION
We now distinguish between the binding parameter target and its origin. The parameter target represents how the binding is bound to the query, the origin points to where the binding parameter comes from (method invocation argument or an expression).

The revised design removes the assumption that binding parameters must match their indices/names of the method call to introduce synthetic parameters for different binding variants while using the same underlying invocation parameters.

We also verify all bindings to ensure that a like-parameter doesn't mix up with plain bindings (e.g. `firstname = %:myparam or lastname = :myparam` -> `firstname = %:myparam or lastname = :myparam_1`). We also create unique synthetic parameters for positional bindings.

Also, fix Regex to properly detect named, anonymous, and positional bind markers.

Closes #3041

Fixes should be backported to `3.0.x` and `3.1.x`