### PR TITLE
Using instancesof pattern matching.

### DIFF
--- a/spring-data-envers/src/main/java/org/springframework/data/envers/repository/support/EnversRevisionRepositoryImpl.java
+++ b/spring-data-envers/src/main/java/org/springframework/data/envers/repository/support/EnversRevisionRepositoryImpl.java
@@ -240,17 +240,12 @@ public class EnversRevisionRepositoryImpl<T, ID, N extends Number & Comparable<N
 
 		private static RevisionMetadata.RevisionType convertRevisionType(RevisionType datum) {
 
-			switch (datum) {
-
-				case ADD:
-					return INSERT;
-				case MOD:
-					return UPDATE;
-				case DEL:
-					return DELETE;
-				default:
-					return UNKNOWN;
-			}
+            return switch (datum) {
+                case ADD -> INSERT;
+                case MOD -> UPDATE;
+                case DEL -> DELETE;
+                default -> UNKNOWN;
+            };
 		}
 	}
 

--- a/spring-data-envers/src/main/java/org/springframework/data/envers/repository/support/EnversRevisionRepositoryImpl.java
+++ b/spring-data-envers/src/main/java/org/springframework/data/envers/repository/support/EnversRevisionRepositoryImpl.java
@@ -169,8 +169,8 @@ public class EnversRevisionRepositoryImpl<T, ID, N extends Number & Comparable<N
 
 		AuditQuery baseQuery = createBaseQuery(id);
 
-		List<AuditOrder> orderMapped = (pageable.getSort() instanceof RevisionSort) ?
-				Collections.singletonList(mapRevisionSort((RevisionSort) pageable.getSort())) :
+		List<AuditOrder> orderMapped = (pageable.getSort() instanceof RevisionSort revisionSort) ?
+				Collections.singletonList(mapRevisionSort(revisionSort)) :
 				mapPropertySort(pageable.getSort());
 
 		orderMapped.forEach(baseQuery::addOrder);
@@ -232,8 +232,8 @@ public class EnversRevisionRepositoryImpl<T, ID, N extends Number & Comparable<N
 
 		RevisionMetadata<?> createRevisionMetadata() {
 
-			return metadata instanceof DefaultRevisionEntity //
-					? new DefaultRevisionMetadata((DefaultRevisionEntity) metadata, revisionType) //
+			return metadata instanceof DefaultRevisionEntity defaultRevisionEntity //
+					? new DefaultRevisionMetadata(defaultRevisionEntity, revisionType) //
 					: new AnnotationRevisionMetadata<>(Hibernate.unproxy(metadata), RevisionNumber.class, RevisionTimestamp.class,
 					revisionType);
 		}

