### PR TITLE
When deriving a COUNT query on a DISTINCT, only put the primary alias inside.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-jpa-parent</artifactId>
-	<version>3.2.0-SNAPSHOT</version>
+	<version>3.2.0-gh-3098-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data JPA Parent</name>

--- a/spring-data-envers/pom.xml
+++ b/spring-data-envers/pom.xml
@@ -5,12 +5,12 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-envers</artifactId>
-	<version>3.2.0-SNAPSHOT</version>
+	<version>3.2.0-gh-3098-SNAPSHOT</version>
 
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-jpa-parent</artifactId>
-		<version>3.2.0-SNAPSHOT</version>
+		<version>3.2.0-gh-3098-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-jpa-distribution/pom.xml
+++ b/spring-data-jpa-distribution/pom.xml
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-jpa-parent</artifactId>
-		<version>3.2.0-SNAPSHOT</version>
+		<version>3.2.0-gh-3098-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-jpa/pom.xml
+++ b/spring-data-jpa/pom.xml
@@ -6,7 +6,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-jpa</artifactId>
-	<version>3.2.0-SNAPSHOT</version>
+	<version>3.2.0-gh-3098-SNAPSHOT</version>
 
 	<name>Spring Data JPA</name>
 	<description>Spring Data module for JPA repositories.</description>
