### PR TITLE
Code Simplification: Removed unnecessary else clause in if statement

### DIFF
--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/AbstractJpaQuery.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/AbstractJpaQuery.java
@@ -171,9 +171,8 @@ public abstract class AbstractJpaQuery implements RepositoryQuery {
 
 		if (method.isModifyingQuery()) {
 			return new ModifyingExecution(method, em);
-		} else {
-			return new SingleEntityExecution();
 		}
+		return new SingleEntityExecution();
 	}
 
 	/**


### PR DESCRIPTION
Hello! This PR aims to simplify the code by removing the unnecessary else clause in the if statement. Previously, the code had an if-else structure where it returned different objects based on the condition method.isModifyingQuery(). However, since the return statement is already present within the if block, the else clause can be safely removed without affecting the logic. The modified code is more concise and easier to read. Your review and feedback on the changes would be greatly appreciated. Thank you!

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [ ] You submit test cases (unit or integration tests) that back your changes.
- [ ] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
