### PR TITLE
Do not rely on ManagedType by default

### DIFF
--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/domain/sample/Book.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/domain/sample/Book.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2008-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.jpa.domain.sample;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import org.springframework.data.jpa.domain.AbstractPersistable;
+
+/**
+ * @author Yanming Zhou
+ */
+@Entity
+public class Book extends OwnerContainer<Owner> {
+
+	@Id
+	@GeneratedValue
+	private Long id;
+
+	public Long getId() {
+		return id;
+	}
+}

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/domain/sample/Owner.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/domain/sample/Owner.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2008-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.jpa.domain.sample;
+
+import jakarta.persistence.Entity;
+import org.springframework.data.jpa.domain.AbstractPersistable;
+
+/**
+ * @author Yanming Zhou
+ */
+@Entity
+public class Owner extends AbstractPersistable<Long> {
+
+	private String name;
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+}

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/domain/sample/OwnerContainer.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/domain/sample/OwnerContainer.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2008-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.jpa.domain.sample;
+
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.MappedSuperclass;
+
+/**
+ * @author Yanming Zhou
+ */
+@MappedSuperclass
+public class OwnerContainer<T> {
+
+	@ManyToOne
+	T owner;
+
+	public T getOwner() {
+		return owner;
+	}
+
+	public void setOwner(T owner) {
+		this.owner = owner;
+	}
+}

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/generics/EclipseLinkGenericsIntegrationTests.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/generics/EclipseLinkGenericsIntegrationTests.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2014-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.jpa.repository.generics;
+
+import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.jpa.domain.sample.Book;
+import org.springframework.data.jpa.domain.sample.Owner;
+import org.springframework.data.jpa.repository.sample.BookRepository;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Yanming Zhou
+ */
+@Transactional
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration({ "classpath:eclipselink.xml", "classpath:config/namespace-application-context.xml" })
+class EclipseLinkGenericsIntegrationTests extends GenericsIntegrationTests {
+
+}

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/generics/GenericsIntegrationTests.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/generics/GenericsIntegrationTests.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2014-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.jpa.repository.generics;
+
+import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.jpa.domain.AbstractPersistable;
+import org.springframework.data.jpa.domain.sample.Book;
+import org.springframework.data.jpa.domain.sample.CustomAbstractPersistable;
+import org.springframework.data.jpa.domain.sample.Owner;
+import org.springframework.data.jpa.repository.sample.BookRepository;
+import org.springframework.data.jpa.repository.sample.CustomAbstractPersistableRepository;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Yanming Zhou
+ */
+@Transactional
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(locations = { "classpath:config/namespace-autoconfig-context.xml" })
+class GenericsIntegrationTests {
+
+	@Autowired
+	BookRepository repository;
+
+	@Autowired
+	EntityManager entityManager;
+
+	@BeforeEach
+	void setUp() {
+		Owner owner = new Owner();
+		owner.setName("owner");
+		entityManager.persist(owner);
+		Book book = new Book();
+		book.setOwner(owner);
+		entityManager.persist(book);
+	}
+
+	@Test
+	void findAllByGenericAssociationProperty() {
+		assertThat(repository.findAllByOwnerName("owner")).hasSize(1);
+	}
+
+}

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/QueryUtilsIntegrationTests.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/QueryUtilsIntegrationTests.java
@@ -17,6 +17,7 @@ package org.springframework.data.jpa.repository.query;
 
 import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.atLeast;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -34,6 +35,7 @@ import jakarta.persistence.criteria.CriteriaQuery;
 import jakarta.persistence.criteria.From;
 import jakarta.persistence.criteria.Join;
 import jakarta.persistence.criteria.JoinType;
+import jakarta.persistence.criteria.Path;
 import jakarta.persistence.criteria.Root;
 import jakarta.persistence.spi.PersistenceProvider;
 import jakarta.persistence.spi.PersistenceProviderResolver;
@@ -54,6 +56,7 @@ import org.springframework.data.jpa.domain.sample.Category;
 import org.springframework.data.jpa.domain.sample.Invoice;
 import org.springframework.data.jpa.domain.sample.InvoiceItem;
 import org.springframework.data.jpa.domain.sample.Order;
+import org.springframework.data.jpa.domain.sample.Product;
 import org.springframework.data.jpa.domain.sample.User;
 import org.springframework.data.jpa.infrastructure.HibernateTestUtils;
 import org.springframework.data.mapping.PropertyPath;
@@ -69,6 +72,7 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
  * @author Patrice Blanchardie
  * @author Diego Krupitza
  * @author Krzysztof Krason
+ * @author Yanming Zhou
  */
 @ExtendWith(SpringExtension.class)
 @ContextConfiguration("classpath:infrastructure.xml")
