### PR TITLE
Render entire statement after applying sort. 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-jpa-parent</artifactId>
-	<version>3.3.0-SNAPSHOT</version>
+	<version>3.3.x-3263-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data JPA Parent</name>

--- a/spring-data-envers/pom.xml
+++ b/spring-data-envers/pom.xml
@@ -5,12 +5,12 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-envers</artifactId>
-	<version>3.3.0-SNAPSHOT</version>
+	<version>3.3.x-3263-SNAPSHOT</version>
 
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-jpa-parent</artifactId>
-		<version>3.3.0-SNAPSHOT</version>
+		<version>3.3.x-3263-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-jpa-distribution/pom.xml
+++ b/spring-data-jpa-distribution/pom.xml
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-jpa-parent</artifactId>
-		<version>3.3.0-SNAPSHOT</version>
+		<version>3.3.x-3263-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-jpa/pom.xml
+++ b/spring-data-jpa/pom.xml
@@ -6,7 +6,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-jpa</artifactId>
-	<version>3.3.0-SNAPSHOT</version>
+	<version>3.3.x-3263-SNAPSHOT</version>
 
 	<name>Spring Data JPA</name>
 	<description>Spring Data module for JPA repositories.</description>
@@ -15,7 +15,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-jpa-parent</artifactId>
-		<version>3.3.0-SNAPSHOT</version>
+		<version>3.3.x-3263-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/JSqlParserQueryEnhancer.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/JSqlParserQueryEnhancer.java
@@ -141,7 +141,7 @@ public class JSqlParserQueryEnhancer implements QueryEnhancer {
 
 		selectBody.getOrderByElements().addAll(orderByElements);
 
-		return selectBody.toString();
+		return selectStatement.toString();
 
 	}
 

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/QueryEnhancerUnitTests.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/QueryEnhancerUnitTests.java
@@ -179,6 +179,17 @@ class QueryEnhancerUnitTests {
 		assertThat(query).endsWithIgnoringCase("ORDER BY p.firstname, p.lastname asc");
 	}
 
+	@Test // GH-3263
+	void doesNotDropWithExpressionWhenApplySort() {
+
+		StringQuery query = new StringQuery("WITH all_projects AS (SELECT * FROM projects) SELECT * FROM all_projects p",
+				true);
+
+		assertThat(getEnhancer(query).applySorting(Sort.by("name"), "p")) //
+				.startsWithIgnoringCase("WITH all_projects AS (SELECT * FROM projects)")
+				.endsWithIgnoringCase("ORDER BY p.name ASC");
+	}
+
 	@Test // GH-2812
 	void createCountQueryFromDeleteQuery() {
 


### PR DESCRIPTION
This PR makes sure to render the entire statement after applying the sort expression via the `QueryEnhancer`.
Previously only parts, the actual statement body, had been considered.

Fixes: #3263 