### PR TITLE
Fixed the URL for the Spring Data Commons documentation

### DIFF
--- a/src/main/antora/resources/antora-resources/antora.yml
+++ b/src/main/antora/resources/antora-resources/antora.yml
@@ -9,7 +9,7 @@ asciidoc:
     attribute-missing: 'warn'
     commons: ${springdata.commons.docs}
     include-xml-namespaces: false
-    spring-data-commons-docs-url: https://docs.spring.io/spring-data-commons/reference
+    spring-data-commons-docs-url: https://docs.spring.io/spring-data/commons/reference
     spring-data-commons-javadoc-base: https://docs.spring.io/spring-data/commons/docs/${springdata.commons}/api/
     springdocsurl: https://docs.spring.io/spring-framework/reference/{springversionshort}
     springjavadocurl: https://docs.spring.io/spring-framework/docs/${spring}/javadoc-api


### PR DESCRIPTION
I fixed broken URLs of Spring Data Commons in the Spring Data JPA documentation.