@@ -291,12 +295,14 @@ class QueryUtilsIntegrationTests {
 		Root<Category> root = query.from(Category.class);
 
 		Root<Category> mock = Mockito.mock(Root.class);
+		Path<Product> path = Mockito.mock(Path.class);
 		doReturn(root.getModel()).when(mock).getModel();
+		doReturn(path).when(mock).get("product");
 		doReturn(Collections.singleton(root.fetch("product", JoinType.LEFT))).when(mock).getFetches();
 
 		QueryUtils.toExpressionRecursively(mock, PropertyPath.from("product", Category.class));
 
-		verify(mock, times(1)).get("product");
+		verify(mock, atLeast(1)).get("product");
 		verify(mock, times(0)).join(Mockito.eq("product"), Mockito.any(JoinType.class));
 	}
 

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/sample/BookRepository.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/sample/BookRepository.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2014-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.jpa.repository.sample;
+
+import org.springframework.data.jpa.domain.sample.Book;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+/**
+ * @author Yanming Zhou
+ */
+public interface BookRepository extends JpaRepository<Book, Long> {
+
+	List<Book> findAllByOwnerName(String ownerName);
+}

--- a/spring-data-jpa/src/test/resources/META-INF/persistence.xml
+++ b/spring-data-jpa/src/test/resources/META-INF/persistence.xml
@@ -12,6 +12,7 @@
 		<class>org.springframework.data.jpa.domain.sample.AuditableUser</class>
 		<class>org.springframework.data.jpa.domain.sample.AuditableEntity</class>
 		<class>org.springframework.data.jpa.domain.sample.AuditableEmbeddable</class>
+		<class>org.springframework.data.jpa.domain.sample.Book</class>
 		<class>org.springframework.data.jpa.domain.sample.Category</class>
 		<class>org.springframework.data.jpa.domain.sample.Child</class>
 		<class>org.springframework.data.jpa.domain.sample.ConcreteType1</class>
@@ -33,6 +34,7 @@
 		<class>org.springframework.data.jpa.domain.sample.MailSender</class>
 		<class>org.springframework.data.jpa.domain.sample.MailUser</class>
 		<class>org.springframework.data.jpa.domain.sample.Order</class>
+		<class>org.springframework.data.jpa.domain.sample.Owner</class>
 		<class>org.springframework.data.jpa.domain.sample.Parent</class>
 		<class>org.springframework.data.jpa.domain.sample.PersistableWithIdClass</class>
 		<class>org.springframework.data.jpa.domain.sample.PersistableWithSingleIdClass

--- a/spring-data-jpa/src/test/resources/META-INF/persistence2.xml
+++ b/spring-data-jpa/src/test/resources/META-INF/persistence2.xml
@@ -8,6 +8,7 @@
 		<class>org.springframework.data.jpa.domain.sample.AuditableUser</class>
 		<class>org.springframework.data.jpa.domain.sample.AuditableEntity</class>
 		<class>org.springframework.data.jpa.domain.sample.AuditableEmbeddable</class>
+		<class>org.springframework.data.jpa.domain.sample.Book</class>
 		<class>org.springframework.data.jpa.domain.sample.Category</class>
 		<class>org.springframework.data.jpa.domain.sample.CustomAbstractPersistable</class>
 		<class>org.springframework.data.jpa.domain.sample.EntityWithAssignedId</class>
@@ -20,6 +21,7 @@
 		<class>org.springframework.data.jpa.domain.sample.Role</class>
 		<class>org.springframework.data.jpa.domain.sample.Site</class>
 		<class>org.springframework.data.jpa.domain.sample.SpecialUser</class>
+		<class>org.springframework.data.jpa.domain.sample.Owner</class>
 		<class>org.springframework.data.jpa.domain.sample.User</class>
 		<class>org.springframework.data.jpa.domain.sample.Dummy</class>
 		<exclude-unlisted-classes>true</exclude-unlisted-classes>


### PR DESCRIPTION
ManagedType may be erased type if the attribute is declared as generic, take Hibernate 6.x for example, exception is thrown like:
```
java.lang.IllegalArgumentException: Unable to locate Attribute with the given name [name] on this ManagedType [java.lang.Object]
	at org.hibernate.metamodel.model.domain.AbstractManagedType.checkNotNull(AbstractManagedType.java:225) ~[hibernate-core-6.3.1.Final.jar:6.3.1.Final]
	at org.hibernate.metamodel.model.domain.AbstractManagedType.getAttribute(AbstractManagedType.java:148) ~[hibernate-core-6.3.1.Final.jar:6.3.1.Final]
	at org.hibernate.metamodel.model.domain.AbstractManagedType.getAttribute(AbstractManagedType.java:43) ~[hibernate-core-6.3.1.Final.jar:6.3.1.Final]
	at org.springframework.data.jpa.repository.query.QueryUtils.requiresOuterJoin(QueryUtils.java:836) ~[spring-data-jpa-3.2.0.jar:3.2.0]
```

Fix GH-3274