### PR TITLE
Create dedicated `ParameterBindings` for count query

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-jpa-parent</artifactId>
-	<version>3.3.0-SNAPSHOT</version>
+	<version>3.3.x-3293-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data JPA Parent</name>

--- a/spring-data-envers/pom.xml
+++ b/spring-data-envers/pom.xml
@@ -5,12 +5,12 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-envers</artifactId>
-	<version>3.3.0-SNAPSHOT</version>
+	<version>3.3.x-3293-SNAPSHOT</version>
 
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-jpa-parent</artifactId>
-		<version>3.3.0-SNAPSHOT</version>
+		<version>3.3.x-3293-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-jpa-distribution/pom.xml
+++ b/spring-data-jpa-distribution/pom.xml
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-jpa-parent</artifactId>
-		<version>3.3.0-SNAPSHOT</version>
+		<version>3.3.x-3293-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-jpa/pom.xml
+++ b/spring-data-jpa/pom.xml
@@ -6,7 +6,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-jpa</artifactId>
-	<version>3.3.0-SNAPSHOT</version>
+	<version>3.3.x-3293-SNAPSHOT</version>
 
 	<name>Spring Data JPA</name>
 	<description>Spring Data module for JPA repositories.</description>
@@ -15,7 +15,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-jpa-parent</artifactId>
-		<version>3.3.0-SNAPSHOT</version>
+		<version>3.3.x-3293-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/StringQuery.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/StringQuery.java
@@ -59,7 +59,7 @@ import org.springframework.util.StringUtils;
 class StringQuery implements DeclaredQuery {
 
 	private final String query;
-	private List<ParameterBinding> bindings;
+	private final List<ParameterBinding> bindings;
 	private final @Nullable String alias;
 	private final boolean hasConstructorExpression;
 	private final boolean containsPageableInSpel;
@@ -115,10 +115,13 @@ class StringQuery implements DeclaredQuery {
 			return new StringQuery(countQuery, this.isNative);
 		}
 
-		// TODO: find better way of passing on bindings
 		StringQuery stringQuery = new StringQuery(this.queryEnhancer.createCountQueryFor(countQueryProjection), //
 				this.isNative);
-		stringQuery.bindings = this.bindings; // carry over bindings
+
+		if(this.hasParameterBindings() && !this.getParameterBindings().equals(stringQuery.getParameterBindings())) {
+			stringQuery.getParameterBindings().clear();
+			stringQuery.getParameterBindings().addAll(this.bindings);
+		}
 
 		return stringQuery;
 	}

