### PR TITLE
Use version-agnostic Hibernate presence check in `QueryEnhancerFactory`

### DIFF
--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/QueryEnhancerFactory.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/QueryEnhancerFactory.java
@@ -37,13 +37,16 @@ public final class QueryEnhancerFactory {
 	private static final boolean hibernatePresent = ClassUtils.isPresent("org.hibernate.query.TypedParameterValue",
 			QueryEnhancerFactory.class.getClassLoader());
 
+	private static final boolean hibernate5Present = ClassUtils.isPresent("org.hibernate.jpa.TypedParameterValue",
+			QueryEnhancerFactory.class.getClassLoader());
+
 	static {
 
 		if (jSqlParserPresent) {
 			LOG.info("JSqlParser is in classpath; If applicable, JSqlParser will be used");
 		}
 
-		if (hibernatePresent) {
+		if (hibernatePresent || hibernate5Present) {
 			LOG.info("Hibernate is in classpath; If applicable, HQL parser will be used.");
 		}
 	}
@@ -70,7 +73,7 @@ public final class QueryEnhancerFactory {
 			return new DefaultQueryEnhancer(query);
 		}
 
-		return hibernatePresent ? JpaQueryEnhancer.forHql(query) : JpaQueryEnhancer.forJpql(query);
+		return (hibernatePresent || hibernate5Present) ? JpaQueryEnhancer.forHql(query) : JpaQueryEnhancer.forJpql(query);
 	}
 
 }

--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/QueryEnhancerFactory.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/QueryEnhancerFactory.java
@@ -25,6 +25,7 @@ import org.springframework.util.ClassUtils;
  * @author Diego Krupitza
  * @author Greg Turnquist
  * @author Mark Paluch
+ * @author Aurelien Marionneau
  * @since 2.7.0
  */
 public final class QueryEnhancerFactory {


### PR DESCRIPTION
Hibernate 5.6 supports JPA 3.0, and should be usable with Spring Data JPA 3.1.x. Currently, only Hibernate 6 is detected and allows for the HQL Parser usage. This PR consists in enabling the HQL Parser in the case of Hibernate 5 too.

- [x ] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x ] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x ] You submit test cases (unit or integration tests) that back your changes.
- [x ] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).