### PR TITLE
Fix order by rendering for queries containing UNION 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-jpa-parent</artifactId>
-	<version>3.4.0-SNAPSHOT</version>
+	<version>3.4.x-3427-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data JPA Parent</name>

--- a/spring-data-envers/pom.xml
+++ b/spring-data-envers/pom.xml
@@ -5,12 +5,12 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-envers</artifactId>
-	<version>3.4.0-SNAPSHOT</version>
+	<version>3.4.x-3427-SNAPSHOT</version>
 
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-jpa-parent</artifactId>
-		<version>3.4.0-SNAPSHOT</version>
+		<version>3.4.x-3427-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-jpa-distribution/pom.xml
+++ b/spring-data-jpa-distribution/pom.xml
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-jpa-parent</artifactId>
-		<version>3.4.0-SNAPSHOT</version>
+		<version>3.4.x-3427-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-jpa/pom.xml
+++ b/spring-data-jpa/pom.xml
@@ -6,7 +6,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-jpa</artifactId>
-	<version>3.4.0-SNAPSHOT</version>
+	<version>3.4.x-3427-SNAPSHOT</version>
 
 	<name>Spring Data JPA</name>
 	<description>Spring Data module for JPA repositories.</description>
@@ -15,7 +15,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-jpa-parent</artifactId>
-		<version>3.4.0-SNAPSHOT</version>
+		<version>3.4.x-3427-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/EqlSortedQueryTransformer.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/EqlSortedQueryTransformer.java
@@ -23,6 +23,7 @@ import org.springframework.data.domain.Sort;
 import org.springframework.data.jpa.repository.query.QueryRenderer.QueryRendererBuilder;
 import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
+import org.springframework.util.ObjectUtils;
 
 /**
  * An ANTLR {@link org.antlr.v4.runtime.tree.ParseTreeVisitor} that transforms a parsed EQL query by applying
@@ -30,6 +31,7 @@ import org.springframework.util.Assert;
  *
  * @author Greg Turnquist
  * @author Mark Paluch
+ * @author Christoph Strobl
  * @since 3.2
  */
 @SuppressWarnings("ConstantValue")
@@ -67,7 +69,7 @@ class EqlSortedQueryTransformer extends EqlQueryRenderer {
 			builder.appendExpression(visit(ctx.having_clause()));
 		}
 