--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/provider/HibernateUtils.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/provider/HibernateUtils.java
@@ -45,8 +45,8 @@ public abstract class HibernateUtils {
 		try {
 
 			// Try the new Hibernate implementation first
-			if (query instanceof SqmQuery) {
-				return ((SqmQuery) query).getSqmStatement().toHqlString();
+			if (query instanceof SqmQuery sqmQuery) {
+				return sqmQuery.getSqmStatement().toHqlString();
 			}
 
 			// Couple of cases in which this still breaks, see HHH-15389

--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/provider/JpaClassUtils.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/provider/JpaClassUtils.java
@@ -48,8 +48,8 @@ abstract class JpaClassUtils {
 		EntityManager entityManagerToUse = em;
 		Object delegate = em.getDelegate();
 
-		if (delegate instanceof EntityManager) {
-			entityManagerToUse = (EntityManager) delegate;
+		if (delegate instanceof EntityManager delegateEntityManager) {
+			entityManagerToUse = delegateEntityManager;
 		}
 
 		return isOfType(entityManagerToUse, type, entityManagerToUse.getClass().getClassLoader());

--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/cdi/JpaRepositoryExtension.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/cdi/JpaRepositoryExtension.java
@@ -68,7 +68,7 @@ public class JpaRepositoryExtension extends CdiRepositoryExtensionSupport {
 		Bean<X> bean = processBean.getBean();
 		for (Type type : bean.getTypes()) {
 			// Check if the bean is an EntityManager.
-			if (type instanceof Class<?> && EntityManager.class.isAssignableFrom((Class<?>) type)) {
+			if (type instanceof Class<?> classType && EntityManager.class.isAssignableFrom(classType)) {
 				Set<Annotation> qualifiers = new HashSet<>(bean.getQualifiers());
 				if (bean.isAlternative() || !entityManagers.containsKey(qualifiers)) {
 					LOGGER.debug(String.format("Discovered '%s' with qualifiers %s", EntityManager.class.getName(), qualifiers));

--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/JpaQueryTransformerSupport.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/JpaQueryTransformerSupport.java
@@ -85,7 +85,7 @@ class JpaQueryTransformerSupport {
 	 */
 	private void checkSortExpression(Sort.Order order) {
 
-		if (order instanceof JpaSort.JpaOrder && ((JpaSort.JpaOrder) order).isUnsafe()) {
+		if (order instanceof JpaSort.JpaOrder jpaOrder && jpaOrder.isUnsafe()) {
 			return;
 		}
 

--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/Meta.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/Meta.java
@@ -103,7 +103,7 @@ public class Meta {
 			values = new LinkedHashMap<>(2);
 		}
 
-		if (value == null || (value instanceof String && !StringUtils.hasText((String) value))) {
+		if (value == null || (value instanceof String stringValue && !StringUtils.hasText(stringValue))) {
 			this.values.remove(key);
 		}
 		this.values.put(key, value);

--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/ParameterMetadataProvider.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/ParameterMetadataProvider.java
@@ -274,9 +274,8 @@ class ParameterMetadataProvider {
 				return null;
 			}
 
-			if (value instanceof Collection) {
+			if (value instanceof Collection<?> collection) {
 
-				Collection<?> collection = (Collection<?>) value;
 				return collection.isEmpty() ? null : collection;
 			}
 

--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/QueryUtils.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/QueryUtils.java
@@ -846,11 +846,9 @@ public abstract class QueryUtils {
 			return true;
 		}
 
-		if (!(propertyPathModel instanceof Attribute)) {
+		if (!(propertyPathModel instanceof Attribute<?, ?> attribute)) {
 			return false;
 		}
-
-		Attribute<?, ?> attribute = (Attribute<?, ?>) propertyPathModel;
 
 		// not a persistent attribute type association (@OneToOne, @ManyToOne)
 		if (!ASSOCIATION_TYPES.containsKey(attribute.getPersistentAttributeType())) {
@@ -882,11 +880,11 @@ public abstract class QueryUtils {
 
 		Member member = attribute.getJavaMember();
 
-		if (!(member instanceof AnnotatedElement)) {
+		if (!(member instanceof AnnotatedElement annotatedMember)) {
 			return defaultValue;
 		}
 
-		Annotation annotation = AnnotationUtils.getAnnotation((AnnotatedElement) member, associationAnnotation);
+		Annotation annotation = AnnotationUtils.getAnnotation(annotatedMember, associationAnnotation);
 		return annotation == null ? defaultValue : (T) AnnotationUtils.getValue(annotation, propertyName);
 	}
 
@@ -945,7 +943,7 @@ public abstract class QueryUtils {
 	 */
 	static void checkSortExpression(Order order) {
 
-		if (order instanceof JpaOrder && ((JpaOrder) order).isUnsafe()) {
+		if (order instanceof JpaOrder jpaOrder && jpaOrder.isUnsafe()) {
 			return;
 		}
 

--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/support/EntityManagerBeanDefinitionRegistrarPostProcessor.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/support/EntityManagerBeanDefinitionRegistrarPostProcessor.java
@@ -64,12 +64,11 @@ public class EntityManagerBeanDefinitionRegistrarPostProcessor implements BeanFa
 
 			BeanFactory definitionFactory = definition.getBeanFactory();
 
-			if (!(definitionFactory instanceof BeanDefinitionRegistry)) {
+			if (!(definitionFactory instanceof BeanDefinitionRegistry definitionRegistry)) {
 				continue;
 			}
 
 			String entityManagerBeanName = "jpaSharedEM_AWC_" + definition.getBeanName();
-			BeanDefinitionRegistry definitionRegistry = (BeanDefinitionRegistry) definitionFactory;
 
 			if (!beanFactory.containsBeanDefinition(entityManagerBeanName)
 					&& !definitionRegistry.containsBeanDefinition(entityManagerBeanName)) {

--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/support/Querydsl.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/support/Querydsl.java
@@ -137,8 +137,8 @@ public class Querydsl {
 			return query;
 		}
 
-		if (sort instanceof QSort) {
-			return addOrderByFrom((QSort) sort, query);
+		if (sort instanceof QSort qsort) {
+			return addOrderByFrom(qsort, query);
 		}
 
 		return addOrderByFrom(sort, query);

--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/util/BeanDefinitionUtils.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/util/BeanDefinitionUtils.java
@@ -107,8 +107,8 @@ public final class BeanDefinitionUtils {
 
 		BeanFactory parentBeanFactory = beanFactory.getParentBeanFactory();
 
-		if (parentBeanFactory instanceof ConfigurableListableBeanFactory) {
-			definitions.addAll(getEntityManagerFactoryBeanDefinitions((ConfigurableListableBeanFactory) parentBeanFactory));
+		if (parentBeanFactory instanceof ConfigurableListableBeanFactory parentConfigurableListableBeanFactory) {
+			definitions.addAll(getEntityManagerFactoryBeanDefinitions(parentConfigurableListableBeanFactory));
 		}
 
 		return definitions;
@@ -157,8 +157,8 @@ public final class BeanDefinitionUtils {
 
 			BeanFactory parentBeanFactory = beanFactory.getParentBeanFactory();
 
-			if (parentBeanFactory instanceof ConfigurableListableBeanFactory) {
-				return getBeanDefinition(name, (ConfigurableListableBeanFactory) parentBeanFactory);
+			if (parentBeanFactory instanceof ConfigurableListableBeanFactory parentConfigurableListableBeanFactory) {
+				return getBeanDefinition(name, parentConfigurableListableBeanFactory);
 			}
 
 			throw o_O;


### PR DESCRIPTION
I fixed methods that didn't use `instanceof pattern matching` to use it.

I didn't apply it to the `equal` method because it seemed to generate without using `instanceof pattern matching`.

I also didn't apply it to the following part of `HibernateUtils` because it was ambiguous to apply, but if you have a good recommendation, I will apply it.
```java
if (query instanceof Query) {
    return ((Query<?>) query).getQueryString();
}
```
