### PR TITLE
Use provider built-in result count to reuse query if possible

### DIFF
--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/AbstractJpaQuery.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/AbstractJpaQuery.java
@@ -62,6 +62,7 @@ import org.springframework.util.Assert;
  * @author Сергей Цыпанов
  * @author Wonchul Heo
  * @author Julia Lee
+ * @author Yanming Zhou
  */
 public abstract class AbstractJpaQuery implements RepositoryQuery {
 
@@ -99,7 +100,7 @@ public abstract class AbstractJpaQuery implements RepositoryQuery {
 			} else if (method.isSliceQuery()) {
 				return new SlicedExecution();
 			} else if (method.isPageQuery()) {
-				return new PagedExecution();
+				return new PagedExecution(em);
 			} else if (method.isModifyingQuery()) {
 				return null;
 			} else {

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/JpaQueryExecutionUnitTests.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/JpaQueryExecutionUnitTests.java
@@ -76,6 +76,7 @@ class JpaQueryExecutionUnitTests {
 	@BeforeEach
 	void setUp() {
 
+		when(em.getDelegate()).thenReturn(em); // for PersistenceProvider.fromEntityManager(em)
 		when(query.executeUpdate()).thenReturn(0);
 		when(jpaQuery.createQuery(Mockito.any(JpaParametersParameterAccessor.class))).thenReturn(query);
 		when(jpaQuery.getQueryMethod()).thenReturn(method);
@@ -183,7 +184,7 @@ class JpaQueryExecutionUnitTests {
 		when(jpaQuery.createQuery(Mockito.any())).thenReturn(query);
 		when(countQuery.getResultList()).thenReturn(Arrays.asList(20L));
 
-		PagedExecution execution = new PagedExecution();
+		PagedExecution execution = new PagedExecution(em);
 		execution.doExecute(jpaQuery,
 				new JpaParametersParameterAccessor(parameters, new Object[] { PageRequest.of(2, 10) }));
 
@@ -199,7 +200,7 @@ class JpaQueryExecutionUnitTests {
 		when(jpaQuery.createQuery(Mockito.any())).thenReturn(query);
 		when(query.getResultList()).thenReturn(Arrays.asList(0L));
 
-		PagedExecution execution = new PagedExecution();
+		PagedExecution execution = new PagedExecution(em);
 		execution.doExecute(jpaQuery,
 				new JpaParametersParameterAccessor(parameters, new Object[] { PageRequest.of(0, 10) }));
 
@@ -215,7 +216,7 @@ class JpaQueryExecutionUnitTests {
 		when(jpaQuery.createQuery(Mockito.any())).thenReturn(query);
 		when(query.getResultList()).thenReturn(Arrays.asList(new Object(), new Object(), new Object(), new Object()));
 
-		PagedExecution execution = new PagedExecution();
+		PagedExecution execution = new PagedExecution(em);
 		execution.doExecute(jpaQuery,
 				new JpaParametersParameterAccessor(parameters, new Object[] { PageRequest.of(0, 10) }));
 
@@ -230,7 +231,7 @@ class JpaQueryExecutionUnitTests {
 		when(jpaQuery.createQuery(Mockito.any())).thenReturn(query);
 		when(query.getResultList()).thenReturn(Arrays.asList(new Object(), new Object(), new Object(), new Object()));
 
-		PagedExecution execution = new PagedExecution();
+		PagedExecution execution = new PagedExecution(em);
 		execution.doExecute(jpaQuery,
 				new JpaParametersParameterAccessor(parameters, new Object[] { PageRequest.of(5, 10) }));
 
@@ -247,7 +248,7 @@ class JpaQueryExecutionUnitTests {
 		when(jpaQuery.createCountQuery(Mockito.any())).thenReturn(query);
 		when(countQuery.getResultList()).thenReturn(Arrays.asList(20L));
 
-		PagedExecution execution = new PagedExecution();
+		PagedExecution execution = new PagedExecution(em);
 		execution.doExecute(jpaQuery,
 				new JpaParametersParameterAccessor(parameters, new Object[] { PageRequest.of(4, 4) }));
 
@@ -264,7 +265,7 @@ class JpaQueryExecutionUnitTests {
 		when(jpaQuery.createCountQuery(Mockito.any())).thenReturn(query);
 		when(countQuery.getResultList()).thenReturn(Arrays.asList(20L));
 
-		PagedExecution execution = new PagedExecution();
+		PagedExecution execution = new PagedExecution(em);
 		execution.doExecute(jpaQuery,
 				new JpaParametersParameterAccessor(parameters, new Object[] { PageRequest.of(4, 4) }));
 


### PR DESCRIPTION
Hibernate introduce `SelectionQuery::getResultCount` since 6.5.0, It may be JPA Query method in the future.