### PR TITLE
Add the ability to set parameter values for Specifications ran via JpaSpecificationExecutor

### DIFF
--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/domain/ParametersValues.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/domain/ParametersValues.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2008-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.jpa.domain;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.BiConsumer;
+
+/**
+ * Holds the values for query parameters Used to set values for Specifications that have named parameters via
+ * JpaSpecificationExecutor
+ *
+ * @author Vladimir Iftodi
+ */
+public class ParametersValues {
+
+	private final Map<String, Object> valuesByParameterName = new HashMap<>();
+
+	public static ParametersValues empty() {
+		return new ParametersValues();
+	}
+
+	public static ParametersValues of(String name, Object value) {
+		var paramValues = new ParametersValues();
+
+		paramValues.setValue(name, value);
+
+		return paramValues;
+	}
+
+	public static ParametersValues of(String name1, Object value1, String name2, Object value2) {
+		var paramValues = new ParametersValues();
+
+		paramValues.setValue(name1, value1);
+		paramValues.setValue(name2, value2);
+
+		return paramValues;
+	}
+
+	public static ParametersValues from(Map<String, Object> paramValuesMap) {
+		var paramValues = new ParametersValues();
+
+		paramValuesMap.forEach(paramValues::setValue);
+
+		return paramValues;
+	}
+
+	public void setValue(String name, Object value) {
+		valuesByParameterName.put(name, value);
+	}
+
+	public void forEach(BiConsumer<String, Object> action) {
+		valuesByParameterName.forEach(action);
+	}
+
+}

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/domain/sample/UserSpecifications.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/domain/sample/UserSpecifications.java
@@ -27,6 +27,7 @@ import org.springframework.data.jpa.domain.Specification;
  *
  * @author Oliver Gierke
  * @author Diego Krupitza
+ * @author Vladimir Iftodi
  */
 public class UserSpecifications {
 
@@ -39,6 +40,14 @@ public class UserSpecifications {
 	}
 
 	/**
+	 * A {@link Specification} to match on a {@link User}'s firstname via a named parameter.
+	 */
+	public static Specification<User> userHasFirstNameEqNamedParameter() {
+
+		return simpleNamedParameterSpec("firstname", String.class, "firstname");
+	}
+
+	/**
 	 * A {@link Specification} to match on a {@link User}'s lastname.
 	 */
 	public static Specification<User> userHasLastname(final String lastname) {
@@ -47,11 +56,28 @@ public class UserSpecifications {
 	}
 
 	/**
+	 * A {@link Specification} to match on a {@link User}'s lastname via a named parameter.
+	 */
+	public static Specification<User> userHasLastNameEqNamedParameter() {
+
+		return simpleNamedParameterSpec("lastname", String.class, "lastname");
+	}
+
+
+	/**
 	 * A {@link Specification} to do a like-match on a {@link User}'s firstname.
 	 */
 	public static Specification<User> userHasFirstnameLike(final String expression) {
 
 		return (root, query, cb) -> cb.like(root.get("firstname").as(String.class), String.format("%%%s%%", expression));
+	}
+
+	/**
+	 * A {@link Specification} to do a like-match on a {@link User}'s firstname with a param.
+	 */
+	public static Specification<User> userHasFirstnameLikeWithParam() {
+
+		return (root, query, cb) -> cb.like(root.get("firstname").as(String.class), cb.parameter(String.class, "like"));
 	}
 
 	/**
@@ -63,6 +89,18 @@ public class UserSpecifications {
 
 		return (root, query, cb) -> cb.lessThan(root.get("age").as(Integer.class), age);
 	}
+
+	/**
+	 * A {@link Specification} to do an age check with a parameter.
+	 *
+	 */
+	public static Specification<User> userHasAgeLessThanParam() {
+
+		return (root, query, cb) -> cb.lessThan(root.get("age").as(Integer.class), cb.parameter(Integer.class, "age"));
+	}
+
+
+	
 
 	/**
 	 * A {@link Specification} to do a like-match on a {@link User}'s lastname but also adding a sort order on the
@@ -82,4 +120,10 @@ public class UserSpecifications {
 
 		return (root, query, builder) -> builder.equal(root.get(property), value);
 	}
+
+	private static <T> Specification<T> simpleNamedParameterSpec(final String property, Class<?> paramClass, final String parameterName) {
+
+		return (root, query, builder) -> builder.equal(root.get(property), builder.parameter(paramClass, parameterName));
+	}
+
 }


### PR DESCRIPTION
It is possible via the CriteriaBuilder to set up parameters, but parameter values can't be set up if a Specification is ran via a spring repository (via JPASpecificationExecutor)

While it is certainly possible to create custom criterias/queries manually using the EntityManager, it is preferable to be able to set parameter values via Specification/Repository since it's a higher level API.

Using parameters instead of values/literals has multiple advantages:

- Better code design: separating the creation of a specification from the filter values that are applied during execution, especially when having dynamic Specifications with many user defined filter values.
- Shorter queries that don't necessarily leak certain information in the query: While Hibernate might automatically create parameters  and their values for certain Specifications (Notably cb.equal(Expression, Object)  if so configured, it can't do it for all cases, notably for cb.function where the arguments are Expression and you are forced to pass literals


This Pull Request adds a new record class ParametersValues in the same package as the Specification, that servers as a way to hold parameter name -> parameter values.

All methods in JPASpecificationExecutor that took Specifications as an argument now have variants that take ParametersValues as an argument as well

In the implementation in SimpleJpaRepository the methods without a ParamatersValues simply delegate their call to the counterparts with such an argument.

And the code that sets up the parameter values is mostly contained in the query creation code.

Test methods have been extended based on existing tests, but instead of using values, Specification using parameters were used instead.

The only test method that hasn't duplicated all tests is the findBy variant using a specification and a queryFunction
This is because the other tests verify mostly behaviour related to the queryFunction, and since the code is shared, only a single test was created to test that paramterValues are actually set

Thank you.

- [x ] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x ] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [ x] You submit test cases (unit or integration tests) that back your changes.
- [ x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
