### PR TITLE
Fluent query API should use ProjectionFactory provided by the RepositoryFactory

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-jpa-parent</artifactId>
-	<version>3.3.0-SNAPSHOT</version>
+	<version>3.3.x-3410-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data JPA Parent</name>

--- a/spring-data-envers/pom.xml
+++ b/spring-data-envers/pom.xml
@@ -5,12 +5,12 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-envers</artifactId>
-	<version>3.3.0-SNAPSHOT</version>
+	<version>3.3.x-3410-SNAPSHOT</version>
 
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-jpa-parent</artifactId>
-		<version>3.3.0-SNAPSHOT</version>
+		<version>3.3.x-3410-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-jpa-distribution/pom.xml
+++ b/spring-data-jpa-distribution/pom.xml
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-jpa-parent</artifactId>
-		<version>3.3.0-SNAPSHOT</version>
+		<version>3.3.x-3410-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-jpa/pom.xml
+++ b/spring-data-jpa/pom.xml
@@ -6,7 +6,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-jpa</artifactId>
-	<version>3.3.0-SNAPSHOT</version>
+	<version>3.3.x-3410-SNAPSHOT</version>
 
 	<name>Spring Data JPA</name>
 	<description>Spring Data module for JPA repositories.</description>
@@ -15,7 +15,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-jpa-parent</artifactId>
-		<version>3.3.0-SNAPSHOT</version>
+		<version>3.3.x-3410-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/support/CrudMethodMetadata.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/support/CrudMethodMetadata.java
@@ -21,6 +21,7 @@ import java.lang.reflect.Method;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.EntityGraph;
+import org.springframework.data.projection.ProjectionFactory;
 import org.springframework.lang.Nullable;
 
 /**
@@ -85,4 +86,11 @@ public interface CrudMethodMetadata {
 	 * @since 1.9
 	 */
 	Method getMethod();
+
+	/**
+	 * @return the {@link ProjectionFactory} to use or {@literal null} if not present.
+	 * @since ??
+	 */
+	@Nullable
+	ProjectionFactory getProjectionFactory();
 }

--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/support/CrudMethodMetadata.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/support/CrudMethodMetadata.java
@@ -21,7 +21,6 @@ import java.lang.reflect.Method;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.EntityGraph;
-import org.springframework.data.projection.ProjectionFactory;
 import org.springframework.lang.Nullable;
 
 /**
@@ -87,10 +86,4 @@ public interface CrudMethodMetadata {
 	 */
 	Method getMethod();
 
-	/**
-	 * @return the {@link ProjectionFactory} to use or {@literal null} if not present.
-	 * @since ??
-	 */
-	@Nullable
-	ProjectionFactory getProjectionFactory();
 }

--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/support/FetchableFluentQueryByPredicate.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/support/FetchableFluentQueryByPredicate.java
@@ -96,8 +96,7 @@ class FetchableFluentQueryByPredicate<S, R> extends FluentQuerySupport<S, R> imp
 		Assert.notNull(sort, "Sort must not be null");
 
 		return new FetchableFluentQueryByPredicate<>(predicate, entityType, resultType, this.sort.and(sort), limit,
-				properties, finder, scroll, pagedFinder, countOperation, existsOperation, entityManager,
-				getProjectionFactory());
+				properties, finder, scroll, pagedFinder, countOperation, existsOperation, entityManager, projectionFactory);
 	}
 
 	@Override
@@ -106,7 +105,7 @@ class FetchableFluentQueryByPredicate<S, R> extends FluentQuerySupport<S, R> imp
 		Assert.isTrue(limit >= 0, "Limit must not be negative");
 
 		return new FetchableFluentQueryByPredicate<>(predicate, entityType, resultType, sort, limit, properties, finder,
-				scroll, pagedFinder, countOperation, existsOperation, entityManager, getProjectionFactory());
+				scroll, pagedFinder, countOperation, existsOperation, entityManager, projectionFactory);
 	}
 
 	@Override
@@ -119,7 +118,7 @@ class FetchableFluentQueryByPredicate<S, R> extends FluentQuerySupport<S, R> imp
 		}
 
 		return new FetchableFluentQueryByPredicate<>(predicate, entityType, resultType, sort, limit, properties, finder,
-				scroll, pagedFinder, countOperation, existsOperation, entityManager, getProjectionFactory());
+				scroll, pagedFinder, countOperation, existsOperation, entityManager, projectionFactory);
 	}
 
 	@Override
