### PR TITLE
Fix small typo in application-context.xml, QueryUtils.java

### DIFF
--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/QueryUtils.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/QueryUtils.java
@@ -623,7 +623,7 @@ public abstract class QueryUtils {
 			} else {
 
 				String alias = QueryUtils.detectAlias(originalQuery);
-				if (("*".equals(variable) && alias != null)) {
+				if ("*".equals(variable) && alias != null) {
 					replacement = alias;
 				}
 			}

--- a/spring-data-jpa/src/test/resources/application-context.xml
+++ b/spring-data-jpa/src/test/resources/application-context.xml
@@ -36,7 +36,7 @@
 	<!-- Necessary to get the entity manager injected into the factory bean -->
 	<bean class="org.springframework.orm.jpa.support.PersistenceAnnotationBeanPostProcessor" />
 
-	<!-- Adds transaparent exception translation to the DAOs -->
+	<!-- Adds transparent exception translation to the DAOs -->
 	<bean class="org.springframework.dao.annotation.PersistenceExceptionTranslationPostProcessor" />
 
 	<bean id="expressionEvaluationContextProvider" class="org.springframework.data.repository.query.ExtensionAwareQueryMethodEvaluationContextProvider" autowire="constructor" />


### PR DESCRIPTION
<!--

Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
Make sure that:

-->

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [ ] You submit test cases (unit or integration tests) that back your changes.
- [ ] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).

I fixed "transaparent" to "transparent" in `spring-data-jpa/src/test/resources/application-context.xml`

and I removed redundant small bracket in `spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/QueryUtils.java`