@@ -15,7 +15,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-jpa-parent</artifactId>
-		<version>3.2.0-SNAPSHOT</version>
+		<version>3.2.0-gh-3098-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/HqlQueryTransformer.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/HqlQueryTransformer.java
@@ -338,6 +338,7 @@ class HqlQueryTransformer extends HqlQueryRenderer {
 		tokens.add(new JpaQueryParsingToken(ctx.SELECT()));
 
 		if (countQuery && !isSubquery(ctx)) {
+
 			tokens.add(TOKEN_COUNT_FUNC);
 
 			if (countProjection != null) {
@@ -354,19 +355,7 @@ class HqlQueryTransformer extends HqlQueryRenderer {
 		if (countQuery && !isSubquery(ctx)) {
 
 			if (countProjection == null) {
-
-				if (ctx.DISTINCT() != null) {
-
-					if (selectionListTokens.stream().anyMatch(hqlToken -> hqlToken.getToken().contains("new"))) {
-						// constructor
-						tokens.add(new JpaQueryParsingToken(() -> primaryFromAlias));
-					} else {
-						// keep all the select items to distinct against
-						tokens.addAll(selectionListTokens);
-					}
-				} else {
-					tokens.add(new JpaQueryParsingToken(() -> primaryFromAlias));
-				}
+				tokens.add(new JpaQueryParsingToken(() -> primaryFromAlias));
 			}
 
 			NOSPACE(tokens);
@@ -376,6 +365,7 @@ class HqlQueryTransformer extends HqlQueryRenderer {
 		}
 
 		if (!projectionProcessed && !isSubquery(ctx)) {
+
 			projection = selectionListTokens;
 			projectionProcessed = true;
 		}

--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/JpqlQueryTransformer.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/JpqlQueryTransformer.java
@@ -146,6 +146,7 @@ class JpqlQueryTransformer extends JpqlQueryRenderer {
 		List<JpaQueryParsingToken> selectItemTokens = newArrayList();
 
 		ctx.select_item().forEach(selectItemContext -> {
+
 			selectItemTokens.addAll(visit(selectItemContext));
 			NOSPACE(selectItemTokens);
 			selectItemTokens.add(TOKEN_COMMA);
@@ -158,19 +159,7 @@ class JpqlQueryTransformer extends JpqlQueryRenderer {
 			if (countProjection != null) {
 				tokens.add(new JpaQueryParsingToken(countProjection));
 			} else {
-
-				if (ctx.DISTINCT() != null) {
-
-					if (selectItemTokens.stream().anyMatch(jpqlToken -> jpqlToken.getToken().contains("new"))) {
-						// constructor
-						tokens.add(new JpaQueryParsingToken(() -> primaryFromAlias));
-					} else {
-						// keep all the select items to distinct against
-						tokens.addAll(selectItemTokens);
-					}
-				} else {
-					tokens.add(new JpaQueryParsingToken(() -> primaryFromAlias));
-				}
+				tokens.add(new JpaQueryParsingToken(() -> primaryFromAlias));
 			}
 
 			NOSPACE(tokens);
@@ -180,6 +169,7 @@ class JpqlQueryTransformer extends JpqlQueryRenderer {
 		}
 
 		if (!projectionProcessed) {
+
 			projection = selectItemTokens;
 			projectionProcessed = true;
 		}

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/DefaultQueryEnhancerUnitTests.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/DefaultQueryEnhancerUnitTests.java
@@ -18,6 +18,8 @@ package org.springframework.data.jpa.repository.query;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
+import static org.assertj.core.api.Assumptions.*;
+
 /**
  * TCK Tests for {@link DefaultQueryEnhancer}.
  *
@@ -34,4 +36,13 @@ public class DefaultQueryEnhancerUnitTests extends QueryEnhancerTckTests {
 	@Test // GH-2511, GH-2773
 	@Disabled("Not properly supported by QueryUtils")
 	void shouldDeriveNativeCountQueryWithVariable(String query, String expected) {}
+
+	@Override
+	void shouldDeriveJpqlCountQuery(String query, String expected) {
+
+		assumeThat(query).as("DefaultQueryEnhancer doesn't passing in the primary alias on COUNT(DISTINCT)") //
+				.doesNotContain("SELECT DISTINCT name");
+
+		super.shouldDeriveJpqlCountQuery(query, expected);
+	}
 }

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/HqlQueryTransformerTests.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/HqlQueryTransformerTests.java
@@ -285,7 +285,7 @@ class HqlQueryTransformerTests {
 	void usesReturnedVariableInCountProjectionIfSet() {
 
 		assertCountQuery("select distinct m.genre from Media m where m.user = ?1 order by m.genre asc",
-				"select count(distinct m.genre) from Media m where m.user = ?1");
+				"select count(distinct m) from Media m where m.user = ?1");
 	}
 
 	@Test // DATAJPA-343
@@ -318,7 +318,7 @@ class HqlQueryTransformerTests {
 	void removesOrderByInGeneratedCountQueryFromOriginalQueryIfPresent() {
 
 		assertCountQuery("select distinct m.genre from Media m where m.user = ?1 OrDer  By   m.genre ASC",
-				"select count(distinct m.genre) from Media m where m.user = ?1");
+				"select count(distinct m) from Media m where m.user = ?1");
 	}
 
 	@Test // DATAJPA-375
@@ -1031,8 +1031,20 @@ class HqlQueryTransformerTests {
 						"SELECT t3 FROM Test3 t3 JOIN t3.test2 x WHERE x.id = :test2Id order by t3.testDuplicateColumnName desc");
 	}
 
+	@Test // GH-3098
+	void foo() {
+
+		assertCountQuery("""
+				SELECT DISTINCT loc.name AS name, loc.lat AS latitude, loc,lon AS longitude
+				FROM LocalityEntity loc
+				""", """
+				SELECT count(DISTINCT loc)
+				FROM LocalityEntity loc
+				""");
+	}
+
 	private void assertCountQuery(String originalQuery, String countQuery) {
-		assertThat(createCountQueryFor(originalQuery)).isEqualTo(countQuery);
+		assertThat(createCountQueryFor(originalQuery)).isEqualToIgnoringWhitespace(countQuery);
 	}
 
 	private String createQueryFor(String query, Sort sort) {

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/JSqlParserQueryEnhancerUnitTests.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/JSqlParserQueryEnhancerUnitTests.java
@@ -49,6 +49,12 @@ public class JSqlParserQueryEnhancerUnitTests extends QueryEnhancerTckTests {
 
 		assumeThat(query).as("JSQLParser does not support constructor JPQL syntax").doesNotContain(" new ");
 
+		assumeThat(query).as("JSQLParser does not properly handle COUNT(DISTINCT) queries.")
+				.doesNotContain("SELECT DISTINCT name");
+
+		assumeThat(query).as("JSQLParser does not properly handle COUNT(DISTINCT) queries.")
+				.doesNotContain("select distinct m.genre");
+
 		super.shouldDeriveJpqlCountQuery(query, expected);
 	}
 

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/JpqlQueryTransformerTests.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/JpqlQueryTransformerTests.java
@@ -274,7 +274,7 @@ class JpqlQueryTransformerTests {
 	void usesReturnedVariableInCountProjectionIfSet() {
 
 		assertCountQuery("select distinct m.genre from Media m where m.user = ?1 order by m.genre asc",
-				"select count(distinct m.genre) from Media m where m.user = ?1");
+				"select count(distinct m) from Media m where m.user = ?1");
 	}
 
 	@Test // DATAJPA-343
@@ -307,7 +307,7 @@ class JpqlQueryTransformerTests {
 	void removesOrderByInGeneratedCountQueryFromOriginalQueryIfPresent() {
 
 		assertCountQuery("select distinct m.genre from Media m where m.user = ?1 OrDer  By   m.genre ASC",
-				"select count(distinct m.genre) from Media m where m.user = ?1");
+				"select count(distinct m) from Media m where m.user = ?1");
 	}
 
 	@Test // DATAJPA-375

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/QueryEnhancerTckTests.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/QueryEnhancerTckTests.java
@@ -136,7 +136,7 @@ abstract class QueryEnhancerTckTests {
 
 				Arguments.of( //
 						"SELECT DISTINCT name FROM table_name some_alias", //
-						"select count(DISTINCT name) FROM table_name some_alias"),
+						"SELECT count(DISTINCT some_alias) FROM table_name some_alias"),
 
 				Arguments.of( //
 						"select distinct new com.example.User(u.name) from User u where u.foo = ?1", //
@@ -164,7 +164,7 @@ abstract class QueryEnhancerTckTests {
 
 				Arguments.of( //
 						"select distinct m.genre from Media m where m.user = ?1 order by m.genre asc", //
-						"select count(distinct m.genre) from Media m where m.user = ?1"));
+						"select count(distinct m) from Media m where m.user = ?1"));
 	}
 
 	@ParameterizedTest // GH-2511, GH-2773


### PR DESCRIPTION
I'd like feedback on this solution, to ensure we are handling this correctly.