### PR TITLE
Rename iteration variable name in PersistenceProviderUnitTests for readability

### DIFF
--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/provider/PersistenceProviderUnitTests.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/provider/PersistenceProviderUnitTests.java
@@ -152,8 +152,8 @@ class PersistenceProviderUnitTests {
 		private static String[] toResourcePaths(Class<?>... interfacesToImplement) {
 
 			List<String> interfaceResourcePaths = new ArrayList<>(interfacesToImplement.length);
-			for (Class<?> iface : interfacesToImplement) {
-				interfaceResourcePaths.add(ClassUtils.convertClassNameToResourcePath(iface.getName()));
+			for (Class<?> targetInterface : interfacesToImplement) {
+				interfaceResourcePaths.add(ClassUtils.convertClassNameToResourcePath(targetInterface.getName()));
 			}
 
 			return interfaceResourcePaths.toArray(new String[0]);


### PR DESCRIPTION
Rename iteration variable name in `PersistenceProviderUnitTests` for readability

<!--

Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
Make sure that:

-->

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [ ] You submit test cases (unit or integration tests) that back your changes.
- [ ] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).

In `PersistenceProviderUnitTests` `toResourcePaths` method, use `iface` in `interfacesToImplement`.

but in my opinion, `targetInterface` is better than `iface` for readability. (`iface` not means direct this variable is a unit of `interfacesToImplement`.)

In my guess, `interface` word is already used in java default words. (type name) so written in `iface`.

could you consider this suggestion?

(The two check boxes at the bottom do not seem to correspond to simple word changes, so I did not check them.)