@@ -127,7 +126,7 @@ class FetchableFluentQueryByPredicate<S, R> extends FluentQuerySupport<S, R> imp
 
 		return new FetchableFluentQueryByPredicate<>(predicate, entityType, resultType, sort, limit,
 				mergeProperties(properties), finder, scroll, pagedFinder, countOperation, existsOperation, entityManager,
-				getProjectionFactory());
+				projectionFactory);
 	}
 
 	@Override

--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/support/FetchableFluentQueryBySpecification.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/support/FetchableFluentQueryBySpecification.java
@@ -90,7 +90,7 @@ class FetchableFluentQueryBySpecification<S, R> extends FluentQuerySupport<S, R>
 		Assert.notNull(sort, "Sort must not be null");
 
 		return new FetchableFluentQueryBySpecification<>(spec, entityType, resultType, this.sort.and(sort), limit,
-				properties, finder, scroll, countOperation, existsOperation, entityManager, getProjectionFactory());
+				properties, finder, scroll, countOperation, existsOperation, entityManager, projectionFactory);
 	}
 
 	@Override
@@ -99,7 +99,7 @@ class FetchableFluentQueryBySpecification<S, R> extends FluentQuerySupport<S, R>
 		Assert.isTrue(limit >= 0, "Limit must not be negative");
 
 		return new FetchableFluentQueryBySpecification<>(spec, entityType, resultType, this.sort.and(sort), limit,
-				properties, finder, scroll, countOperation, existsOperation, entityManager, getProjectionFactory());
+				properties, finder, scroll, countOperation, existsOperation, entityManager, projectionFactory);
 	}
 
 	@Override
@@ -111,14 +111,14 @@ class FetchableFluentQueryBySpecification<S, R> extends FluentQuerySupport<S, R>
 		}
 
 		return new FetchableFluentQueryBySpecification<>(spec, entityType, resultType, sort, limit, properties, finder,
-				scroll, countOperation, existsOperation, entityManager, getProjectionFactory());
+				scroll, countOperation, existsOperation, entityManager, projectionFactory);
 	}
 
 	@Override
 	public FetchableFluentQuery<R> project(Collection<String> properties) {
 
 		return new FetchableFluentQueryBySpecification<>(spec, entityType, resultType, sort, limit, properties, finder,
-				scroll, countOperation, existsOperation, entityManager, getProjectionFactory());
+				scroll, countOperation, existsOperation, entityManager, projectionFactory);
 	}
 
 	@Override

--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/support/FluentQuerySupport.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/support/FluentQuerySupport.java
@@ -26,6 +26,7 @@ import java.util.function.Function;
 import org.springframework.core.convert.support.DefaultConversionService;
 import org.springframework.data.domain.ScrollPosition;
 import org.springframework.data.domain.Sort;
+import org.springframework.data.projection.ProjectionFactory;
 import org.springframework.data.projection.SpelAwareProxyProjectionFactory;
 import org.springframework.lang.Nullable;
 
@@ -36,6 +37,7 @@ import org.springframework.lang.Nullable;
  * @author Greg Turnquist
  * @author Jens Schauder
  * @author Mark Paluch
