### PR TITLE
Replace links to the Java EE JPA Spec with ones to the Jakarta Persistence Spec

### DIFF
--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/EntityGraph.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/EntityGraph.java
@@ -34,6 +34,7 @@ import org.springframework.data.jpa.repository.query.JpaQueryMethod;
  * @author Christoph Strobl
  * @author Thomas Darimont
  * @author Oerd Cukalla
+ * @author Aleksei Elin
  * @since 1.6
  */
 @Retention(RetentionPolicy.RUNTIME)
@@ -78,8 +79,8 @@ public @interface EntityGraph {
 		 * by attribute nodes of the entity graph are treated as FetchType.EAGER and attributes that are not specified are
 		 * treated according to their specified or default FetchType.
 		 *
-		 * @see <a href="https://download.oracle.com/otn-pub/jcp/persistence-2_1-fr-eval-spec/JavaPersistence.pdf">JPA 2.1
-		 *      Specification: 3.7.4.2 Load Graph Semantics</a>
+		 * @see <a href="https://jakarta.ee/specifications/persistence/3.1/jakarta-persistence-spec-3.1#load-graph-semantics">Jakarta
+		 *      Persistence Specification: Load Graph Semantics</a>
 		 */
 		LOAD("jakarta.persistence.loadgraph"),
 
@@ -88,8 +89,8 @@ public @interface EntityGraph {
 		 * by attribute nodes of the entity graph are treated as FetchType.EAGER and attributes that are not specified are
 		 * treated as FetchType.LAZY
 		 *
-		 * @see <a href="https://download.oracle.com/otn-pub/jcp/persistence-2_1-fr-eval-spec/JavaPersistence.pdf">JPA 2.1
-		 *      Specification: 3.7.4.1 Fetch Graph Semantics</a>
+		 * @see <a href="https://jakarta.ee/specifications/persistence/3.1/jakarta-persistence-spec-3.1#fetch-graph-semantics">Jakarta
+		 *      Persistence Specification: Fetch Graph Semantics</a>
 		 */
 		FETCH("jakarta.persistence.fetchgraph");
 

--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/Jpa21Utils.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/Jpa21Utils.java
@@ -43,6 +43,7 @@ import org.springframework.util.StringUtils;
  * @author Christoph Strobl
  * @author Mark Paluch
  * @author Jens Schauder
+ * @author Aleksei Elin
  * @since 1.6
  */
 public class Jpa21Utils {
@@ -86,8 +87,8 @@ public class Jpa21Utils {
 	/**
 	 * Adds a JPA 2.1 fetch-graph or load-graph hint to the given {@link Query} if running under JPA 2.1.
 	 *
-	 * @see <a href="download.oracle.com/otn-pub/jcp/persistence-2_1-fr-eval-spec/JavaPersistence.pdf">JPA 2.1
-	 *      Specfication 3.7.4 - Use of Entity Graphs in find and query operations P.117</a>
+	 * @see <a href="https://jakarta.ee/specifications/persistence/3.1/jakarta-persistence-spec-3.1#a2814">Jakarta
+	 *      Persistence Specfication - Use of Entity Graphs in find and query operations</a>
 	 * @param em must not be {@literal null}.
 	 * @param jpaEntityGraph must not be {@literal null}.
 	 * @param entityType must not be {@literal null}.

--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/JpaQueryMethod.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/JpaQueryMethod.java
@@ -63,13 +63,15 @@ import org.springframework.util.StringUtils;
  * @author Сергей Цыпанов
  * @author Réda Housni Alaoui
  * @author Greg Turnquist
+ * @author Aleksei Elin
  */
 public class JpaQueryMethod extends QueryMethod {
 
 	/**
 	 * @see <a href=
-	 *      "https://download.oracle.com/otn-pub/jcp/persistence-2.0-fr-eval-oth-JSpec/persistence-2_0-final-spec.pdf">JPA
-	 *      2.0 Specification 2.2 Persistent Fields and Properties Page 23 - Top paragraph.</a>
+	 *      "https://jakarta.ee/specifications/persistence/3.1/jakarta-persistence-spec-3.1#persistent-fields-and-properties">Jakarta
+	 *      Persistence Specification: Persistent Fields and Properties - Paragraph
+	 *      starting with "Collection-valued persistent...".</a>
 	 */
 	private static final Set<Class<?>> NATIVE_ARRAY_TYPES;
 	private static final StoredProcedureAttributeSource storedProcedureAttributeSource = StoredProcedureAttributeSource.INSTANCE;

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/domain/sample/Item.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/domain/sample/Item.java
@@ -26,8 +26,9 @@ import java.util.Objects;
 
 /**
  * @author Mark Paluch
- * @see <a href="download.oracle.com/otn-pub/jcp/persistence-2_1-fr-eval-spec/JavaPersistence.pdf">Final JPA 2.1
- *      Specification 2.4.1.3 Derived Identities Example 2</a>
+ * @author Aleksei Elin
+ * @see <a href="https://jakarta.ee/specifications/persistence/3.1/jakarta-persistence-spec-3.1#examples-of-derived-identities">Jakarta Persistence
+ *      Specification: Derived Identities, Example 2</a>
  */
 @Entity
 @Table

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/domain/sample/ItemId.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/domain/sample/ItemId.java
@@ -19,8 +19,9 @@ import java.io.Serializable;
 
 /**
  * @author Mark Paluch
- * @see <a href="download.oracle.com/otn-pub/jcp/persistence-2_1-fr-eval-spec/JavaPersistence.pdf">Final JPA 2.1
- *      Specification 2.4.1.3 Derived Identities Example 2</a>
+ * @author Aleksei Elin
+ * @see <a href="https://jakarta.ee/specifications/persistence/3.1/jakarta-persistence-spec-3.1#examples-of-derived-identities">Jakarta
+ *      Persistence Specification: Derived Identities, Example 2</a>
  */
 public class ItemId implements Serializable {
 

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/domain/sample/ItemSite.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/domain/sample/ItemSite.java
@@ -23,8 +23,9 @@ import jakarta.persistence.Table;
 
 /**
  * @author Mark Paluch
- * @see <a href="download.oracle.com/otn-pub/jcp/persistence-2_1-fr-eval-spec/JavaPersistence.pdf">Final JPA 2.1
- *      Specification 2.4.1.3 Derived Identities Example 2</a>
+ * @author Aleksei Elin
+ * @see <a href="https://jakarta.ee/specifications/persistence/3.1/jakarta-persistence-spec-3.1#examples-of-derived-identities">Jakarta
+ *      Persistence Specification: Derived Identities, Example 2</a>
  */
 @Entity
 @Table

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/domain/sample/ItemSiteId.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/domain/sample/ItemSiteId.java
@@ -19,8 +19,9 @@ import java.io.Serializable;
 
 /**
  * @author Mark Paluch
- * @see <a href="download.oracle.com/otn-pub/jcp/persistence-2_1-fr-eval-spec/JavaPersistence.pdf">Final JPA 2.1
- *      Specification 2.4.1.3 Derived Identities Example 2</a>
+ * @author Aleksei Elin
+ * @see <a href="https://jakarta.ee/specifications/persistence/3.1/jakarta-persistence-spec-3.1#examples-of-derived-identities">Jakarta
+ *      Persistence Specification: Derived Identities, Example 2</a>
  */
 public class ItemSiteId implements Serializable {
 

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/domain/sample/Site.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/domain/sample/Site.java
@@ -23,8 +23,9 @@ import jakarta.persistence.Table;
 /**
  * @author Mark Paluch
  * @author Oliver Gierke
- * @see <a href="download.oracle.com/otn-pub/jcp/persistence-2_1-fr-eval-spec/JavaPersistence.pdf">Final JPA 2.1
- *      Specification 2.4.1.3 Derived Identities Example 2</a>
+ * @author Aleksei Elin
+ * @see <a href="https://jakarta.ee/specifications/persistence/3.1/jakarta-persistence-spec-3.1#examples-of-derived-identities">Jakarta
+ *      Persistence Specification: Derived Identities, Example 2</a>
  */
 @Entity
 @Table

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/RepositoryWithCompositeKeyTests.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/RepositoryWithCompositeKeyTests.java
@@ -51,6 +51,7 @@ import org.springframework.transaction.annotation.Transactional;
  * @author Jens Schauder
  * @author Ernst-Jan van der Laan
  * @author Krzysztof Krason
+ * @author Aleksei Elin
  */
 @ExtendWith(SpringExtension.class)
 @ContextConfiguration(classes = SampleConfig.class)
@@ -62,8 +63,8 @@ class RepositoryWithCompositeKeyTests {
 	@Autowired EntityManager em;
 
 	/**
-	 * @see <a href="download.oracle.com/otn-pub/jcp/persistence-2_1-fr-eval-spec/JavaPersistence.pdf">Final JPA 2.0
-	 *      Specification 2.4.1.3 Derived Identities Example 2</a>
+	 * @see <a href="https://jakarta.ee/specifications/persistence/3.1/jakarta-persistence-spec-3.1#examples-of-derived-identities">Jakarta
+	 *      Persistence Specification: Derived Identities, Example 2</a>
 	 */
 	@Test // DATAJPA-269
 	void shouldSupportSavingEntitiesWithCompositeKeyClassesWithIdClassAndDerivedIdentities() {
@@ -88,8 +89,8 @@ class RepositoryWithCompositeKeyTests {
 	}
 
 	/**
-	 * @see <a href="download.oracle.com/otn-pub/jcp/persistence-2_1-fr-eval-spec/JavaPersistence.pdf">Final JPA 2.0
-	 *      Specification 2.4.1.3 Derived Identities Example 3</a>
+	 * @see <a href="https://jakarta.ee/specifications/persistence/3.1/jakarta-persistence-spec-3.1#examples-of-derived-identities">Jakarta
+	 *      Persistence Specification: Derived Identities, Example 3</a>
 	 */
 	@Test // DATAJPA-269
 	void shouldSupportSavingEntitiesWithCompositeKeyClassesWithEmbeddedIdsAndDerivedIdentities() {

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/RepositoryWithIdClassKeyTests.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/RepositoryWithIdClassKeyTests.java
@@ -48,6 +48,7 @@ import org.springframework.transaction.annotation.Transactional;
  * @author Mark Paluch
  * @author Jens Schauder
  * @author Krzysztof Krason
+ * @author Aleksei Elin
  */
 @ExtendWith(SpringExtension.class)
 @ContextConfiguration(classes = RepositoryWithIdClassKeyTests.TestConfig.class)
@@ -61,8 +62,8 @@ class RepositoryWithIdClassKeyTests {
 	@Autowired private ItemSiteRepository itemSiteRepository;
 
 	/**
-	 * @see <a href="download.oracle.com/otn-pub/jcp/persistence-2_1-fr-eval-spec/JavaPersistence.pdf">Final JPA 2.1
-	 *      Specification 2.4.1.3 Derived Identities Example 2</a>
+	 * @see <a href="https://jakarta.ee/specifications/persistence/3.1/jakarta-persistence-spec-3.1#examples-of-derived-identities">Jakarta
+	 *      Persistence Specification: 2.4.1.3 Derived Identities Example 2</a>
 	 */
 	@Test // DATAJPA-413
 	void shouldSaveAndLoadEntitiesWithDerivedIdentities() {

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/StringQueryUnitTests.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/StringQueryUnitTests.java
@@ -40,6 +40,7 @@ import org.springframework.data.repository.query.parser.Part.Type;
  * @author Andriy Redko
  * @author Diego Krupitza
  * @author Mark Paluch
+ * @author Aleksei Elin
  */
 class StringQueryUnitTests {
 
@@ -456,8 +457,8 @@ class StringQueryUnitTests {
 	}
 
 	/**
-	 * @see <a href="download.oracle.com/otn-pub/jcp/persistence-2_1-fr-eval-spec/JavaPersistence.pdf">JPA 2.1
-	 *      specification, section 4.8</a>
+	 * @see <a href="https://jakarta.ee/specifications/persistence/3.1/jakarta-persistence-spec-3.1#a5438">Jakarta
+	 *      Persistence Specification: SELECT clause</a>
 	 */
 	@Test // DATAJPA-886
 	void detectsConstructorExpressionForDefaultConstructor() {

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/sample/ItemRepository.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/sample/ItemRepository.java
@@ -22,7 +22,8 @@ import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 
 /**
  * @author Mark Paluch
- * @see <a href="download.oracle.com/otn-pub/jcp/persistence-2_1-fr-eval-spec/JavaPersistence.pdf">Final JPA 2.1
- *      Specification 2.4.1.3 Derived Identities Example 2</a>
+ * @author Aleksei Elin
+ * @see <a href="https://jakarta.ee/specifications/persistence/3.1/jakarta-persistence-spec-3.1#examples-of-derived-identities">Jakarta
+ *      Persistence Specification: Derived Identities, Example 2</a>
  */
 public interface ItemRepository extends JpaRepository<Item, ItemId>, JpaSpecificationExecutor<Item> {}

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/sample/ItemSiteRepository.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/sample/ItemSiteRepository.java
@@ -21,7 +21,8 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 /**
  * @author Mark Paluch
- * @see <a href="download.oracle.com/otn-pub/jcp/persistence-2_1-fr-eval-spec/JavaPersistence.pdf">Final JPA 2.1
- *      Specification 2.4.1.3 Derived Identities Example 2</a>
+ * @author Aleksei Elin
+ * @see <a href="https://jakarta.ee/specifications/persistence/3.1/jakarta-persistence-spec-3.1#a5438">Jakarta
+ *      Persistence Specification: Derived Identities, Example 2</a>
  */
 public interface ItemSiteRepository extends JpaRepository<ItemSite, ItemSiteId> {}

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/sample/SiteRepository.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/sample/SiteRepository.java
@@ -20,7 +20,8 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 /**
  * @author Mark Paluch
- * @see <a href="download.oracle.com/otn-pub/jcp/persistence-2_1-fr-eval-spec/JavaPersistence.pdf">Final JPA 2.1
- *      Specification 2.4.1.3 Derived Identities Example 2</a>
+ * @author Aleksei Elin
+ * @see <a href="https://jakarta.ee/specifications/persistence/3.1/jakarta-persistence-spec-3.1#examples-of-derived-identities">Jakarta
+ *      Persistence Specification: Derived Identities, Example 2</a>
  */
 public interface SiteRepository extends JpaRepository<Site, Integer> {}


### PR DESCRIPTION

Replace links to the Java EE JPA Spec with ones to the Jakarta Persistence Spec.

Now the spec is released as Jakarta, not Java EE. That's why I've updated the links.