### PR TITLE
Refine AspectJ plugin build phase config

### DIFF
--- a/spring-data-jpa/pom.xml
+++ b/spring-data-jpa/pom.xml
@@ -360,8 +360,7 @@
 			<!--
 				Attention: aspectj-maven-plugin MUST be declared AFTER maven-compiler-plugin, if they are both supposed to run
 				in the same default phases 'compile' and 'test-compile', but execution order is to be guaranteed. Then, you have
-				the convenience of being able to run e.g. 'mvn [clean] compile' instead of 'mvn [clean] process-classes'. For a
-				slightly less convenient, but less refactoring-error-prone solution, see the commented-out phases below.
+				the convenience of being able to run e.g. 'mvn [clean] compile' instead of 'mvn [clean] process-classes'.
 			-->
 			<plugin>
 				<groupId>org.codehaus.mojo</groupId>
@@ -380,14 +379,12 @@
 						<goals>
 							<goal>compile</goal>
 						</goals>
-						<!--<phase>process-classes</phase>-->
 					</execution>
 					<execution>
 						<id>aspectj-test-compile</id>
 						<goals>
 							<goal>test-compile</goal>
 						</goals>
-						<!--<phase>process-test-classes</phase>-->
 					</execution>
 				</executions>
 				<configuration>

--- a/spring-data-jpa/pom.xml
+++ b/spring-data-jpa/pom.xml
@@ -357,6 +357,12 @@
 				</configuration>
 			</plugin>
 
+			<!--
+				Attention: aspectj-maven-plugin MUST be declared AFTER maven-compiler-plugin, if they are both supposed to run
+				in the same default phases 'compile' and 'test-compile', but execution order is to be guaranteed. Then, you have
+				the convenience of being able to run e.g. 'mvn [clean] compile' instead of 'mvn [clean] process-classes'. For a
+				slightly less convenient, but less refactoring-error-prone solution, see the commented-out phases below.
+			-->
 			<plugin>
 				<groupId>org.codehaus.mojo</groupId>
 				<artifactId>aspectj-maven-plugin</artifactId>
@@ -374,14 +380,14 @@
 						<goals>
 							<goal>compile</goal>
 						</goals>
-						<phase>process-classes</phase>
+						<!--<phase>process-classes</phase>-->
 					</execution>
 					<execution>
 						<id>aspectj-test-compile</id>
 						<goals>
 							<goal>test-compile</goal>
 						</goals>
-						<phase>process-test-classes</phase>
+						<!--<phase>process-test-classes</phase>-->
 					</execution>
 				</executions>
 				<configuration>


### PR DESCRIPTION
This is a follow-up on #3282, where a reviewer's misunderstanding (running test builds with wrong Maven phases) led to parts of the PR getting falsely erased. This PR ~~not only reinstates those erased parts, but also~~ enables developers who do not know the build configuration well enough to know that they should run `mvn process-classes` rather than `mvn compile` to now use the latter. This new convenience feature is not a fix or change of the previous PR, but changes a build phase which has been there long before the PR.

@mp911de, @odrotbohm