### PR TITLE
Improve AspectJ build

### DIFF
--- a/spring-data-jpa/pom.xml
+++ b/spring-data-jpa/pom.xml
@@ -318,6 +318,39 @@
 			</plugin>
 
 			<plugin>
+				<groupId>org.codehaus.mojo</groupId>
+				<artifactId>build-helper-maven-plugin</artifactId>
+				<executions>
+					<!--
+						To understand what this plugin execution does, please read
+						https://www.mojohaus.org/build-helper-maven-plugin/usage.html#set-a-property-according-to-whether-target-files-are-up-to-date
+					-->
+					<execution>
+						<id>set-antlr4-directory</id>
+						<goals>
+							<goal>uptodate-property</goal>
+						</goals>
+						<!-- Repeat default phase for clarity -->
+						<phase>validate</phase>
+						<configuration>
+							<name>antlr4.dir</name>
+							<value>antlr4-dummy</value>
+							<else>antlr4</else>
+							<fileSet>
+								<directory>${project.basedir}/src/main/antlr4</directory>
+								<outputDirectory>${project.build.directory}/generated-sources/antlr4</outputDirectory>
+								<mapper>
+									<type>glob</type>
+									<from>*.g4</from>
+									<to>*.interp</to>
+								</mapper>
+							</fileSet>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+
+			<plugin>
 				<groupId>org.antlr</groupId>
 				<artifactId>antlr4-maven-plugin</artifactId>
 				<version>${antlr}</version>
@@ -329,6 +362,8 @@
 						<phase>generate-sources</phase>
 						<configuration>
 							<visitor>true</visitor>
+							<!-- Set source dir explicitly, either to default or to dummy value, the latter yielding 0 hits -->
+							<sourceDirectory>${project.basedir}/src/main/${antlr4.dir}</sourceDirectory>
 						</configuration>
 					</execution>
 				</executions>
@@ -336,24 +371,26 @@
 
 			<plugin>
 				<groupId>com.google.code.maven-replacer-plugin</groupId>
-				<artifactId>maven-replacer-plugin</artifactId>
-				<version>1.4.1</version>
+				<artifactId>replacer</artifactId>
+				<version>1.5.3</version>
 				<executions>
 					<execution>
 						<phase>process-sources</phase>
 						<goals>
 							<goal>replace</goal>
 						</goals>
+						<configuration>
+							<basedir>${project.build.directory}/generated-sources</basedir>
+							<includes>
+								<!-- Replace tokens in real or dummy directory, the latter yielding 0 hits -->
+								<include>${antlr4.dir}/**/*.java</include>
+							</includes>
+							<variableTokenValueMap>
+								public class=class,public interface=interface
+							</variableTokenValueMap>
+						</configuration>
 					</execution>
 				</executions>
-				<configuration>
-					<includes>
-						<include>target/generated-sources/antlr4/**/*.java</include>
-					</includes>
-					<variableTokenValueMap>
-						public class=class,public interface=interface
-					</variableTokenValueMap>
-				</configuration>
 			</plugin>
 
 			<plugin>

--- a/spring-data-jpa/pom.xml
+++ b/spring-data-jpa/pom.xml
@@ -357,6 +357,13 @@
 			</plugin>
 
 			<plugin>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<configuration>
+					<proc>only</proc>
+				</configuration>
+			</plugin>
+
+			<plugin>
 				<groupId>org.codehaus.mojo</groupId>
 				<artifactId>aspectj-maven-plugin</artifactId>
 				<version>1.14.0</version>
@@ -369,32 +376,37 @@
 				</dependencies>
 				<executions>
 					<execution>
+						<id>aspectj-compile</id>
 						<goals>
 							<goal>compile</goal>
 						</goals>
 						<phase>process-classes</phase>
+						<configuration>
+						</configuration>
+					</execution>
+					<execution>
+						<id>aspectj-test-compile</id>
+						<goals>
+							<goal>test-compile</goal>
+						</goals>
+						<phase>process-test-classes</phase>
+						<configuration>
+						</configuration>
 					</execution>
 				</executions>
 				<configuration>
+					<!-- Annotation processing is done by Maven Compiler (hard to configure for AJ Maven) -->
+					<proc>none</proc>
+					<!-- Generate metadata for reflection on method parameters -->
+					<parameters>true</parameters>
 					<verbose>true</verbose>
-					<!--
-						To workaround:
-
-						- https://issues.apache.org/jira/browse/MCOMPILER-205
-						- https://issues.apache.org/jira/browse/MCOMPILER-209
-						- https://github.com/mojohaus/aspectj-maven-plugin/issues/15
-
-					-->
-					<forceAjcCompile>true</forceAjcCompile>
+					<showWeaveInfo>true</showWeaveInfo>
 					<aspectLibraries>
 						<aspectLibrary>
 							<groupId>org.springframework</groupId>
 							<artifactId>spring-aspects</artifactId>
 						</aspectLibrary>
 					</aspectLibraries>
-					<includes>
-						<include>**/domain/support/AuditingEntityListener.java</include>
-					</includes>
 					<complianceLevel>${source.level}</complianceLevel>
 					<source>${source.level}</source>
 					<target>${source.level}</target>

--- a/spring-data-jpa/pom.xml
+++ b/spring-data-jpa/pom.xml
@@ -81,9 +81,8 @@
 
 		<dependency>
 			<groupId>org.aspectj</groupId>
-			<artifactId>aspectjweaver</artifactId>
+			<artifactId>aspectjrt</artifactId>
 			<version>${aspectj}</version>
-			<scope>test</scope>
 		</dependency>
 
 		<dependency>
@@ -362,11 +361,6 @@
 				<artifactId>aspectj-maven-plugin</artifactId>
 				<version>1.14.0</version>
 				<dependencies>
-					<dependency>
-						<groupId>org.aspectj</groupId>
-						<artifactId>aspectjrt</artifactId>
-						<version>${aspectj}</version>
-					</dependency>
 					<dependency>
 						<groupId>org.aspectj</groupId>
 						<artifactId>aspectjtools</artifactId>


### PR DESCRIPTION
### Compile-time weaving requires aspectjrt, not aspectjweaver

Aspect-enhanced classes need aspectjrt on the class path. If it is not, the AspectJ Compiler usually complains, either warning or even failing the build, also via AspectJ Maven. The aspectjweaver, however, is for load-time weaving. It is a superset of aspectjrt, but bigger than necessary. Also, the weaver was only test-scoped, but also during normal runtime aspectjrt is necessary. Without it, it can only work by the lucky chance that Spring already depends on aspectjweaver, which is not good dependency management. Each Maven module should be self-consistent.

Aspectjrt was a plugin dependency for AJ Maven, which is also superfluous, because aspectjtools already is a superset of aspectjweaver, i.e. it also contains aspectjrt. Hence, aspectjtools is all AJ Maven needs, but the compiled application is who really needs aspectjrt.

### Get rid of 'forceAjcCompile' workaround and special includes

by separation of concerns: Let
  - Maven Compiler do annotation processing without compilation and
  - AspectJ Maven compilation of all Java sources and aspects without annotation processing.

Actually, we could let AJ Maven do all the work, but it would be difficult to configure everything correctly in JDK 9+, because AJ Maven is incomplete regarding automatically putting everything on the right module paths. so, this separation of concerns saves tedious configuration work.

Relates to https://github.com/mojohaus/aspectj-maven-plugin/issues/15.

@odrotbohm, feel free to accept the PR if it helps you straighten out the situation.