### PR TITLE
Fixes FileSystemException

### DIFF
--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/EclipseLinkMetaAnnotatedQueryMethodIntegrationTests.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/EclipseLinkMetaAnnotatedQueryMethodIntegrationTests.java
@@ -84,7 +84,8 @@ class EclipseLinkMetaAnnotatedQueryMethodIntegrationTests {
 		LOG_FILE = logFile.toAbsolutePath().toString();
 	}
 
-	@AfterAll static void deleteLogFile(){
+	@AfterAll
+	static void deleteLogFile(){
 		logFile.toFile().deleteOnExit();
 	}
 

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/EclipseLinkMetaAnnotatedQueryMethodIntegrationTests.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/EclipseLinkMetaAnnotatedQueryMethodIntegrationTests.java
@@ -31,7 +31,6 @@ import javax.sql.DataSource;
 
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -77,10 +76,16 @@ class EclipseLinkMetaAnnotatedQueryMethodIntegrationTests {
 	private static final ResourceLoader RESOURCE_LOADER = new DefaultResourceLoader();
 	private static String LOG_FILE;
 
+	private static Path logFile;
+
 	@BeforeAll
 	static void createLogfile() throws IOException {
-		Path logFile = Files.createTempFile("test-eclipselink-meta", ".log");
+		logFile = Files.createTempFile("test-eclipselink-meta", ".log");
 		LOG_FILE = logFile.toAbsolutePath().toString();
+	}
+
+	@AfterAll static void deleteLogFile(){
+		logFile.toFile().deleteOnExit();
 	}
 
 	@Test // GH-775

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/EclipseLinkMetaAnnotatedQueryMethodIntegrationTests.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/EclipseLinkMetaAnnotatedQueryMethodIntegrationTests.java
@@ -19,17 +19,18 @@ import static org.assertj.core.api.Assertions.*;
 
 import jakarta.persistence.EntityManagerFactory;
 
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.Reader;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Properties;
 
 import javax.sql.DataSource;
 
 import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -58,12 +59,12 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.FileCopyUtils;
-import org.springframework.util.FileSystemUtils;
 
 /**
  * Verify that {@link Meta}-annotated methods properly embed comments into EclipseLink queries.
  *
  * @author Greg Turnquist
+ * @author Edoardo Patti
  * @since 3.0
  */
 @ExtendWith(SpringExtension.class)
@@ -74,16 +75,12 @@ class EclipseLinkMetaAnnotatedQueryMethodIntegrationTests {
 	@Autowired RoleRepositoryWithMeta repository;
 
 	private static final ResourceLoader RESOURCE_LOADER = new DefaultResourceLoader();
-	private static final String LOG_FILE = "test-eclipselink-meta.log";
+	private static String LOG_FILE;
 
-	@BeforeEach
-	void cleanoutLogfile() throws IOException {
-		new FileOutputStream(LOG_FILE).close();
-	}
-
-	@AfterAll
-	static void deleteLogfile() throws IOException {
-		FileSystemUtils.deleteRecursively(Path.of(LOG_FILE));
+	@BeforeAll
+	static void createLogfile() throws IOException {
+		Path logFile = Files.createTempFile("test-eclipselink-meta", ".log");
+		LOG_FILE = logFile.toAbsolutePath().toString();
 	}
 
 	@Test // GH-775


### PR DESCRIPTION
![image](https://github.com/spring-projects/spring-data-jpa/assets/57438193/e530ac7a-0a18-4e7e-8515-309e5ee90fc2)  

Under Windows operating system, unfortunately, I'm unable to build the JPA project because of a FileSystemException thrown at the act of delete the test-eclipselink-meta.log file in the EclipseLinkMetaAnnotatedQueryMethodIntegrationTests class. The proposal is to use a temporary file whose life cycle can be easily managed by the underlying operating system. Thanks in advance to the JPA team.
