### PR TITLE
Code Simplification: Removed unnecessary else clause in if statement in AbstractJpaQuery, EqlQueryRenderer, JpaEntityInformationSupport

### DIFF
--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/AbstractJpaQuery.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/AbstractJpaQuery.java
@@ -102,9 +102,8 @@ public abstract class AbstractJpaQuery implements RepositoryQuery {
 				return new PagedExecution();
 			} else if (method.isModifyingQuery()) {
 				return null;
-			} else {
-				return new SingleEntityExecution();
 			}
+			return new SingleEntityExecution();
 		});
 	}
 

--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/EqlQueryRenderer.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/EqlQueryRenderer.java
@@ -44,9 +44,8 @@ class EqlQueryRenderer extends EqlBaseVisitor<List<JpaQueryParsingToken>> {
 			return visit(ctx.update_statement());
 		} else if (ctx.delete_statement() != null) {
 			return visit(ctx.delete_statement());
-		} else {
-			return List.of();
 		}
+		return List.of();
 	}
 
 	@Override

--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/support/JpaEntityInformationSupport.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/support/JpaEntityInformationSupport.java
@@ -65,9 +65,8 @@ public abstract class JpaEntityInformationSupport<T, ID> extends AbstractEntityI
 
 		if (Persistable.class.isAssignableFrom(domainClass)) {
 			return new JpaPersistableEntityInformation(domainClass, metamodel, persistenceUnitUtil);
-		} else {
-			return new JpaMetamodelEntityInformation(domainClass, metamodel, persistenceUnitUtil);
 		}
+		return new JpaMetamodelEntityInformation(domainClass, metamodel, persistenceUnitUtil);
 	}
 
 	@Override


### PR DESCRIPTION
Hello! This PR aims to simplify the code by removing the unnecessary else clause in the if statement. While I was looking through `AbstractJpaQuery`, `EqlQueryRender`, and `JpaEntityInformationSupport`, I discovered an unnecessary `else` syntax and suggested pr similar to before. I think the `else` clauses can be safely removed without affecting the logic. Your review and feedback on the changes would be greatly appreciated. Thank you!

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [ ] You submit test cases (unit or integration tests) that back your changes.
- [ ] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
