### PR TITLE
Properly handle native queries with SpEL

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-jpa-parent</artifactId>
-	<version>3.2.0-SNAPSHOT</version>
+	<version>3.2.0-gh-3096-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data JPA Parent</name>

--- a/spring-data-envers/pom.xml
+++ b/spring-data-envers/pom.xml
@@ -5,12 +5,12 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-envers</artifactId>
-	<version>3.2.0-SNAPSHOT</version>
+	<version>3.2.0-gh-3096-SNAPSHOT</version>
 
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-jpa-parent</artifactId>
-		<version>3.2.0-SNAPSHOT</version>
+		<version>3.2.0-gh-3096-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-jpa-distribution/pom.xml
+++ b/spring-data-jpa-distribution/pom.xml
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-jpa-parent</artifactId>
-		<version>3.2.0-SNAPSHOT</version>
+		<version>3.2.0-gh-3096-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-jpa/pom.xml
+++ b/spring-data-jpa/pom.xml
@@ -6,7 +6,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-jpa</artifactId>
-	<version>3.2.0-SNAPSHOT</version>
+	<version>3.2.0-gh-3096-SNAPSHOT</version>
 
 	<name>Spring Data JPA</name>
 	<description>Spring Data module for JPA repositories.</description>
@@ -15,7 +15,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-jpa-parent</artifactId>
-		<version>3.2.0-SNAPSHOT</version>
+		<version>3.2.0-gh-3096-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/DeclaredQuery.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/DeclaredQuery.java
@@ -46,17 +46,17 @@ interface DeclaredQuery {
 	 *
 	 * @param query might be {@literal null} or empty.
 	 * @param nativeQuery is a given query is native or not
-	 * @param method is a {@link JpaQueryMethod} that has the related metadata
+	 * @param entityMetadata is a {@link JpaEntityMetadata} that might be {@literal null}
 	 * @return a {@literal DeclaredQuery} instance even for a {@literal null} or empty argument.
 	 */
-	static DeclaredQuery of(@Nullable String query, Boolean nativeQuery, @Nullable JpaQueryMethod method) {
+	static DeclaredQuery of(@Nullable String query, Boolean nativeQuery, @Nullable JpaEntityMetadata<?> entityMetadata) {
 
 		if (ObjectUtils.isEmpty(query)) {
 			return EmptyDeclaredQuery.EMPTY_QUERY;
 		}
 
-		if (ExpressionBasedStringQuery.containsExpression(query) && method != null) {
-			return new ExpressionBasedStringQuery(query, method.getEntityInformation(), JpaQueryFactory.PARSER, nativeQuery);
+		if (ExpressionBasedStringQuery.containsExpression(query) && entityMetadata != null) {
+			return new ExpressionBasedStringQuery(query, entityMetadata, JpaQueryFactory.PARSER, nativeQuery);
 		}
 
 		return new StringQuery(query, nativeQuery);

--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/DeclaredQuery.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/DeclaredQuery.java
@@ -25,6 +25,7 @@ import org.springframework.util.ObjectUtils;
  *
  * @author Jens Schauder
  * @author Diego Krupitza
+ * @author Greg Turnquist
  * @since 2.0.3
  */
 interface DeclaredQuery {
@@ -37,7 +38,28 @@ interface DeclaredQuery {
 	 * @return a {@literal DeclaredQuery} instance even for a {@literal null} or empty argument.
 	 */
 	static DeclaredQuery of(@Nullable String query, boolean nativeQuery) {
-		return ObjectUtils.isEmpty(query) ? EmptyDeclaredQuery.EMPTY_QUERY : new StringQuery(query, nativeQuery);
+		return of(query, nativeQuery, null);
+	}
+
+	/**
+	 * Creates a {@literal DeclaredQuery} from a query {@literal String} and the related {@link JpaQueryMethod}.
+	 *
+	 * @param query might be {@literal null} or empty.
+	 * @param nativeQuery is a given query is native or not
+	 * @param method is a {@link JpaQueryMethod} that has the related metadata
+	 * @return a {@literal DeclaredQuery} instance even for a {@literal null} or empty argument.
+	 */
+	static DeclaredQuery of(@Nullable String query, Boolean nativeQuery, @Nullable JpaQueryMethod method) {
+
+		if (ObjectUtils.isEmpty(query)) {
+			return EmptyDeclaredQuery.EMPTY_QUERY;
+		}
+
+		if (ExpressionBasedStringQuery.containsExpression(query) && method != null) {
+			return new ExpressionBasedStringQuery(query, method.getEntityInformation(), JpaQueryFactory.PARSER, nativeQuery);
+		}
+
+		return new StringQuery(query, nativeQuery);
 	}
 
 	/**

--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/ExpressionBasedStringQuery.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/ExpressionBasedStringQuery.java
@@ -61,7 +61,7 @@ class ExpressionBasedStringQuery extends StringQuery {
 	 */
 	public ExpressionBasedStringQuery(String query, JpaEntityMetadata<?> metadata, SpelExpressionParser parser,
 			boolean nativeQuery) {
-		super(renderQueryIfExpressionOrReturnQuery(query, metadata, parser), nativeQuery && !containsExpression(query));
+		super(renderQueryIfExpressionOrReturnQuery(query, metadata, parser), nativeQuery);
 	}
 
 	/**
@@ -118,7 +118,10 @@ class ExpressionBasedStringQuery extends StringQuery {
 		return EXPRESSION_PARAMETER_QUOTING.matcher(query).replaceAll(QUOTED_EXPRESSION_PARAMETER);
 	}
 
-	private static boolean containsExpression(String query) {
+	/**
+	 * Does the {@literal query} contains a SpEL expression?
+	 */
+	static boolean containsExpression(String query) {
 		return query.contains(ENTITY_NAME_VARIABLE_EXPRESSION);
 	}
 }

--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/JpaQueryFactory.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/JpaQueryFactory.java
@@ -29,12 +29,13 @@ import org.springframework.lang.Nullable;
  *
  * @author Thomas Darimont
  * @author Mark Paluch
+ * @author Greg Turnquist
  */
 enum JpaQueryFactory {
 
 	INSTANCE;
 
-	private static final SpelExpressionParser PARSER = new SpelExpressionParser();
+	static final SpelExpressionParser PARSER = new SpelExpressionParser();
 
 	/**
 	 * Creates a {@link RepositoryQuery} from the given {@link String} query.

--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/JpaQueryMethod.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/JpaQueryMethod.java
@@ -162,7 +162,7 @@ public class JpaQueryMethod extends QueryMethod {
 
 		String annotatedQuery = getAnnotatedQuery();
 
-		if (!DeclaredQuery.of(annotatedQuery, this.isNativeQuery.get(), this).hasNamedParameter()) {
+		if (!DeclaredQuery.of(annotatedQuery, this.isNativeQuery.get(), getEntityInformation()).hasNamedParameter()) {
 			return;
 		}
 

--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/JpaQueryMethod.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/JpaQueryMethod.java
@@ -162,7 +162,7 @@ public class JpaQueryMethod extends QueryMethod {
 
 		String annotatedQuery = getAnnotatedQuery();
 
-		if (!DeclaredQuery.of(annotatedQuery, this.isNativeQuery.get()).hasNamedParameter()) {
+		if (!DeclaredQuery.of(annotatedQuery, this.isNativeQuery.get(), this).hasNamedParameter()) {
 			return;
 		}
 

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/UserRepositoryTests.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/UserRepositoryTests.java
@@ -1073,6 +1073,14 @@ class UserRepositoryTests {
 		assertThat(repository.findByActiveTrue()).isEmpty();
 	}
 
+	@Test // GH-3096
+	void shouldSupportNativeQueriesWithSpEL() {
+
+		flushTestUsers();
+
+		assertThat(repository.nativeQueryWithSpEL()).containsExactly(firstUser, secondUser, thirdUser, fourthUser);
+	}
+
 	@Test // DATAJPA-405
 	void executesFinderWithOrderClauseOnly() {
 

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/ExpressionBasedStringQueryUnitTests.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/ExpressionBasedStringQueryUnitTests.java
@@ -97,7 +97,7 @@ class ExpressionBasedStringQueryUnitTests {
 	}
 
 	@Test
-	void shouldDetectComplexNativeQueriesWithSpelAsNonNative() {
+	void shouldDetectComplexNativeQueriesWithSpelAsRetainingNativeQueryStatus() {
 
 		StringQuery query = new ExpressionBasedStringQuery(
 				"select n from #{#entityName} n where (LOWER(n.name) LIKE LOWER(NULLIF(text(concat('%',?#{#networkRequest.name},'%')), '')) OR ?#{#networkRequest.name} IS NULL )"
@@ -106,15 +106,15 @@ class ExpressionBasedStringQueryUnitTests {
 						+ "AND (n.updatedAt >= ?#{#networkRequest.updatedTime.startDateTime}) AND (n.updatedAt <=?#{#networkRequest.updatedTime.endDateTime})",
 				metadata, SPEL_PARSER, true);
 
-		assertThat(query.isNativeQuery()).isFalse();
+		assertThat(query.isNativeQuery()).isTrue();
 	}
 
 	@Test
-	void shouldDetectSimpleNativeQueriesWithSpelAsNonNative() {
+	void shouldDetectSimpleNativeQueriesWithSpelAsRetainingNativeQueryStatus() {
 
 		StringQuery query = new ExpressionBasedStringQuery("select n from #{#entityName} n", metadata, SPEL_PARSER, true);
 
-		assertThat(query.isNativeQuery()).isFalse();
+		assertThat(query.isNativeQuery()).isTrue();
 	}
 
 	@Test

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/sample/UserRepository.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/sample/UserRepository.java
@@ -734,6 +734,10 @@ public interface UserRepository extends JpaRepository<User, Integer>, JpaSpecifi
 	@Query("select u from User u where u.firstname >= (select Min(u0.firstname) from User u0)")
 	List<NameOnly> findProjectionBySubselect();
 
+	// GH-3096
+	@Query(value = "select * from SD_User as #{#entityName}", nativeQuery = true)
+	List<User> nativeQueryWithSpEL();
+
 	Window<User> findBy(OffsetScrollPosition position);
 
 	interface RolesAndFirstname {


### PR DESCRIPTION
The following repository definition:

```java
public interface EmployeeRepository extends JpaRepository<Employee, Long> {

	@Query(value = "select * from #{#entityName}", nativeQuery = true)
	List<Employee> custom();
}
```
...wil fail.

We have code that will explicitly switch it from native to non-native, and hence force it into one of the query parsers, which will cause it to fail.

However, it's not as simple as simply retaining the `nativeQuery` value. It also causes the `QueryEnhancerFactory` to kick in before parsing the SpEL expression inside. Tools like JSqlParser will fail. Thus, we need to detect it's SpEL nature sooner and properly mark it, so it's handled correctly.

This PR alters the visibility of a couple private items, but only makes them package-private.