--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/StringQuery.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/StringQuery.java
@@ -59,7 +59,7 @@ import org.springframework.util.StringUtils;
 class StringQuery implements DeclaredQuery {
 
 	private final String query;
-	private final List<ParameterBinding> bindings;
+	private List<ParameterBinding> bindings;
 	private final @Nullable String alias;
 	private final boolean hasConstructorExpression;
 	private final boolean containsPageableInSpel;
@@ -111,9 +111,16 @@ class StringQuery implements DeclaredQuery {
 	@Override
 	public DeclaredQuery deriveCountQuery(@Nullable String countQuery, @Nullable String countQueryProjection) {
 
-		return DeclaredQuery.of( //
-				countQuery != null ? countQuery : this.queryEnhancer.createCountQueryFor(countQueryProjection), //
+		if(StringUtils.hasText(countQuery)) {
+			return new StringQuery(countQuery, this.isNative);
+		}
+
+		// TODO: find better way of passing on bindings
+		StringQuery stringQuery = new StringQuery(this.queryEnhancer.createCountQueryFor(countQueryProjection), //
 				this.isNative);
+		stringQuery.bindings = this.bindings; // carry over bindings
+
+		return stringQuery;
 	}
 
 	@Override

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/UserRepositoryTests.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/UserRepositoryTests.java
@@ -41,6 +41,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
 import org.assertj.core.api.SoftAssertions;
@@ -1741,6 +1742,25 @@ class UserRepositoryTests {
 		List<User> users = repository.findByFirstnameAndLastnameWithSpelExpression("Oliver", "ierk");
 
 		assertThat(users).containsOnly(firstUser);
+	}
+
+	@Test // GH-2393
+	void bindsSpELParameterOnlyUsedInCountQuery() {
+
+		flushTestUsers(); // add some noise
+
+		IntStream.range(0, 10).mapToObj(counter -> {
+			User source = new User();
+			source.setFirstname("%d-Spring".formatted(counter));
+			source.setLastname("Data");
+			source.setEmailAddress("spring-%s@data.org".formatted(counter));
+			return source;
+		}).forEach(repository::save);
+		em.flush();
+
+		Page<User> users = repository.findByWithSpelParameterOnlyUsedForCountQuery("Data", PageRequest.of(0, 2));
+		assertThat(users.getSize()).isEqualTo(2);
+		assertThat(users.getTotalElements()).isEqualTo(10);
 	}
 
 	@Test // DATAJPA-564

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/SimpleJpaQueryUnitTests.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/SimpleJpaQueryUnitTests.java
@@ -28,10 +28,12 @@ import jakarta.persistence.metamodel.Metamodel;
 import java.lang.reflect.Method;
 import java.util.Collection;
 import java.util.List;
+import java.util.Optional;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -53,6 +55,7 @@ import org.springframework.data.repository.query.QueryMethodEvaluationContextPro
 import org.springframework.data.repository.query.RepositoryQuery;
 import org.springframework.data.util.TypeInformation;
 import org.springframework.expression.spel.standard.SpelExpressionParser;
+import org.springframework.lang.Nullable;
 
 /**
  * Unit test for {@link SimpleJpaQuery}.
@@ -65,6 +68,7 @@ import org.springframework.expression.spel.standard.SpelExpressionParser;
  * @author Greg Turnquist
  * @author Krzysztof Krason
  * @author Erik Pellizzon
+ * @author Christoph Strobl
  */
 @ExtendWith(MockitoExtension.class)
 @MockitoSettings(strictness = Strictness.LENIENT)
@@ -217,6 +221,23 @@ class SimpleJpaQueryUnitTests {
 		verify(em).createNativeQuery(anyString());
 	}
 
+	@Test // GH-3293
+	void allowsCountQueryUsingParametersNotInOriginalQuery() throws Exception {
+
+		when(em.createNativeQuery(anyString())).thenReturn(query);
+
+		AbstractJpaQuery jpaQuery = createJpaQuery(
+				SampleRepository.class.getMethod("findAllWithBindingsOnlyInCountQuery", String.class, Pageable.class), Optional.empty());
+
+		jpaQuery.doCreateCountQuery(new JpaParametersParameterAccessor(jpaQuery.getQueryMethod().getParameters(),
+				new Object[]{"data", PageRequest.of(0, 10)}));
+
+		ArgumentCaptor<String> queryStringCaptor = ArgumentCaptor.forClass(String.class);
+		verify(em).createQuery(queryStringCaptor.capture(), eq(Long.class));
+
+		assertThat(queryStringCaptor.getValue()).startsWith("select count(u.id) from User u where u.name =");
+	}
+
 	@Test // DATAJPA-885
 	void projectsWithManuallyDeclaredQuery() throws Exception {
 
@@ -260,10 +281,19 @@ class SimpleJpaQueryUnitTests {
 	}
 
 	private AbstractJpaQuery createJpaQuery(Method method) {
+		return createJpaQuery(method, null);
+	}
+
+	private AbstractJpaQuery createJpaQuery(JpaQueryMethod queryMethod, @Nullable String queryString, @Nullable String countQueryString) {
+
+		return JpaQueryFactory.INSTANCE.fromMethodWithQueryString(queryMethod, em, queryString, countQueryString,
+				QueryRewriter.IdentityQueryRewriter.INSTANCE, EVALUATION_CONTEXT_PROVIDER);
+	}
+
+	private AbstractJpaQuery createJpaQuery(Method method, @Nullable Optional<String> countQueryString) {
 
 		JpaQueryMethod queryMethod = new JpaQueryMethod(method, metadata, factory, extractor);
-		return JpaQueryFactory.INSTANCE.fromMethodWithQueryString(queryMethod, em, queryMethod.getAnnotatedQuery(), null,
-				QueryRewriter.IdentityQueryRewriter.INSTANCE, EVALUATION_CONTEXT_PROVIDER);
+		return createJpaQuery(queryMethod, queryMethod.getAnnotatedQuery(), countQueryString == null ? null : countQueryString.orElse(queryMethod.getCountQuery()));
 	}
 
 	interface SampleRepository {
@@ -294,6 +324,10 @@ class SimpleJpaQueryUnitTests {
 
 		@Query(value = "select u from #{#entityName} u", countQuery = "select count(u.id) from #{#entityName} u")
 		List<User> findAllWithExpressionInCountQuery(Pageable pageable);
+
+
+		@Query(value = "select u from User u", countQuery = "select count(u.id) from #{#entityName} u where u.name = :#{#arg0}")
+		List<User> findAllWithBindingsOnlyInCountQuery(String arg0, Pageable pageable);
 
 	}
 

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/sample/UserRepository.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/sample/UserRepository.java
@@ -449,6 +449,9 @@ public interface UserRepository extends JpaRepository<User, Integer>, JpaSpecifi
 	@Query("select u from User u where u.firstname = ?#{[0]} and u.firstname = ?1 and u.lastname like %?#{[1]}% and u.lastname like %?2%")
 	List<User> findByFirstnameAndLastnameWithSpelExpression(String firstname, String lastname);
 
+	@Query(value = "select * from SD_User", countQuery = "select count(1) from SD_User u where u.lastname = :#{#lastname}", nativeQuery = true)
+	Page<User> findByWithSpelParameterOnlyUsedForCountQuery(String lastname, Pageable page);
+
 	// DATAJPA-564
 	@Query("select u from User u where u.lastname like %:#{[0]}% and u.lastname like %:lastname%")
 	List<User> findByLastnameWithSpelExpression(@Param("lastname") String lastname);


### PR DESCRIPTION
This PR makes sure we create individual parameter bindings for the count query instead of reusing the bindings from the actual query. This ensures we do not miss bindings that are only present in the count query.