-		doVisitOrderBy(builder, ctx);
+		doVisitOrderBy(builder, ctx, ObjectUtils.isEmpty(ctx.setOperator()) ? this.sort : Sort.unsorted());
 
 		for (int i = 0; i < ctx.setOperator().size(); i++) {
 
@@ -78,7 +80,7 @@ class EqlSortedQueryTransformer extends EqlQueryRenderer {
 		return builder;
 	}
 
-	private void doVisitOrderBy(QueryRendererBuilder builder, EqlParser.Select_statementContext ctx) {
+	private void doVisitOrderBy(QueryRendererBuilder builder, EqlParser.Select_statementContext ctx, Sort sort) {
 
 		if (ctx.orderby_clause() != null) {
 			QueryTokenStream existingOrder = visit(ctx.orderby_clause());

--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/HqlSortedQueryTransformer.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/HqlSortedQueryTransformer.java
@@ -100,7 +100,7 @@ class HqlSortedQueryTransformer extends HqlQueryRenderer {
 
 		QueryTokenStream tokens = super.visitJoinPath(ctx);
 
-		if (ctx.variable() != null) {
+		if (ctx.variable() != null  && !isSubquery(ctx)) {
 			transformerSupport.registerAlias(tokens.getLast());
 		}
 
@@ -112,7 +112,7 @@ class HqlSortedQueryTransformer extends HqlQueryRenderer {
 
 		QueryTokenStream tokens = super.visitJoinSubquery(ctx);
 
-		if (ctx.variable() != null && !tokens.isEmpty()) {
+		if (ctx.variable() != null && !tokens.isEmpty()  && !isSubquery(ctx)) {
 			transformerSupport.registerAlias(tokens.getLast());
 		}
 
@@ -124,7 +124,7 @@ class HqlSortedQueryTransformer extends HqlQueryRenderer {
 
 		QueryTokenStream tokens = super.visitVariable(ctx);
 
-		if (ctx.identifier() != null && !tokens.isEmpty()) {
+		if (ctx.identifier() != null && !tokens.isEmpty()  && !isSubquery(ctx)) {
 			transformerSupport.registerAlias(tokens.getLast());
 		}
 

--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/JpaQueryTransformerSupport.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/JpaQueryTransformerSupport.java
@@ -53,7 +53,7 @@ class JpaQueryTransformerSupport {
 	 * @param sort
 	 * @return
 	 */
-	List<QueryToken> orderBy(String primaryFromAlias, Sort sort) {
+	List<QueryToken> orderBy(@Nullable String primaryFromAlias, Sort sort) {
 
 		List<QueryToken> tokens = new ArrayList<>();
 

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/EqlQueryTransformerTests.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/EqlQueryTransformerTests.java
@@ -759,6 +759,15 @@ class EqlQueryTransformerTests {
 				""");
 	}
 
+	@Test // GH-3427
+	void sortShouldBeAppendedToFullSelectOnlyInCaseOfSetOperator() {
+
+		String source = "SELECT tb FROM Test tb WHERE (tb.type='A') UNION SELECT tb FROM Test tb WHERE (tb.type='B')";
+		String target = createQueryFor(source, Sort.by("Type").ascending());
+
+		assertThat(target).isEqualTo("SELECT tb FROM Test tb WHERE (tb.type = 'A') UNION SELECT tb FROM Test tb WHERE (tb.type = 'B') order by tb.Type asc");
+	}
+
 	static Stream<Arguments> queriesWithReservedWordsAsIdentifiers() {
 
 		return Stream.of( //

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/HqlQueryTransformerTests.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/HqlQueryTransformerTests.java
@@ -1070,8 +1070,11 @@ class HqlQueryTransformerTests {
 
         String source = "SELECT tb FROM Test tb WHERE (tb.type='A') UNION SELECT tb FROM Test tb WHERE (tb.type='B')";
 		String target = createQueryFor(source, Sort.by("Type").ascending());
+		
+		System.out.println("target: " + target);
 
-		assertThat(target).contains(" UNION SELECT ").doesNotContainPattern(Pattern.compile(".*\\SUNION"));
+		assertThat(target).isEqualTo("SELECT tb FROM Test tb WHERE (tb.type = 'A') UNION SELECT tb FROM Test tb WHERE (tb.type = 'B') order by tb.Type asc");
+//		assertThat(target).contains(" UNION SELECT ").doesNotContainPattern(Pattern.compile(".*\\SUNION"));
 	}
 
 	@ParameterizedTest // GH-3427

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/HqlQueryTransformerTests.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/HqlQueryTransformerTests.java
@@ -1071,10 +1071,7 @@ class HqlQueryTransformerTests {
         String source = "SELECT tb FROM Test tb WHERE (tb.type='A') UNION SELECT tb FROM Test tb WHERE (tb.type='B')";
 		String target = createQueryFor(source, Sort.by("Type").ascending());
 		
-		System.out.println("target: " + target);
-
 		assertThat(target).isEqualTo("SELECT tb FROM Test tb WHERE (tb.type = 'A') UNION SELECT tb FROM Test tb WHERE (tb.type = 'B') order by tb.Type asc");
-//		assertThat(target).contains(" UNION SELECT ").doesNotContainPattern(Pattern.compile(".*\\SUNION"));
 	}
 
 	@ParameterizedTest // GH-3427


### PR DESCRIPTION
Make sure to append space after order by clause and fix alias detection for wrapped sub select.
Also make sure to ignore alias used in subselect so they do not conflict with root ones.

Closes: #3427 