### PR TITLE
Remove unused typo.

### DIFF
--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/NativeJpaQuery.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/NativeJpaQuery.java
@@ -83,7 +83,7 @@ final class NativeJpaQuery extends AbstractStringBasedJpaQuery {
 			return result;
 		}
 
-		return returnedType.isProjecting() && !getMetamodel().isJpaManaged(returnedType.getReturnedType()) //
+		return returnedType.isProjecting() && !getMetamodel().isJpaManaged(returnedType.getReturnedType()) 
 				? Tuple.class
 				: result;
 	}


### PR DESCRIPTION
 See: #3366

This PR deletes an unused comment in the codebase that contains a minor typo. The comment is not utilized, and its removal improves code cleanliness and readability.
