### PR TITLE
Rename all EntityManager variables to entityManager in org.springframework.data.jpa Package

### DIFF
--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/provider/HibernateJpaParametersParameterAccessor.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/provider/HibernateJpaParametersParameterAccessor.java
@@ -49,13 +49,13 @@ class HibernateJpaParametersParameterAccessor extends JpaParametersParameterAcce
 	 *
 	 * @param parameters must not be {@literal null}.
 	 * @param values must not be {@literal null}.
-	 * @param em must not be {@literal null}.
+	 * @param entityManager must not be {@literal null}.
 	 */
-	HibernateJpaParametersParameterAccessor(Parameters<?, ?> parameters, Object[] values, EntityManager em) {
+	HibernateJpaParametersParameterAccessor(Parameters<?, ?> parameters, Object[] values, EntityManager entityManager) {
 
 		super(parameters, values);
 
-		this.typeHelper = em.getEntityManagerFactory() //
+		this.typeHelper = entityManager.getEntityManagerFactory() //
 				.unwrap(SessionFactoryImplementor.class) //
 				.getTypeConfiguration() //
 				.getBasicTypeRegistry();

--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/provider/JpaClassUtils.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/provider/JpaClassUtils.java
@@ -39,14 +39,14 @@ abstract class JpaClassUtils {
 	/**
 	 * Returns whether the given {@link EntityManager} is of the given type.
 	 *
-	 * @param em must not be {@literal null}.
+	 * @param entityManager must not be {@literal null}.
 	 * @param type the fully qualified expected {@link EntityManager} type, must not be {@literal null} or empty.
 	 * @return whether the given {@code EntityManager} is of the given type.
 	 */
-	public static boolean isEntityManagerOfType(EntityManager em, String type) {
+	public static boolean isEntityManagerOfType(EntityManager entityManager, String type) {
 
-		EntityManager entityManagerToUse = em;
-		Object delegate = em.getDelegate();
+		EntityManager entityManagerToUse = entityManager;
+		Object delegate = entityManager.getDelegate();
 
 		if (delegate instanceof EntityManager) {
 			entityManagerToUse = (EntityManager) delegate;

--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/provider/PersistenceProvider.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/provider/PersistenceProvider.java
@@ -108,8 +108,8 @@ public enum PersistenceProvider implements QueryExtractor, ProxyIdAccessor, Quer
 
 		@Override
 		public JpaParametersParameterAccessor getParameterAccessor(JpaParameters parameters, Object[] values,
-				EntityManager em) {
-			return new HibernateJpaParametersParameterAccessor(parameters, values, em);
+				EntityManager entityManager) {
+			return new HibernateJpaParametersParameterAccessor(parameters, values, entityManager);
 		}
 
 		@Override
@@ -238,14 +238,14 @@ public enum PersistenceProvider implements QueryExtractor, ProxyIdAccessor, Quer
 	 * Determines the {@link PersistenceProvider} from the given {@link EntityManager}. If no special one can be
 	 * determined {@link #GENERIC_JPA} will be returned.
 	 *
-	 * @param em must not be {@literal null}.
+	 * @param entityManager must not be {@literal null}.
 	 * @return will never be {@literal null}.
 	 */
-	public static PersistenceProvider fromEntityManager(EntityManager em) {
+	public static PersistenceProvider fromEntityManager(EntityManager entityManager) {
 
-		Assert.notNull(em, "EntityManager must not be null");
+		Assert.notNull(entityManager, "EntityManager must not be null");
 
-		Class<?> entityManagerType = em.getDelegate().getClass();
+		Class<?> entityManagerType = entityManager.getDelegate().getClass();
 		PersistenceProvider cachedProvider = CACHE.get(entityManagerType);
 
 		if (cachedProvider != null) {
@@ -254,7 +254,7 @@ public enum PersistenceProvider implements QueryExtractor, ProxyIdAccessor, Quer
 
 		for (PersistenceProvider provider : ALL) {
 			for (String entityManagerClassName : provider.entityManagerClassNames) {
-				if (isEntityManagerOfType(em, entityManagerClassName)) {
+				if (isEntityManagerOfType(entityManager, entityManagerClassName)) {
 					return cacheAndReturn(entityManagerType, provider);
 				}
 			}
@@ -293,7 +293,7 @@ public enum PersistenceProvider implements QueryExtractor, ProxyIdAccessor, Quer
 	}
 
 	public JpaParametersParameterAccessor getParameterAccessor(JpaParameters parameters, Object[] values,
-			EntityManager em) {
+			EntityManager entityManager) {
 		return new JpaParametersParameterAccessor(parameters, values);
 	}
 
@@ -351,7 +351,7 @@ public enum PersistenceProvider implements QueryExtractor, ProxyIdAccessor, Quer
 
 		String GENERIC_JPA_ENTITY_MANAGER_INTERFACE = "jakarta.persistence.EntityManager";
 		String ECLIPSELINK_ENTITY_MANAGER_INTERFACE = "org.eclipse.persistence.jpa.JpaEntityManager";
-		// needed as Spring only exposes that interface via the EM proxy
+		// needed as Spring only exposes that interface via the EntityManager proxy
 		String HIBERNATE_ENTITY_MANAGER_INTERFACE = "org.hibernate.engine.spi.SessionImplementor";
 
 		String HIBERNATE_JPA_METAMODEL_TYPE = "org.hibernate.metamodel.model.domain.JpaMetamodel";

--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/AbstractJpaQuery.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/AbstractJpaQuery.java
@@ -65,7 +65,7 @@ import org.springframework.util.Assert;
 public abstract class AbstractJpaQuery implements RepositoryQuery {
 
 	private final JpaQueryMethod method;
-	private final EntityManager em;
+	private final EntityManager entityManager;
 	private final JpaMetamodel metamodel;
 	private final PersistenceProvider provider;
 	private final Lazy<JpaQueryExecution> execution;
@@ -76,17 +76,17 @@ public abstract class AbstractJpaQuery implements RepositoryQuery {
 	 * Creates a new {@link AbstractJpaQuery} from the given {@link JpaQueryMethod}.
 	 *
 	 * @param method
-	 * @param em
+	 * @param entityManager
 	 */
-	public AbstractJpaQuery(JpaQueryMethod method, EntityManager em) {
+	public AbstractJpaQuery(JpaQueryMethod method, EntityManager entityManager) {
 
 		Assert.notNull(method, "JpaQueryMethod must not be null");
-		Assert.notNull(em, "EntityManager must not be null");
+		Assert.notNull(entityManager, "EntityManager must not be null");
 
 		this.method = method;
-		this.em = em;
-		this.metamodel = JpaMetamodel.of(em.getMetamodel());
-		this.provider = PersistenceProvider.fromEntityManager(em);
+		this.entityManager = entityManager;
+		this.metamodel = JpaMetamodel.of(entityManager.getMetamodel());
+		this.provider = PersistenceProvider.fromEntityManager(entityManager);
 		this.execution = Lazy.of(() -> {
 
 			if (method.isStreamQuery()) {
@@ -118,7 +118,7 @@ public abstract class AbstractJpaQuery implements RepositoryQuery {
 	 * @return will never be {@literal null}.
 	 */
 	protected EntityManager getEntityManager() {
-		return em;
+		return entityManager;
 	}
 
 	/**
@@ -153,7 +153,7 @@ public abstract class AbstractJpaQuery implements RepositoryQuery {
 
 	private JpaParametersParameterAccessor obtainParameterAccessor(Object[] values) {
 
-		return provider.getParameterAccessor(method.getParameters(), values, em);
+		return provider.getParameterAccessor(method.getParameters(), values, entityManager);
 	}
 
 	protected JpaQueryExecution getExecution() {
@@ -165,7 +165,7 @@ public abstract class AbstractJpaQuery implements RepositoryQuery {
 		}
 
 		if (method.isModifyingQuery()) {
-			return new ModifyingExecution(method, em);
+			return new ModifyingExecution(method, entityManager);
 		} else {
 			return new SingleEntityExecution();
 		}
@@ -247,7 +247,7 @@ public abstract class AbstractJpaQuery implements RepositoryQuery {
 		JpaEntityGraph entityGraph = method.getEntityGraph();
 
 		if (entityGraph != null) {
-			QueryHints hints = Jpa21Utils.getFetchGraphHint(em, method.getEntityGraph(),
+			QueryHints hints = Jpa21Utils.getFetchGraphHint(entityManager, method.getEntityGraph(),
 					getQueryMethod().getEntityInformation().getJavaType());
 
 			hints.forEach(query::setHint);

--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/AbstractStringBasedJpaQuery.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/AbstractStringBasedJpaQuery.java
@@ -55,18 +55,18 @@ abstract class AbstractStringBasedJpaQuery extends AbstractJpaQuery {
 	 * query {@link String}.
 	 *
 	 * @param method must not be {@literal null}.
-	 * @param em must not be {@literal null}.
+	 * @param entityManager must not be {@literal null}.
 	 * @param queryString must not be {@literal null}.
 	 * @param countQueryString must not be {@literal null}.
 	 * @param evaluationContextProvider must not be {@literal null}.
 	 * @param parser must not be {@literal null}.
 	 * @param queryRewriter must not be {@literal null}.
 	 */
-	public AbstractStringBasedJpaQuery(JpaQueryMethod method, EntityManager em, String queryString,
+	public AbstractStringBasedJpaQuery(JpaQueryMethod method, EntityManager entityManager, String queryString,
 			@Nullable String countQueryString, QueryRewriter queryRewriter,
 			QueryMethodEvaluationContextProvider evaluationContextProvider, SpelExpressionParser parser) {
 
-		super(method, em);
+		super(method, entityManager);
 
 		Assert.hasText(queryString, "Query string must not be null or empty");
 		Assert.notNull(evaluationContextProvider, "ExpressionEvaluationContextProvider must not be null");
@@ -117,11 +117,11 @@ abstract class AbstractStringBasedJpaQuery extends AbstractJpaQuery {
 	protected Query doCreateCountQuery(JpaParametersParameterAccessor accessor) {
 
 		String queryString = countQuery.get().getQueryString();
-		EntityManager em = getEntityManager();
+		EntityManager entityManager = getEntityManager();
 
 		Query query = getQueryMethod().isNativeQuery() //
-				? em.createNativeQuery(queryString) //
-				: em.createQuery(queryString, Long.class);
+				? entityManager.createNativeQuery(queryString) //
+				: entityManager.createQuery(queryString, Long.class);
 
 		QueryParameterSetter.QueryMetadata metadata = metadataCache.getMetadata(queryString, query);
 
@@ -151,17 +151,17 @@ abstract class AbstractStringBasedJpaQuery extends AbstractJpaQuery {
 	protected Query createJpaQuery(String queryString, Sort sort, @Nullable Pageable pageable,
 			ReturnedType returnedType) {
 
-		EntityManager em = getEntityManager();
+		EntityManager entityManager = getEntityManager();
 
 		if (this.query.hasConstructorExpression() || this.query.isDefaultProjection()) {
-			return em.createQuery(potentiallyRewriteQuery(queryString, sort, pageable));
+			return entityManager.createQuery(potentiallyRewriteQuery(queryString, sort, pageable));
 		}
 
 		Class<?> typeToRead = getTypeToRead(returnedType);
 
 		return typeToRead == null //
-				? em.createQuery(potentiallyRewriteQuery(queryString, sort, pageable)) //
-				: em.createQuery(potentiallyRewriteQuery(queryString, sort, pageable), typeToRead);
+				? entityManager.createQuery(potentiallyRewriteQuery(queryString, sort, pageable)) //
+				: entityManager.createQuery(potentiallyRewriteQuery(queryString, sort, pageable), typeToRead);
 	}
 
 	/**

--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/Jpa21Utils.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/Jpa21Utils.java
@@ -64,7 +64,7 @@ public class Jpa21Utils {
 		// prevent instantiation
 	}
 
-	public static QueryHints getFetchGraphHint(EntityManager em, @Nullable JpaEntityGraph entityGraph,
+	public static QueryHints getFetchGraphHint(EntityManager entityManager, @Nullable JpaEntityGraph entityGraph,
 			Class<?> entityType) {
 
 		MutableQueryHints result = new MutableQueryHints();
@@ -73,7 +73,7 @@ public class Jpa21Utils {
 			return result;
 		}
 
-		EntityGraph<?> graph = tryGetFetchGraph(em, entityGraph, entityType);
+		EntityGraph<?> graph = tryGetFetchGraph(entityManager, entityGraph, entityType);
 
 		if (graph == null) {
 			return result;
@@ -88,15 +88,15 @@ public class Jpa21Utils {
 	 *
 	 * @see <a href="download.oracle.com/otn-pub/jcp/persistence-2_1-fr-eval-spec/JavaPersistence.pdf">JPA 2.1
 	 *      Specfication 3.7.4 - Use of Entity Graphs in find and query operations P.117</a>
-	 * @param em must not be {@literal null}.
+	 * @param entityManager must not be {@literal null}.
 	 * @param jpaEntityGraph must not be {@literal null}.
 	 * @param entityType must not be {@literal null}.
 	 * @return the {@link EntityGraph} described by the given {@code entityGraph}.
 	 */
 	@Nullable
-	private static EntityGraph<?> tryGetFetchGraph(EntityManager em, JpaEntityGraph jpaEntityGraph, Class<?> entityType) {
+	private static EntityGraph<?> tryGetFetchGraph(EntityManager entityManager, JpaEntityGraph jpaEntityGraph, Class<?> entityType) {
 
-		Assert.notNull(em, "EntityManager must not be null");
+		Assert.notNull(entityManager, "EntityManager must not be null");
 		Assert.notNull(jpaEntityGraph, "EntityGraph must not be null");
 		Assert.notNull(entityType, "EntityType must not be null");
 
@@ -106,31 +106,31 @@ public class Jpa21Utils {
 
 		try {
 			// first check whether an entityGraph with that name is already registered.
-			return em.getEntityGraph(jpaEntityGraph.getName());
+			return entityManager.getEntityGraph(jpaEntityGraph.getName());
 		} catch (Exception ex) {
 			// try to create and dynamically register the entityGraph
-			return createDynamicEntityGraph(em, jpaEntityGraph, entityType);
+			return createDynamicEntityGraph(entityManager, jpaEntityGraph, entityType);
 		}
 	}
 
 	/**
 	 * Creates a dynamic {@link EntityGraph} from the given {@link JpaEntityGraph} information.
 	 *
-	 * @param em must not be {@literal null}.
+	 * @param entityManager must not be {@literal null}.
 	 * @param jpaEntityGraph must not be {@literal null}.
 	 * @param entityType must not be {@literal null}.
 	 * @return
 	 * @since 1.9
 	 */
-	private static EntityGraph<?> createDynamicEntityGraph(EntityManager em, JpaEntityGraph jpaEntityGraph,
+	private static EntityGraph<?> createDynamicEntityGraph(EntityManager entityManager, JpaEntityGraph jpaEntityGraph,
 			Class<?> entityType) {
 
-		Assert.notNull(em, "EntityManager must not be null");
+		Assert.notNull(entityManager, "EntityManager must not be null");
 		Assert.notNull(jpaEntityGraph, "JpaEntityGraph must not be null");
 		Assert.notNull(entityType, "Entity type must not be null");
 		Assert.isTrue(jpaEntityGraph.isAdHocEntityGraph(), "The given " + jpaEntityGraph + " is not dynamic");
 
-		EntityGraph<?> entityGraph = em.createEntityGraph(entityType);
+		EntityGraph<?> entityGraph = entityManager.createEntityGraph(entityType);
 		configureFetchGraphFrom(jpaEntityGraph, entityGraph);
 
 		return entityGraph;

--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/JpaQueryExecution.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/JpaQueryExecution.java
@@ -229,7 +229,7 @@ public abstract class JpaQueryExecution {
 	 */
 	static class ModifyingExecution extends JpaQueryExecution {
 
-		private final EntityManager em;
+		private final EntityManager entityManager;
 		private final boolean flush;
 		private final boolean clear;
 
@@ -237,11 +237,11 @@ public abstract class JpaQueryExecution {
 		 * Creates an execution that automatically flushes the given {@link EntityManager} before execution and/or clears
 		 * the given {@link EntityManager} after execution.
 		 *
-		 * @param em Must not be {@literal null}.
+		 * @param entityManager Must not be {@literal null}.
 		 */
-		public ModifyingExecution(JpaQueryMethod method, EntityManager em) {
+		public ModifyingExecution(JpaQueryMethod method, EntityManager entityManager) {
 
-			Assert.notNull(em, "The EntityManager must not be null");
+			Assert.notNull(entityManager, "The EntityManager must not be null");
 
 			Class<?> returnType = method.getReturnType();
 
@@ -251,7 +251,7 @@ public abstract class JpaQueryExecution {
 			Assert.isTrue(isInt || isVoid,
 					"Modifying queries can only use void or int/Integer as return type; Offending method: " + method);
 
-			this.em = em;
+			this.entityManager = entityManager;
 			this.flush = method.getFlushAutomatically();
 			this.clear = method.getClearAutomatically();
 		}
@@ -260,13 +260,13 @@ public abstract class JpaQueryExecution {
 		protected Object doExecute(AbstractJpaQuery query, JpaParametersParameterAccessor accessor) {
 
 			if (flush) {
-				em.flush();
+				entityManager.flush();
 			}
 
 			int result = query.createQuery(accessor).executeUpdate();
 
 			if (clear) {
-				em.clear();
+				entityManager.clear();
 			}
 
 			return result;
@@ -282,10 +282,10 @@ public abstract class JpaQueryExecution {
 	 */
 	static class DeleteExecution extends JpaQueryExecution {
 
-		private final EntityManager em;
+		private final EntityManager entityManager;
 
-		public DeleteExecution(EntityManager em) {
-			this.em = em;
+		public DeleteExecution(EntityManager entityManager) {
+			this.entityManager = entityManager;
 		}
 
 		@Override
@@ -295,7 +295,7 @@ public abstract class JpaQueryExecution {
 			List<?> resultList = query.getResultList();
 
 			for (Object o : resultList) {
-				em.remove(o);
+				entityManager.remove(o);
 			}
 
 			return jpaQuery.getQueryMethod().isCollectionQuery() ? resultList : resultList.size();

--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/JpaQueryFactory.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/JpaQueryFactory.java
@@ -40,13 +40,13 @@ enum JpaQueryFactory {
 	 * Creates a {@link RepositoryQuery} from the given {@link String} query.
 	 *
 	 * @param method must not be {@literal null}.
-	 * @param em must not be {@literal null}.
+	 * @param entityManager must not be {@literal null}.
 	 * @param countQueryString
 	 * @param queryString must not be {@literal null}.
 	 * @param evaluationContextProvider
 	 * @return
 	 */
-	AbstractJpaQuery fromMethodWithQueryString(JpaQueryMethod method, EntityManager em, String queryString,
+	AbstractJpaQuery fromMethodWithQueryString(JpaQueryMethod method, EntityManager entityManager, String queryString,
 			@Nullable String countQueryString, QueryRewriter queryRewriter,
 			QueryMethodEvaluationContextProvider evaluationContextProvider) {
 
@@ -55,9 +55,9 @@ enum JpaQueryFactory {
 		}
 
 		return method.isNativeQuery()
-				? new NativeJpaQuery(method, em, queryString, countQueryString, queryRewriter, evaluationContextProvider,
+				? new NativeJpaQuery(method, entityManager, queryString, countQueryString, queryRewriter, evaluationContextProvider,
 						PARSER)
-				: new SimpleJpaQuery(method, em, queryString, countQueryString, queryRewriter, evaluationContextProvider,
+				: new SimpleJpaQuery(method, entityManager, queryString, countQueryString, queryRewriter, evaluationContextProvider,
 						PARSER);
 	}
 
@@ -65,15 +65,15 @@ enum JpaQueryFactory {
 	 * Creates a {@link StoredProcedureJpaQuery} from the given {@link JpaQueryMethod} query.
 	 *
 	 * @param method must not be {@literal null}.
-	 * @param em must not be {@literal null}.
+	 * @param entityManager must not be {@literal null}.
 	 * @return
 	 */
-	public StoredProcedureJpaQuery fromProcedureAnnotation(JpaQueryMethod method, EntityManager em) {
+	public StoredProcedureJpaQuery fromProcedureAnnotation(JpaQueryMethod method, EntityManager entityManager) {
 
 		if (method.isScrollQuery()) {
 			throw QueryCreationException.create(method, "Scroll queries are not supported using stored procedures");
 		}
 
-		return new StoredProcedureJpaQuery(method, em);
+		return new StoredProcedureJpaQuery(method, entityManager);
 	}
 }

--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/NativeJpaQuery.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/NativeJpaQuery.java
@@ -46,16 +46,16 @@ final class NativeJpaQuery extends AbstractStringBasedJpaQuery {
 	 * Creates a new {@link NativeJpaQuery} encapsulating the query annotated on the given {@link JpaQueryMethod}.
 	 *
 	 * @param method must not be {@literal null}.
-	 * @param em must not be {@literal null}.
+	 * @param entityManager must not be {@literal null}.
 	 * @param queryString must not be {@literal null} or empty.
 	 * @param countQueryString must not be {@literal null} or empty.
 	 * @param rewriter the query rewriter to use.
 	 */
-	public NativeJpaQuery(JpaQueryMethod method, EntityManager em, String queryString, @Nullable String countQueryString,
+	public NativeJpaQuery(JpaQueryMethod method, EntityManager entityManager, String queryString, @Nullable String countQueryString,
 			QueryRewriter rewriter, QueryMethodEvaluationContextProvider evaluationContextProvider,
 			SpelExpressionParser parser) {
 
-		super(method, em, queryString, countQueryString, rewriter, evaluationContextProvider, parser);
+		super(method, entityManager, queryString, countQueryString, rewriter, evaluationContextProvider, parser);
 
 		Parameters<?, ?> parameters = method.getParameters();
 
@@ -67,11 +67,11 @@ final class NativeJpaQuery extends AbstractStringBasedJpaQuery {
 	@Override
 	protected Query createJpaQuery(String queryString, Sort sort, Pageable pageable, ReturnedType returnedType) {
 
-		EntityManager em = getEntityManager();
+		EntityManager entityManager = getEntityManager();
 		Class<?> type = getTypeToQueryFor(returnedType);
 
-		return type == null ? em.createNativeQuery(potentiallyRewriteQuery(queryString, sort, pageable))
-				: em.createNativeQuery(potentiallyRewriteQuery(queryString, sort, pageable), type);
+		return type == null ? entityManager.createNativeQuery(potentiallyRewriteQuery(queryString, sort, pageable))
+				: entityManager.createNativeQuery(potentiallyRewriteQuery(queryString, sort, pageable), type);
 	}
 
 	@Nullable

--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/PartTreeJpaQuery.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/PartTreeJpaQuery.java
@@ -59,7 +59,7 @@ public class PartTreeJpaQuery extends AbstractJpaQuery {
 
 	private final QueryPreparer query;
 	private final QueryPreparer countQuery;
-	private final EntityManager em;
+	private final EntityManager entityManager;
 	private final EscapeCharacter escape;
 	private final JpaMetamodelEntityInformation<?, Object> entityInformation;
 
@@ -67,30 +67,30 @@ public class PartTreeJpaQuery extends AbstractJpaQuery {
 	 * Creates a new {@link PartTreeJpaQuery}.
 	 *
 	 * @param method must not be {@literal null}.
-	 * @param em must not be {@literal null}.
+	 * @param entityManager must not be {@literal null}.
 	 */
-	PartTreeJpaQuery(JpaQueryMethod method, EntityManager em) {
-		this(method, em, EscapeCharacter.DEFAULT);
+	PartTreeJpaQuery(JpaQueryMethod method, EntityManager entityManager) {
+		this(method, entityManager, EscapeCharacter.DEFAULT);
 	}
 
 	/**
 	 * Creates a new {@link PartTreeJpaQuery}.
 	 *
 	 * @param method must not be {@literal null}.
-	 * @param em must not be {@literal null}.
+	 * @param entityManager must not be {@literal null}.
 	 * @param escape character used for escaping characters used as patterns in LIKE-expressions.
 	 */
-	PartTreeJpaQuery(JpaQueryMethod method, EntityManager em, EscapeCharacter escape) {
+	PartTreeJpaQuery(JpaQueryMethod method, EntityManager entityManager, EscapeCharacter escape) {
 
-		super(method, em);
+		super(method, entityManager);
 
-		this.em = em;
+		this.entityManager = entityManager;
 		this.escape = escape;
 		this.parameters = method.getParameters();
 
 		Class<?> domainClass = method.getEntityInformation().getJavaType();
-		PersistenceUnitUtil persistenceUnitUtil = em.getEntityManagerFactory().getPersistenceUnitUtil();
-		this.entityInformation = new JpaMetamodelEntityInformation<>(domainClass, em.getMetamodel(), persistenceUnitUtil);
+		PersistenceUnitUtil persistenceUnitUtil = entityManager.getEntityManagerFactory().getPersistenceUnitUtil();
+		this.entityInformation = new JpaMetamodelEntityInformation<>(domainClass, entityManager.getMetamodel(), persistenceUnitUtil);
 
 		boolean recreationRequired = parameters.hasDynamicProjection() || parameters.potentiallySortsDynamically()
 				|| method.isScrollQuery();
@@ -125,7 +125,7 @@ public class PartTreeJpaQuery extends AbstractJpaQuery {
 		if (this.getQueryMethod().isScrollQuery()) {
 			return new ScrollExecution(this.tree.getSort(), new ScrollDelegate<>(entityInformation));
 		} else if (this.tree.isDelete()) {
-			return new DeleteExecution(em);
+			return new DeleteExecution(entityManager);
 		} else if (this.tree.isExistsProjection()) {
 			return new ExistsExecution();
 		}

--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/SimpleJpaQuery.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/SimpleJpaQuery.java
@@ -40,32 +40,32 @@ final class SimpleJpaQuery extends AbstractStringBasedJpaQuery {
 	 * Creates a new {@link SimpleJpaQuery} encapsulating the query annotated on the given {@link JpaQueryMethod}.
 	 *
 	 * @param method must not be {@literal null}
-	 * @param em must not be {@literal null}
+	 * @param entityManager must not be {@literal null}
 	 * @param countQueryString
 	 * @param queryRewriter must not be {@literal null}
 	 * @param evaluationContextProvider must not be {@literal null}
 	 * @param parser must not be {@literal null}
 	 */
-	public SimpleJpaQuery(JpaQueryMethod method, EntityManager em, @Nullable String countQueryString,
+	public SimpleJpaQuery(JpaQueryMethod method, EntityManager entityManager, @Nullable String countQueryString,
 			QueryRewriter queryRewriter, QueryMethodEvaluationContextProvider evaluationContextProvider, SpelExpressionParser parser) {
-		this(method, em, method.getRequiredAnnotatedQuery(), countQueryString, queryRewriter, evaluationContextProvider, parser);
+		this(method, entityManager, method.getRequiredAnnotatedQuery(), countQueryString, queryRewriter, evaluationContextProvider, parser);
 	}
 
 	/**
 	 * Creates a new {@link SimpleJpaQuery} that encapsulates a simple query string.
 	 *
 	 * @param method must not be {@literal null}
-	 * @param em must not be {@literal null}
+	 * @param entityManager must not be {@literal null}
 	 * @param queryString must not be {@literal null} or empty
 	 * @param countQueryString
 	 * @param queryRewriter
 	 * @param evaluationContextProvider must not be {@literal null}
 	 * @param parser must not be {@literal null}
 	 */
-	public SimpleJpaQuery(JpaQueryMethod method, EntityManager em, String queryString, @Nullable String countQueryString, QueryRewriter queryRewriter,
+	public SimpleJpaQuery(JpaQueryMethod method, EntityManager entityManager, String queryString, @Nullable String countQueryString, QueryRewriter queryRewriter,
 			QueryMethodEvaluationContextProvider evaluationContextProvider, SpelExpressionParser parser) {
 
-		super(method, em, queryString, countQueryString, queryRewriter, evaluationContextProvider, parser);
+		super(method, entityManager, queryString, countQueryString, queryRewriter, evaluationContextProvider, parser);
 
 		validateQuery(getQuery().getQueryString(), "Validation failed for query for method %s", method);
 
@@ -87,11 +87,11 @@ final class SimpleJpaQuery extends AbstractStringBasedJpaQuery {
 			return;
 		}
 
-		EntityManager validatingEm = null;
+		EntityManager validatingEntityManager = null;
 
 		try {
-			validatingEm = getEntityManager().getEntityManagerFactory().createEntityManager();
-			validatingEm.createQuery(query);
+			validatingEntityManager = getEntityManager().getEntityManagerFactory().createEntityManager();
+			validatingEntityManager.createQuery(query);
 
 		} catch (RuntimeException e) {
 
@@ -101,8 +101,8 @@ final class SimpleJpaQuery extends AbstractStringBasedJpaQuery {
 
 		} finally {
 
-			if (validatingEm != null) {
-				validatingEm.close();
+			if (validatingEntityManager != null) {
+				validatingEntityManager.close();
 			}
 		}
 	}

--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/StoredProcedureJpaQuery.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/StoredProcedureJpaQuery.java
@@ -55,11 +55,11 @@ class StoredProcedureJpaQuery extends AbstractJpaQuery {
 	 * Creates a new {@link StoredProcedureJpaQuery}.
 	 *
 	 * @param method must not be {@literal null}
-	 * @param em must not be {@literal null}
+	 * @param entityManager must not be {@literal null}
 	 */
-	StoredProcedureJpaQuery(JpaQueryMethod method, EntityManager em) {
+	StoredProcedureJpaQuery(JpaQueryMethod method, EntityManager entityManager) {
 
-		super(method, em);
+		super(method, entityManager);
 		this.procedureAttributes = method.getProcedureAttributes();
 		this.useNamedParameters = useNamedParameters(method);
 	}

--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/support/JpaRepositoryFactory.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/support/JpaRepositoryFactory.java
@@ -323,13 +323,13 @@ public class JpaRepositoryFactory extends RepositoryFactorySupport {
 		/**
 		 * Creates a new {@link EclipseLinkProjectionQueryCreationListener} for the given {@link EntityManager}.
 		 *
-		 * @param em must not be {@literal null}.
+		 * @param entityManager must not be {@literal null}.
 		 */
-		public EclipseLinkProjectionQueryCreationListener(EntityManager em) {
+		public EclipseLinkProjectionQueryCreationListener(EntityManager entityManager) {
 
-			Assert.notNull(em, "EntityManager must not be null");
+			Assert.notNull(entityManager, "EntityManager must not be null");
 
-			this.metamodel = JpaMetamodel.of(em.getMetamodel());
+			this.metamodel = JpaMetamodel.of(entityManager.getMetamodel());
 		}
 
 		@Override

--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/support/MutableQueryHints.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/support/MutableQueryHints.java
@@ -38,7 +38,7 @@ public class MutableQueryHints implements QueryHints {
 	private final MultiValueMap<String, Object> values = new LinkedMultiValueMap<>();
 
 	@Override
-	public QueryHints withFetchGraphs(EntityManager em) {
+	public QueryHints withFetchGraphs(EntityManager entityManager) {
 		return this;
 	}
 

--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/support/QueryHints.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/support/QueryHints.java
@@ -56,10 +56,10 @@ public interface QueryHints {
 	/**
 	 * Creates and returns a new {@link QueryHints} instance including {@link jakarta.persistence.EntityGraph}.
 	 *
-	 * @param em must not be {@literal null}.
+	 * @param entityManager must not be {@literal null}.
 	 * @return new instance of {@link QueryHints}.
 	 */
-	QueryHints withFetchGraphs(EntityManager em);
+	QueryHints withFetchGraphs(EntityManager entityManager);
 
 	/**
 	 * Creates and returns a new {@link QueryHints} instance that will contain only those hints applicable for count
@@ -93,7 +93,7 @@ public interface QueryHints {
 		INSTANCE;
 
 		@Override
-		public QueryHints withFetchGraphs(EntityManager em) {
+		public QueryHints withFetchGraphs(EntityManager entityManager) {
 			return this;
 		}
 

--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/support/Querydsl.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/support/Querydsl.java
@@ -51,23 +51,23 @@ import com.querydsl.jpa.impl.JPAQuery;
  */
 public class Querydsl {
 
-	private final EntityManager em;
+	private final EntityManager entityManager;
 	private final PersistenceProvider provider;
 	private final PathBuilder<?> builder;
 
 	/**
 	 * Creates a new {@link Querydsl} for the given {@link EntityManager} and {@link PathBuilder}.
 	 *
-	 * @param em must not be {@literal null}.
+	 * @param entityManager must not be {@literal null}.
 	 * @param builder must not be {@literal null}.
 	 */
-	public Querydsl(EntityManager em, PathBuilder<?> builder) {
+	public Querydsl(EntityManager entityManager, PathBuilder<?> builder) {
 
-		Assert.notNull(em, "EntityManager must not be null");
+		Assert.notNull(entityManager, "EntityManager must not be null");
 		Assert.notNull(builder, "PathBuilder must not be null");
 
-		this.em = em;
-		this.provider = PersistenceProvider.fromEntityManager(em);
+		this.entityManager = entityManager;
+		this.provider = PersistenceProvider.fromEntityManager(entityManager);
 		this.builder = builder;
 	}
 
@@ -78,12 +78,12 @@ public class Querydsl {
 
 		switch (provider) {
 			case ECLIPSELINK:
-				return new JPAQuery<>(em, EclipseLinkTemplates.DEFAULT);
+				return new JPAQuery<>(entityManager, EclipseLinkTemplates.DEFAULT);
 			case HIBERNATE:
-				return new JPAQuery<>(em, HQLTemplates.DEFAULT);
+				return new JPAQuery<>(entityManager, HQLTemplates.DEFAULT);
 			case GENERIC_JPA:
 			default:
-				return new JPAQuery<>(em);
+				return new JPAQuery<>(entityManager);
 		}
 	}
 

--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/support/SimpleJpaRepository.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/support/SimpleJpaRepository.java
@@ -99,7 +99,7 @@ public class SimpleJpaRepository<T, ID> implements JpaRepositoryImplementation<T
 	private static final String ID_MUST_NOT_BE_NULL = "The given id must not be null";
 
 	private final JpaEntityInformation<T, ?> entityInformation;
-	private final EntityManager em;
+	private final EntityManager entityManager;
 	private final PersistenceProvider provider;
 
 	private @Nullable CrudMethodMetadata metadata;
@@ -117,7 +117,7 @@ public class SimpleJpaRepository<T, ID> implements JpaRepositoryImplementation<T
 		Assert.notNull(entityManager, "EntityManager must not be null");
 
 		this.entityInformation = entityInformation;
-		this.em = entityManager;
+		this.entityManager = entityManager;
 		this.provider = PersistenceProvider.fromEntityManager(entityManager);
 	}
 
@@ -125,10 +125,10 @@ public class SimpleJpaRepository<T, ID> implements JpaRepositoryImplementation<T
 	 * Creates a new {@link SimpleJpaRepository} to manage objects of the given domain type.
 	 *
 	 * @param domainClass must not be {@literal null}.
-	 * @param em must not be {@literal null}.
+	 * @param entityManager must not be {@literal null}.
 	 */
-	public SimpleJpaRepository(Class<T> domainClass, EntityManager em) {
-		this(JpaEntityInformationSupport.getEntityInformation(domainClass, em), em);
+	public SimpleJpaRepository(Class<T> domainClass, EntityManager entityManager) {
+		this(JpaEntityInformationSupport.getEntityInformation(domainClass, entityManager), entityManager);
 	}
 
 	/**
@@ -188,14 +188,14 @@ public class SimpleJpaRepository<T, ID> implements JpaRepositoryImplementation<T
 
 		Class<?> type = ProxyUtils.getUserClass(entity);
 
-		T existing = (T) em.find(type, entityInformation.getId(entity));
+		T existing = (T) entityManager.find(type, entityInformation.getId(entity));
 
 		// if the entity to be deleted doesn't exist, delete is a NOOP
 		if (existing == null) {
 			return;
 		}
 
-		em.remove(em.contains(entity) ? entity : em.merge(entity));
+		entityManager.remove(entityManager.contains(entity) ? entity : entityManager.merge(entity));
 	}
 
 	@Override
@@ -230,7 +230,7 @@ public class SimpleJpaRepository<T, ID> implements JpaRepositoryImplementation<T
 			String queryString = String.format(DELETE_ALL_QUERY_BY_ID_STRING, entityInformation.getEntityName(),
 					entityInformation.getIdAttribute().getName());
 
-			Query query = em.createQuery(queryString);
+			Query query = entityManager.createQuery(queryString);
 
 			/*
 			 * Some JPA providers require {@code ids} to be a {@link Collection} so we must convert if it's not already.
@@ -271,7 +271,7 @@ public class SimpleJpaRepository<T, ID> implements JpaRepositoryImplementation<T
 			return;
 		}
 
-		applyAndBind(getQueryString(DELETE_ALL_QUERY_STRING, entityInformation.getEntityName()), entities, em)
+		applyAndBind(getQueryString(DELETE_ALL_QUERY_STRING, entityInformation.getEntityName()), entities, entityManager)
 				.executeUpdate();
 	}
 
@@ -288,7 +288,7 @@ public class SimpleJpaRepository<T, ID> implements JpaRepositoryImplementation<T
 	@Transactional
 	public void deleteAllInBatch() {
 
-		Query query = em.createQuery(getDeleteAllQueryString());
+		Query query = entityManager.createQuery(getDeleteAllQueryString());
 
 		applyQueryHints(query);
 
@@ -303,13 +303,13 @@ public class SimpleJpaRepository<T, ID> implements JpaRepositoryImplementation<T
 		Class<T> domainType = getDomainClass();
 
 		if (metadata == null) {
-			return Optional.ofNullable(em.find(domainType, id));
+			return Optional.ofNullable(entityManager.find(domainType, id));
 		}
 
 		LockModeType type = metadata.getLockModeType();
 		Map<String, Object> hints = getHints();
 
-		return Optional.ofNullable(type == null ? em.find(domainType, id, hints) : em.find(domainType, id, type, hints));
+		return Optional.ofNullable(type == null ? entityManager.find(domainType, id, hints) : entityManager.find(domainType, id, type, hints));
 	}
 
 	@Deprecated
@@ -332,7 +332,7 @@ public class SimpleJpaRepository<T, ID> implements JpaRepositoryImplementation<T
 	public T getReferenceById(ID id) {
 
 		Assert.notNull(id, ID_MUST_NOT_BE_NULL);
-		return em.getReference(getDomainClass(), id);
+		return entityManager.getReference(getDomainClass(), id);
 	}
 
 	@Override
@@ -349,7 +349,7 @@ public class SimpleJpaRepository<T, ID> implements JpaRepositoryImplementation<T
 		Iterable<String> idAttributeNames = entityInformation.getIdAttributeNames();
 		String existsQuery = QueryUtils.getExistsQueryString(entityName, placeholder, idAttributeNames);
 
-		TypedQuery<Long> query = em.createQuery(existsQuery, Long.class);
+		TypedQuery<Long> query = entityManager.createQuery(existsQuery, Long.class);
 
 		applyQueryHints(query);
 
@@ -456,20 +456,20 @@ public class SimpleJpaRepository<T, ID> implements JpaRepositoryImplementation<T
 	@Override
 	public boolean exists(Specification<T> spec) {
 
-		CriteriaQuery<Integer> cq = this.em.getCriteriaBuilder() //
+		CriteriaQuery<Integer> cq = this.entityManager.getCriteriaBuilder() //
 				.createQuery(Integer.class) //
-				.select(this.em.getCriteriaBuilder().literal(1));
+				.select(this.entityManager.getCriteriaBuilder().literal(1));
 
 		applySpecificationToCriteria(spec, getDomainClass(), cq);
 
-		TypedQuery<Integer> query = applyRepositoryMethodMetadata(this.em.createQuery(cq));
+		TypedQuery<Integer> query = applyRepositoryMethodMetadata(this.entityManager.createQuery(cq));
 		return query.setMaxResults(1).getResultList().size() == 1;
 	}
 
 	@Override
 	public long delete(Specification<T> spec) {
 
-		CriteriaBuilder builder = this.em.getCriteriaBuilder();
+		CriteriaBuilder builder = this.entityManager.getCriteriaBuilder();
 		CriteriaDelete<T> delete = builder.createCriteriaDelete(getDomainClass());
 
 		if (spec != null) {
@@ -480,7 +480,7 @@ public class SimpleJpaRepository<T, ID> implements JpaRepositoryImplementation<T
 			}
 		}
 
-		return this.em.createQuery(delete).executeUpdate();
+		return this.entityManager.createQuery(delete).executeUpdate();
 	}
 
 	@Override
@@ -522,7 +522,7 @@ public class SimpleJpaRepository<T, ID> implements JpaRepositoryImplementation<T
 		SpecificationScrollDelegate<T> scrollDelegate = new SpecificationScrollDelegate<>(scrollFunction,
 				entityInformation);
 		FetchableFluentQuery<T> fluentQuery = new FetchableFluentQueryBySpecification<>(spec, domainClass, finder,
-				scrollDelegate, this::count, this::exists, this.em);
+				scrollDelegate, this::count, this::exists, this.entityManager);
 
 		return queryFunction.apply((FetchableFluentQuery<S>) fluentQuery);
 	}
@@ -549,13 +549,13 @@ public class SimpleJpaRepository<T, ID> implements JpaRepositoryImplementation<T
 	public <S extends T> boolean exists(Example<S> example) {
 
 		Specification<S> spec = new ExampleSpecification<>(example, this.escapeCharacter);
-		CriteriaQuery<Integer> cq = this.em.getCriteriaBuilder() //
+		CriteriaQuery<Integer> cq = this.entityManager.getCriteriaBuilder() //
 				.createQuery(Integer.class) //
-				.select(this.em.getCriteriaBuilder().literal(1));
+				.select(this.entityManager.getCriteriaBuilder().literal(1));
 
 		applySpecificationToCriteria(spec, example.getProbeType(), cq);
 
-		TypedQuery<Integer> query = applyRepositoryMethodMetadata(this.em.createQuery(cq));
+		TypedQuery<Integer> query = applyRepositoryMethodMetadata(this.entityManager.createQuery(cq));
 		return query.setMaxResults(1).getResultList().size() == 1;
 	}
 
@@ -595,7 +595,7 @@ public class SimpleJpaRepository<T, ID> implements JpaRepositoryImplementation<T
 	@Override
 	public long count() {
 
-		TypedQuery<Long> query = em.createQuery(getCountQueryString(), Long.class);
+		TypedQuery<Long> query = entityManager.createQuery(getCountQueryString(), Long.class);
 
 		applyQueryHintsForCount(query);
 
@@ -614,10 +614,10 @@ public class SimpleJpaRepository<T, ID> implements JpaRepositoryImplementation<T
 		Assert.notNull(entity, "Entity must not be null");
 
 		if (entityInformation.isNew(entity)) {
-			em.persist(entity);
+			entityManager.persist(entity);
 			return entity;
 		} else {
-			return em.merge(entity);
+			return entityManager.merge(entity);
 		}
 	}
 
@@ -659,7 +659,7 @@ public class SimpleJpaRepository<T, ID> implements JpaRepositoryImplementation<T
 	@Transactional
 	@Override
 	public void flush() {
-		em.flush();
+		entityManager.flush();
 	}
 
 	/**
@@ -742,7 +742,7 @@ public class SimpleJpaRepository<T, ID> implements JpaRepositoryImplementation<T
 	 */
 	protected <S extends T> TypedQuery<S> getQuery(@Nullable Specification<S> spec, Class<S> domainClass, Sort sort) {
 
-		CriteriaBuilder builder = em.getCriteriaBuilder();
+		CriteriaBuilder builder = entityManager.getCriteriaBuilder();
 		CriteriaQuery<S> query = builder.createQuery(domainClass);
 
 		Root<S> root = applySpecificationToCriteria(spec, domainClass, query);
@@ -752,7 +752,7 @@ public class SimpleJpaRepository<T, ID> implements JpaRepositoryImplementation<T
 			query.orderBy(toOrders(sort, root, builder));
 		}
 
-		return applyRepositoryMethodMetadata(em.createQuery(query));
+		return applyRepositoryMethodMetadata(entityManager.createQuery(query));
 	}
 
 	/**
@@ -774,7 +774,7 @@ public class SimpleJpaRepository<T, ID> implements JpaRepositoryImplementation<T
 	 */
 	protected <S extends T> TypedQuery<Long> getCountQuery(@Nullable Specification<S> spec, Class<S> domainClass) {
 
-		CriteriaBuilder builder = em.getCriteriaBuilder();
+		CriteriaBuilder builder = entityManager.getCriteriaBuilder();
 		CriteriaQuery<Long> query = builder.createQuery(Long.class);
 
 		Root<S> root = applySpecificationToCriteria(spec, domainClass, query);
@@ -788,7 +788,7 @@ public class SimpleJpaRepository<T, ID> implements JpaRepositoryImplementation<T
 		// Remove all Orders the Specifications might have applied
 		query.orderBy(Collections.emptyList());
 
-		return applyRepositoryMethodMetadataForCount(em.createQuery(query));
+		return applyRepositoryMethodMetadataForCount(entityManager.createQuery(query));
 	}
 
 	/**
@@ -825,7 +825,7 @@ public class SimpleJpaRepository<T, ID> implements JpaRepositoryImplementation<T
 			return root;
 		}
 
-		CriteriaBuilder builder = em.getCriteriaBuilder();
+		CriteriaBuilder builder = entityManager.getCriteriaBuilder();
 		Predicate predicate = spec.toPredicate(root, query, builder);
 
 		if (predicate != null) {
@@ -855,7 +855,7 @@ public class SimpleJpaRepository<T, ID> implements JpaRepositoryImplementation<T
 			return;
 		}
 
-		getQueryHints().withFetchGraphs(em).forEach(query::setHint);
+		getQueryHints().withFetchGraphs(entityManager).forEach(query::setHint);
 		applyComment(metadata, query::setHint);
 	}
 
@@ -884,7 +884,7 @@ public class SimpleJpaRepository<T, ID> implements JpaRepositoryImplementation<T
 
 		Map<String, Object> hints = new HashMap<>();
 
-		getQueryHints().withFetchGraphs(em).forEach(hints::put);
+		getQueryHints().withFetchGraphs(entityManager).forEach(hints::put);
 
 		if (metadata != null) {
 			applyComment(metadata, hints::put);


### PR DESCRIPTION
I saw the PR (#3120) and renamed all of them to entityManager in the org.springframework.data.jpa package.