### PR TITLE
Change the BeanDefinitionNames constant interface to a final class Constant class that cannot be inherited.

### DIFF
--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/config/AuditingBeanDefinitionParser.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/config/AuditingBeanDefinitionParser.java
@@ -16,7 +16,7 @@
 package org.springframework.data.jpa.repository.config;
 
 import static org.springframework.beans.factory.support.BeanDefinitionBuilder.*;
-
+import static org.springframework.data.jpa.repository.config.BeanDefinitionNames.*;
 import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.beans.factory.parsing.BeanComponentDefinition;
 import org.springframework.beans.factory.support.AbstractBeanDefinition;
@@ -41,7 +41,7 @@ public class AuditingBeanDefinitionParser implements BeanDefinitionParser {
 	private static final String AUDITING_BFPP_CLASS_NAME = "org.springframework.data.jpa.domain.support.AuditingBeanFactoryPostProcessor";
 
 	private final AuditingHandlerBeanDefinitionParser auditingHandlerParser = new AuditingHandlerBeanDefinitionParser(
-			BeanDefinitionNames.JPA_MAPPING_CONTEXT_BEAN_NAME);
+			JPA_MAPPING_CONTEXT_BEAN_NAME);
 	private final SpringConfiguredBeanDefinitionParser springConfiguredParser = new SpringConfiguredBeanDefinitionParser();
 
 	@Override

--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/config/BeanDefinitionNames.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/config/BeanDefinitionNames.java
@@ -22,9 +22,11 @@ package org.springframework.data.jpa.repository.config;
  * @author Thomas Darimont
  * @author Andrew Walters
  */
-interface BeanDefinitionNames {
+public final class BeanDefinitionNames {
 
-	String JPA_MAPPING_CONTEXT_BEAN_NAME = "jpaMappingContext";
-	String JPA_CONTEXT_BEAN_NAME = "jpaContext";
-	String EM_BEAN_DEFINITION_REGISTRAR_POST_PROCESSOR_BEAN_NAME = "emBeanDefinitionRegistrarPostProcessor";
+	private BeanDefinitionNames() {}
+
+	static final String JPA_MAPPING_CONTEXT_BEAN_NAME = "jpaMappingContext";
+	static final String JPA_CONTEXT_BEAN_NAME = "jpaContext";
+	static final String EM_BEAN_DEFINITION_REGISTRAR_POST_PROCESSOR_BEAN_NAME = "emBeanDefinitionRegistrarPostProcessor";
 }


### PR DESCRIPTION
The BeanDefinitionNames interface is a constant interface, so there is a risk of namespace pollution in other classes if they accidentally implement it. To prevent the risk of accidental implementation, we have transformed the constant interface into a final class with three constants. Additionally, we have updated the AuditingBeanDefinitionParser class, which currently lacks static imports, to include them.