### PR TITLE
Upgrade to MySQL 8.2.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
 		<hsqldb>2.7.1</hsqldb>
 		<h2>2.2.220</h2>
 		<jsqlparser>4.5</jsqlparser>
-		<mysql-connector-java>8.0.33</mysql-connector-java>
+		<mysql-connector-java>8.2.0</mysql-connector-java>
 		<postgresql>42.6.0</postgresql>
 		<springdata.commons>3.3.0-SNAPSHOT</springdata.commons>
 		<vavr>0.10.3</vavr>


### PR DESCRIPTION
 MySQL 8.2.0 has been released, will spring jpa 3.2 use it
MySQL 8.0 series drivers are no longer maintained, we should upgrade to the latest GA version
https://dev.mysql.com/doc/relnotes/connector-j/en/news-8-0-33.html