+ * @author Christoph Strobl
  * @since 2.6
  */
 abstract class FluentQuerySupport<S, R> {
@@ -46,10 +48,10 @@ abstract class FluentQuerySupport<S, R> {
 	protected final Set<String> properties;
 	protected final Class<S> entityType;
 
-	private final SpelAwareProxyProjectionFactory projectionFactory = new SpelAwareProxyProjectionFactory();
+	private final ProjectionFactory projectionFactory;
 
 	FluentQuerySupport(Class<R> resultType, Sort sort, int limit, @Nullable Collection<String> properties,
-			Class<S> entityType) {
+		Class<S> entityType, ProjectionFactory projectionFactory) {
 
 		this.resultType = resultType;
 		this.sort = sort;
@@ -62,6 +64,11 @@ abstract class FluentQuerySupport<S, R> {
 		}
 
 		this.entityType = entityType;
+		this.projectionFactory = projectionFactory;
+	}
+
+	ProjectionFactory getProjectionFactory() {
+		return projectionFactory;
 	}
 
 	final Collection<String> mergeProperties(Collection<String> additionalProperties) {

--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/support/FluentQuerySupport.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/support/FluentQuerySupport.java
@@ -27,7 +27,6 @@ import org.springframework.core.convert.support.DefaultConversionService;
 import org.springframework.data.domain.ScrollPosition;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.projection.ProjectionFactory;
-import org.springframework.data.projection.SpelAwareProxyProjectionFactory;
 import org.springframework.lang.Nullable;
 
 /**
@@ -47,8 +46,7 @@ abstract class FluentQuerySupport<S, R> {
 	protected final int limit;
 	protected final Set<String> properties;
 	protected final Class<S> entityType;
-
-	private final ProjectionFactory projectionFactory;
+	protected final ProjectionFactory projectionFactory;
 
 	FluentQuerySupport(Class<R> resultType, Sort sort, int limit, @Nullable Collection<String> properties,
 		Class<S> entityType, ProjectionFactory projectionFactory) {
@@ -65,10 +63,6 @@ abstract class FluentQuerySupport<S, R> {
 
 		this.entityType = entityType;
 		this.projectionFactory = projectionFactory;
-	}
-
-	ProjectionFactory getProjectionFactory() {
-		return projectionFactory;
 	}
 
 	final Collection<String> mergeProperties(Collection<String> additionalProperties) {

--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/support/JpaRepositoryConfigurationAware.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/support/JpaRepositoryConfigurationAware.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.jpa.repository.support;
+
+import org.springframework.data.jpa.repository.query.EscapeCharacter;
+import org.springframework.data.projection.ProjectionFactory;
+
+/**
+ * Interface to be implemented by classes that want to be aware of their configuration in a JPA repository context.
+ *
+ * @author Mark Paluch
+ * @since 3.2.6
+ */
+public interface JpaRepositoryConfigurationAware {
+
+	/**
+	 * Configures the {@link EscapeCharacter} to be used with the repository.
+	 *
+	 * @param escapeCharacter must not be {@literal null}.
+	 */
+	default void setEscapeCharacter(EscapeCharacter escapeCharacter) {
+
+	}
+
+	/**
+	 * Configures the {@link ProjectionFactory} to be used with the repository.
+	 *
+	 * @param projectionFactory must not be {@literal null}.
+	 */
+	default void setProjectionFactory(ProjectionFactory projectionFactory) {
+
+	}
+
+	/**
+	 * Configures the {@link CrudMethodMetadata} to be used with the repository.
+	 *
+	 * @param metadata must not be {@literal null}.
+	 */
+	default void setRepositoryMethodMetadata(CrudMethodMetadata metadata) {
+
+	}
+}

--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/support/JpaRepositoryFactory.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/support/JpaRepositoryFactory.java
@@ -100,7 +100,7 @@ public class JpaRepositoryFactory extends RepositoryFactorySupport {
 
 		this.entityManager = entityManager;
 		this.extractor = PersistenceProvider.fromEntityManager(entityManager);
-		this.crudMethodMetadataPostProcessor = new CrudMethodMetadataPostProcessor();
+		this.crudMethodMetadataPostProcessor = new CrudMethodMetadataPostProcessor(() -> getProjectionFactory());
 		this.entityPathResolver = SimpleEntityPathResolver.INSTANCE;
 		this.queryMethodFactory = new DefaultJpaQueryMethodFactory(extractor);
 		this.queryRewriterProvider = QueryRewriterProvider.simple();

--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/support/JpaRepositoryFactory.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/support/JpaRepositoryFactory.java
@@ -83,6 +83,7 @@ public class JpaRepositoryFactory extends RepositoryFactorySupport {
 	private final EntityManager entityManager;
 	private final QueryExtractor extractor;
 	private final CrudMethodMetadataPostProcessor crudMethodMetadataPostProcessor;
+	private final CrudMethodMetadata crudMethodMetadata;
 
 	private EntityPathResolver entityPathResolver;
 	private EscapeCharacter escapeCharacter = EscapeCharacter.DEFAULT;
@@ -100,7 +101,7 @@ public class JpaRepositoryFactory extends RepositoryFactorySupport {
 
 		this.entityManager = entityManager;
 		this.extractor = PersistenceProvider.fromEntityManager(entityManager);
-		this.crudMethodMetadataPostProcessor = new CrudMethodMetadataPostProcessor(() -> getProjectionFactory());
+		this.crudMethodMetadataPostProcessor = new CrudMethodMetadataPostProcessor();
 		this.entityPathResolver = SimpleEntityPathResolver.INSTANCE;
 		this.queryMethodFactory = new DefaultJpaQueryMethodFactory(extractor);
 		this.queryRewriterProvider = QueryRewriterProvider.simple();
@@ -116,6 +117,8 @@ public class JpaRepositoryFactory extends RepositoryFactorySupport {
 		if (extractor.equals(PersistenceProvider.ECLIPSELINK)) {
 			addQueryCreationListener(new EclipseLinkProjectionQueryCreationListener(entityManager));
 		}
+
+		this.crudMethodMetadata = crudMethodMetadataPostProcessor.getCrudMethodMetadata();
 	}
 
 	@Override
@@ -192,11 +195,12 @@ public class JpaRepositoryFactory extends RepositoryFactorySupport {
 	protected final JpaRepositoryImplementation<?, ?> getTargetRepository(RepositoryInformation information) {
 
 		JpaRepositoryImplementation<?, ?> repository = getTargetRepository(information, entityManager);
-		repository.setRepositoryMethodMetadata(crudMethodMetadataPostProcessor.getCrudMethodMetadata());
-		repository.setEscapeCharacter(escapeCharacter);
+
+		invokeAwareMethods(repository);
 
 		return repository;
 	}
+
 
 	/**
 	 * Callback to create a {@link JpaRepository} instance with the given {@link EntityManager}
@@ -250,7 +254,7 @@ public class JpaRepositoryFactory extends RepositoryFactorySupport {
 	protected RepositoryFragments getRepositoryFragments(RepositoryMetadata metadata) {
 
 		return getRepositoryFragments(metadata, entityManager, entityPathResolver,
-				crudMethodMetadataPostProcessor.getCrudMethodMetadata());
+				this.crudMethodMetadata);
 	}
 
 	/**
@@ -279,11 +283,21 @@ public class JpaRepositoryFactory extends RepositoryFactorySupport {
 						"Cannot combine Querydsl and reactive repository support in a single interface");
 			}
 
-			return RepositoryFragments.just(new QuerydslJpaPredicateExecutor<>(getEntityInformation(metadata.getDomainType()),
-					entityManager, resolver, crudMethodMetadata));
+			QuerydslJpaPredicateExecutor<?> querydslJpaPredicateExecutor = new QuerydslJpaPredicateExecutor<>(
+					getEntityInformation(metadata.getDomainType()), entityManager, resolver, crudMethodMetadata);
+			invokeAwareMethods(querydslJpaPredicateExecutor);
+
+			return RepositoryFragments.just(querydslJpaPredicateExecutor);
 		}
 
 		return RepositoryFragments.empty();
+	}
+
+	private void invokeAwareMethods(JpaRepositoryConfigurationAware repository) {
+
+		repository.setRepositoryMethodMetadata(crudMethodMetadata);
+		repository.setEscapeCharacter(escapeCharacter);
+		repository.setProjectionFactory(getProjectionFactory());
 	}
 
 	private static boolean isTransactionNeeded(Class<?> repositoryClass) {

--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/support/JpaRepositoryImplementation.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/support/JpaRepositoryImplementation.java
@@ -17,7 +17,6 @@ package org.springframework.data.jpa.repository.support;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
-import org.springframework.data.jpa.repository.query.EscapeCharacter;
 import org.springframework.data.repository.NoRepositoryBean;
 
 /**
@@ -28,21 +27,7 @@ import org.springframework.data.repository.NoRepositoryBean;
  * @author Jens Schauder
  */
 @NoRepositoryBean
-public interface JpaRepositoryImplementation<T, ID> extends JpaRepository<T, ID>, JpaSpecificationExecutor<T> {
+public interface JpaRepositoryImplementation<T, ID>
+		extends JpaRepository<T, ID>, JpaSpecificationExecutor<T>, JpaRepositoryConfigurationAware {
 
-	/**
-	 * Configures the {@link CrudMethodMetadata} to be used with the repository.
-	 *
-	 * @param crudMethodMetadata must not be {@literal null}.
-	 */
-	void setRepositoryMethodMetadata(CrudMethodMetadata crudMethodMetadata);
-
-	/**
-	 * Configures the {@link EscapeCharacter} to be used with the repository.
-	 *
-	 * @param escapeCharacter Must not be {@literal null}.
-	 */
-	default void setEscapeCharacter(EscapeCharacter escapeCharacter) {
-
-	}
 }

--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/support/SimpleJpaRepository.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/support/SimpleJpaRepository.java
@@ -105,6 +105,7 @@ public class SimpleJpaRepository<T, ID> implements JpaRepositoryImplementation<T
 	private final PersistenceProvider provider;
 
 	private @Nullable CrudMethodMetadata metadata;
+	private @Nullable ProjectionFactory projectionFactory;
 	private EscapeCharacter escapeCharacter = EscapeCharacter.DEFAULT;
 
 	/**
@@ -137,16 +138,21 @@ public class SimpleJpaRepository<T, ID> implements JpaRepositoryImplementation<T
 	 * Configures a custom {@link CrudMethodMetadata} to be used to detect {@link LockModeType}s and query hints to be
 	 * applied to queries.
 	 *
-	 * @param crudMethodMetadata
+	 * @param metadata
 	 */
 	@Override
-	public void setRepositoryMethodMetadata(CrudMethodMetadata crudMethodMetadata) {
-		this.metadata = crudMethodMetadata;
+	public void setRepositoryMethodMetadata(CrudMethodMetadata metadata) {
+		this.metadata = metadata;
 	}
 
 	@Override
 	public void setEscapeCharacter(EscapeCharacter escapeCharacter) {
 		this.escapeCharacter = escapeCharacter;
+	}
+
+	@Override
+	public void setProjectionFactory(ProjectionFactory projectionFactory) {
+		this.projectionFactory = projectionFactory;
 	}
 
 	@Nullable
@@ -907,12 +913,11 @@ public class SimpleJpaRepository<T, ID> implements JpaRepositoryImplementation<T
 
 	private ProjectionFactory getProjectionFactory() {
 
-		CrudMethodMetadata metadata = getRepositoryMethodMetadata();
-		if(metadata == null || metadata.getProjectionFactory() == null) {
-			return new SpelAwareProxyProjectionFactory();
+		if (projectionFactory == null) {
+			projectionFactory = new SpelAwareProxyProjectionFactory();
 		}
 
-		return metadata.getProjectionFactory();
+		return projectionFactory;
 	}
 
 	/**

--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/support/SimpleJpaRepository.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/support/SimpleJpaRepository.java
@@ -61,6 +61,8 @@ import org.springframework.data.jpa.repository.support.FetchableFluentQueryBySpe
 import org.springframework.data.jpa.repository.support.FluentQuerySupport.ScrollQueryFactory;
 import org.springframework.data.jpa.repository.support.QueryHints.NoHints;
 import org.springframework.data.jpa.support.PageableUtils;
+import org.springframework.data.projection.ProjectionFactory;
+import org.springframework.data.projection.SpelAwareProxyProjectionFactory;
 import org.springframework.data.repository.query.FluentQuery.FetchableFluentQuery;
 import org.springframework.data.support.PageableExecutionUtils;
 import org.springframework.data.util.ProxyUtils;
@@ -524,8 +526,8 @@ public class SimpleJpaRepository<T, ID> implements JpaRepositoryImplementation<T
 
 		SpecificationScrollDelegate<T> scrollDelegate = new SpecificationScrollDelegate<>(scrollFunction,
 				entityInformation);
-		FetchableFluentQuery<T> fluentQuery = new FetchableFluentQueryBySpecification<>(spec, domainClass, finder,
-				scrollDelegate, this::count, this::exists, this.entityManager);
+		FetchableFluentQueryBySpecification<?, T> fluentQuery = new FetchableFluentQueryBySpecification<>(spec, domainClass, finder,
+				scrollDelegate, this::count, this::exists, this.entityManager, getProjectionFactory());
 
 		return queryFunction.apply((FetchableFluentQuery<S>) fluentQuery);
 	}
@@ -901,6 +903,16 @@ public class SimpleJpaRepository<T, ID> implements JpaRepositoryImplementation<T
 		if (metadata.getComment() != null && provider.getCommentHintKey() != null) {
 			consumer.accept(provider.getCommentHintKey(), provider.getCommentHintValue(this.metadata.getComment()));
 		}
+	}
+
+	private ProjectionFactory getProjectionFactory() {
+
+		CrudMethodMetadata metadata = getRepositoryMethodMetadata();
+		if(metadata == null || metadata.getProjectionFactory() == null) {
+			return new SpelAwareProxyProjectionFactory();
+		}
+
+		return metadata.getProjectionFactory();
 	}
 
 	/**

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/GreetingsFrom.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/GreetingsFrom.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.jpa.repository;
+
+/**
+ * A trivial component registered via {@literal appication-context.xml} to be called from SpEL.
+ */
+public class GreetingsFrom {
+
+    public String groot(String name) {
+        return "(%s) - I am Groot!".formatted(name);
+    }
+}

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/JavaConfigUserRepositoryTests.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/JavaConfigUserRepositoryTests.java
@@ -88,6 +88,11 @@ class JavaConfigUserRepositoryTests extends UserRepositoryTests {
 			return factory.getObject();
 		}
 
+		@Bean
+		public GreetingsFrom greetingsFrom() {
+			return new GreetingsFrom();
+		}
+
 		private NamedQueries namedQueries() throws IOException {
 
 			PropertiesFactoryBean factory = new PropertiesFactoryBean();

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/support/CrudMethodMetadataPopulatingMethodInterceptorUnitTests.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/support/CrudMethodMetadataPopulatingMethodInterceptorUnitTests.java
@@ -34,6 +34,7 @@ import org.mockito.quality.Strictness;
 import org.springframework.aop.framework.ProxyFactory;
 import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.support.CrudMethodMetadataPostProcessor.CrudMethodMetadataPopulatingMethodInterceptor;
+import org.springframework.data.projection.SpelAwareProxyProjectionFactory;
 import org.springframework.data.repository.core.RepositoryInformation;
 import org.springframework.transaction.support.TransactionSynchronizationManager;
 
@@ -56,7 +57,7 @@ class CrudMethodMetadataPopulatingMethodInterceptorUnitTests {
 
 		ProxyFactory factory = new ProxyFactory(new Object());
 		factory.addInterface(Sample.class);
-		factory.addAdvice(new CrudMethodMetadataPopulatingMethodInterceptor(information));
+		factory.addAdvice(new CrudMethodMetadataPopulatingMethodInterceptor(information, SpelAwareProxyProjectionFactory::new));
 		factory.addAdvice(new MethodInterceptor() {
 
 			@Override
@@ -78,7 +79,7 @@ class CrudMethodMetadataPopulatingMethodInterceptorUnitTests {
 		when(information.getRepositoryInterface()).thenReturn((Class) Sample.class);
 
 		CrudMethodMetadataPopulatingMethodInterceptor interceptor = new CrudMethodMetadataPopulatingMethodInterceptor(
-				information);
+				information, () -> new SpelAwareProxyProjectionFactory());
 		interceptor.invoke(invocation);
 
 		assertThat(TransactionSynchronizationManager.getResource(method)).isNull();
@@ -88,7 +89,7 @@ class CrudMethodMetadataPopulatingMethodInterceptorUnitTests {
 	@SuppressWarnings("unchecked")
 	void looksUpCrudMethodMetadataForEveryInvocation() {
 
-		CrudMethodMetadata metadata = new CrudMethodMetadataPostProcessor().getCrudMethodMetadata();
+		CrudMethodMetadata metadata = new CrudMethodMetadataPostProcessor(() -> new SpelAwareProxyProjectionFactory()).getCrudMethodMetadata();
 		when(information.isQueryMethod(any())).thenReturn(false);
 		when(information.getRepositoryInterface()).thenReturn((Class) Sample.class);
 

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/support/CrudMethodMetadataPopulatingMethodInterceptorUnitTests.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/support/CrudMethodMetadataPopulatingMethodInterceptorUnitTests.java
@@ -18,9 +18,9 @@ package org.springframework.data.jpa.repository.support;
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
-import java.lang.reflect.Method;
-
 import jakarta.persistence.LockModeType;
+
+import java.lang.reflect.Method;
 
 import org.aopalliance.intercept.MethodInterceptor;
 import org.aopalliance.intercept.MethodInvocation;
@@ -34,7 +34,6 @@ import org.mockito.quality.Strictness;
 import org.springframework.aop.framework.ProxyFactory;
 import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.support.CrudMethodMetadataPostProcessor.CrudMethodMetadataPopulatingMethodInterceptor;
-import org.springframework.data.projection.SpelAwareProxyProjectionFactory;
 import org.springframework.data.repository.core.RepositoryInformation;
 import org.springframework.transaction.support.TransactionSynchronizationManager;
 
@@ -57,7 +56,7 @@ class CrudMethodMetadataPopulatingMethodInterceptorUnitTests {
 
 		ProxyFactory factory = new ProxyFactory(new Object());
 		factory.addInterface(Sample.class);
-		factory.addAdvice(new CrudMethodMetadataPopulatingMethodInterceptor(information, SpelAwareProxyProjectionFactory::new));
+		factory.addAdvice(new CrudMethodMetadataPopulatingMethodInterceptor(information));
 		factory.addAdvice(new MethodInterceptor() {
 
 			@Override
@@ -79,7 +78,7 @@ class CrudMethodMetadataPopulatingMethodInterceptorUnitTests {
 		when(information.getRepositoryInterface()).thenReturn((Class) Sample.class);
 
 		CrudMethodMetadataPopulatingMethodInterceptor interceptor = new CrudMethodMetadataPopulatingMethodInterceptor(
-				information, () -> new SpelAwareProxyProjectionFactory());
+				information);
 		interceptor.invoke(invocation);
 
 		assertThat(TransactionSynchronizationManager.getResource(method)).isNull();
@@ -89,7 +88,7 @@ class CrudMethodMetadataPopulatingMethodInterceptorUnitTests {
 	@SuppressWarnings("unchecked")
 	void looksUpCrudMethodMetadataForEveryInvocation() {
 
-		CrudMethodMetadata metadata = new CrudMethodMetadataPostProcessor(() -> new SpelAwareProxyProjectionFactory()).getCrudMethodMetadata();
+		CrudMethodMetadata metadata = new CrudMethodMetadataPostProcessor().getCrudMethodMetadata();
 		when(information.isQueryMethod(any())).thenReturn(false);
 		when(information.getRepositoryInterface()).thenReturn((Class) Sample.class);
 

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/support/FetchableFluentQueryByPredicateUnitTests.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/support/FetchableFluentQueryByPredicateUnitTests.java
@@ -35,7 +35,7 @@ class FetchableFluentQueryByPredicateUnitTests {
 		Sort s1 = Sort.by(Order.by("s1"));
 		Sort s2 = Sort.by(Order.by("s2"));
 		FetchableFluentQueryByPredicate f = new FetchableFluentQueryByPredicate(null, null, null, null, null, null, null,
-				null);
+				null, null);
 		f = (FetchableFluentQueryByPredicate) f.sortBy(s1).sortBy(s2);
 		assertThat(f.sort).isEqualTo(s1.and(s2));
 	}

--- a/spring-data-jpa/src/test/resources/application-context.xml
+++ b/spring-data-jpa/src/test/resources/application-context.xml
@@ -43,4 +43,6 @@
 	
 	<bean class="org.springframework.data.jpa.repository.support.EntityManagerBeanDefinitionRegistrarPostProcessor" />
 
+	<bean class="org.springframework.data.jpa.repository.GreetingsFrom" name="greetingsFrom" />
+
 </beans>

--- a/spring-data-jpa/src/test/resources/config/namespace-application-context.xml
+++ b/spring-data-jpa/src/test/resources/config/namespace-application-context.xml
@@ -28,4 +28,6 @@
 	<!-- Register custom DAO implementation explicitly -->
 	<bean id="userRepositoryImpl" class="org.springframework.data.jpa.repository.sample.UserRepositoryImpl" />
 
+	<bean class="org.springframework.data.jpa.repository.GreetingsFrom" name="greetingsFrom" />
+
 </beans>


### PR DESCRIPTION
This PR makes sure to push the `ProjectionFactory` down to the fluent query to make use of beans registered in the context. Prior to this change the fluent query variant would host its own factory not being aware of its surroundings.

Resolves: #3410