### PR TITLE
Issue/3460

### DIFF
--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/ProcedureParameter.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/ProcedureParameter.java
@@ -28,6 +28,7 @@ import org.springframework.lang.Nullable;
  *
  * @author Gabriel Basilio
  * @author Greg Turnquist
+ * @author Thorben Janssen
  */
 class ProcedureParameter {
 

--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/ProcedureParameter.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/ProcedureParameter.java
@@ -32,18 +32,24 @@ import org.springframework.lang.Nullable;
 class ProcedureParameter {
 
 	private final String name;
+	private final int position;
 	private final ParameterMode mode;
 	private final Class<?> type;
 
-	ProcedureParameter(@Nullable String name, ParameterMode mode, Class<?> type) {
+	ProcedureParameter(@Nullable String name, int position, ParameterMode mode, Class<?> type) {
 
 		this.name = name;
+		this.position = position;
 		this.mode = mode;
 		this.type = type;
 	}
 
 	public String getName() {
 		return name;
+	}
+
+	public int getPosition() {
+		return position;
 	}
 
 	public ParameterMode getMode() {

--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/ProcedureParameter.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/ProcedureParameter.java
@@ -82,6 +82,6 @@ class ProcedureParameter {
 
 	@Override
 	public String toString() {
-		return "ProcedureParameter{" + "name='" + name + '\'' + ", mode=" + mode + ", type=" + type + '}';
+		return "ProcedureParameter{" + "name='" + name + '\'' + ", position=" + position + ", mode=" + mode + ", type=" + type + '}';
 	}
 }

--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/StoredProcedureAttributeSource.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/StoredProcedureAttributeSource.java
@@ -20,18 +20,17 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import java.util.stream.Collectors;
-
-import jakarta.persistence.NamedStoredProcedureQueries;
-import jakarta.persistence.NamedStoredProcedureQuery;
-import jakarta.persistence.ParameterMode;
-import jakarta.persistence.StoredProcedureParameter;
 
 import org.springframework.core.annotation.AnnotatedElementUtils;
 import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
 import org.springframework.util.ObjectUtils;
 import org.springframework.util.StringUtils;
+
+import jakarta.persistence.NamedStoredProcedureQueries;
+import jakarta.persistence.NamedStoredProcedureQuery;
+import jakarta.persistence.ParameterMode;
+import jakarta.persistence.StoredProcedureParameter;
 
 /**
  * A factory class for {@link StoredProcedureAttributes}.

--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/StoredProcedureAttributeSource.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/StoredProcedureAttributeSource.java
@@ -43,6 +43,7 @@ import jakarta.persistence.StoredProcedureParameter;
  * @author Jeff Sheets
  * @author Gabriel Basilio
  * @author Greg Turnquist
+ * @author Thorben Janssen
  * @since 1.6
  */
 enum StoredProcedureAttributeSource {

--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/StoredProcedureAttributeSource.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/StoredProcedureAttributeSource.java
@@ -119,10 +119,7 @@ enum StoredProcedureAttributeSource {
 		} else {
 
 			// try to discover the output parameter
-			outputParameters = extractOutputParametersFrom(namedStoredProc).stream() //
-					.map(namedParameter -> new ProcedureParameter(namedParameter.name(), namedParameter.mode(),
-							namedParameter.type())) //
-					.collect(Collectors.toList());
+			outputParameters = extractOutputParametersFrom(namedStoredProc);
 		}
 
 		return new StoredProcedureAttributes(namedStoredProc.name(), outputParameters, true);
@@ -137,33 +134,36 @@ enum StoredProcedureAttributeSource {
 	 */
 	private ProcedureParameter createOutputProcedureParameterFrom(Method method, Procedure procedure) {
 
-		return new ProcedureParameter(procedure.outputParameterName(),
+		return new ProcedureParameter(procedure.outputParameterName(), 1,
 				procedure.refCursor() ? ParameterMode.REF_CURSOR : ParameterMode.OUT, method.getReturnType());
 	}
 
 	/**
 	 * Translate all the {@Link NamedStoredProcedureQuery} parameters into a {@link List} of
-	 * {@link StoredProcedureParameter}s.
+	 * {@link ProcedureParameter}s.
 	 *
 	 * @param namedStoredProc
 	 * @return
 	 */
-	private List<StoredProcedureParameter> extractOutputParametersFrom(NamedStoredProcedureQuery namedStoredProc) {
+	private List<ProcedureParameter> extractOutputParametersFrom(NamedStoredProcedureQuery namedStoredProc) {
 
-		List<StoredProcedureParameter> outputParameters = new ArrayList<>();
+		List<ProcedureParameter> outputParameters = new ArrayList<>();
 
+		int position = 1;
 		for (StoredProcedureParameter param : namedStoredProc.parameters()) {
 
 			switch (param.mode()) {
 				case OUT:
 				case INOUT:
 				case REF_CURSOR:
-					outputParameters.add(param);
+					outputParameters.add(new ProcedureParameter(param.name(), position, param.mode(), param.type()));
 					break;
 				case IN:
 				default:
-					continue;
+					// not an output parameter
 			}
+
+			position++;
 		}
 
 		return outputParameters;

--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/StoredProcedureAttributes.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/StoredProcedureAttributes.java
@@ -88,7 +88,7 @@ class StoredProcedureAttributes {
 
 	private ProcedureParameter getParameterWithCompletedName(ProcedureParameter parameter, int i) {
 
-		return new ProcedureParameter(completeOutputParameterName(i, parameter.getName()), i+1, parameter.getMode(),
+		return new ProcedureParameter(completeOutputParameterName(i, parameter.getName()), parameter.getPosition(), parameter.getMode(),
 				parameter.getType());
 	}
 

--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/StoredProcedureAttributes.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/StoredProcedureAttributes.java
@@ -34,6 +34,7 @@ import org.springframework.util.StringUtils;
  * @author Jeff Sheets
  * @author Jens Schauder
  * @author Gabriel Basilio
+ * @author Thorben Janssen
  * @since 1.6
  */
 class StoredProcedureAttributes {

--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/StoredProcedureAttributes.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/StoredProcedureAttributes.java
@@ -87,7 +87,7 @@ class StoredProcedureAttributes {
 
 	private ProcedureParameter getParameterWithCompletedName(ProcedureParameter parameter, int i) {
 
-		return new ProcedureParameter(completeOutputParameterName(i, parameter.getName()), parameter.getMode(),
+		return new ProcedureParameter(completeOutputParameterName(i, parameter.getName()), i+1, parameter.getMode(),
 				parameter.getType());
 	}
 

--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/StoredProcedureJpaQuery.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/StoredProcedureJpaQuery.java
@@ -43,6 +43,7 @@ import org.springframework.util.StringUtils;
  * @author Mark Paluch
  * @author Jeff Sheets
  * @author JyotirmoyVS
+ * @author Thorben Janssen
  * @since 1.6
  */
 class StoredProcedureJpaQuery extends AbstractJpaQuery {

--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/StoredProcedureJpaQuery.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/StoredProcedureJpaQuery.java
@@ -124,8 +124,7 @@ class StoredProcedureJpaQuery extends AbstractJpaQuery {
 
 		Map<String, Object> outputValues = new HashMap<>();
 
-		for (int i = 0; i < outputParameters.size(); i++) {
-			ProcedureParameter outputParameter = outputParameters.get(i);
+		for (ProcedureParameter outputParameter : outputParameters) {
 			outputValues.put(!outputParameter.getName().isEmpty() ? outputParameter.getName() : outputParameter.getPosition()+"",
 					extractOutputParameterValue(outputParameter, storedProcedureQuery));
 		}

--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/StoredProcedureJpaQuery.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/StoredProcedureJpaQuery.java
@@ -119,15 +119,15 @@ class StoredProcedureJpaQuery extends AbstractJpaQuery {
 		List<ProcedureParameter> outputParameters = procedureAttributes.getOutputProcedureParameters();
 
 		if (outputParameters.size() == 1) {
-			return extractOutputParameterValue(outputParameters.get(0), 0, storedProcedureQuery);
+			return extractOutputParameterValue(outputParameters.get(0), storedProcedureQuery);
 		}
 
 		Map<String, Object> outputValues = new HashMap<>();
 
 		for (int i = 0; i < outputParameters.size(); i++) {
 			ProcedureParameter outputParameter = outputParameters.get(i);
-			outputValues.put(outputParameter.getName(),
-					extractOutputParameterValue(outputParameter, i, storedProcedureQuery));
+			outputValues.put(!outputParameter.getName().isEmpty() ? outputParameter.getName() : outputParameter.getPosition()+"",
+					extractOutputParameterValue(outputParameter, storedProcedureQuery));
 		}
 
 		return outputValues;
@@ -136,14 +136,12 @@ class StoredProcedureJpaQuery extends AbstractJpaQuery {
 	/**
 	 * @return The value of an output parameter either by name or by index.
 	 */
-	private Object extractOutputParameterValue(ProcedureParameter outputParameter, Integer index,
+	private Object extractOutputParameterValue(ProcedureParameter outputParameter, 
 			StoredProcedureQuery storedProcedureQuery) {
-
-		JpaParameters methodParameters = getQueryMethod().getParameters();
 
 		return useNamedParameters && StringUtils.hasText(outputParameter.getName())
 				? storedProcedureQuery.getOutputParameterValue(outputParameter.getName())
-				: storedProcedureQuery.getOutputParameterValue(methodParameters.getNumberOfParameters() + index + 1);
+				: storedProcedureQuery.getOutputParameterValue(outputParameter.getPosition());
 	}
 
 	/**

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/procedures/PostgresStoredProcedureIntegrationTests.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/procedures/PostgresStoredProcedureIntegrationTests.java
@@ -66,6 +66,7 @@ import jakarta.persistence.StoredProcedureParameter;
  * @author Gabriel Basilio
  * @author Greg Turnquist
  * @author Yanming Zhou
+ * @author Thorben Janssen
  */
 @Transactional
 @ExtendWith(SpringExtension.class)

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/procedures/PostgresStoredProcedureIntegrationTests.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/procedures/PostgresStoredProcedureIntegrationTests.java
@@ -16,15 +16,7 @@
 
 package org.springframework.data.jpa.repository.procedures;
 
-import static org.assertj.core.api.Assertions.*;
-
-import jakarta.persistence.Entity;
-import jakarta.persistence.EntityManagerFactory;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.Id;
-import jakarta.persistence.NamedStoredProcedureQuery;
-import jakarta.persistence.ParameterMode;
-import jakarta.persistence.StoredProcedureParameter;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.math.BigDecimal;
 import java.util.List;
@@ -46,7 +38,6 @@ import org.springframework.core.io.ClassPathResource;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 import org.springframework.data.jpa.repository.query.Procedure;
-import org.springframework.data.jpa.util.DisabledOnHibernate61;
 import org.springframework.data.jpa.util.DisabledOnHibernate62;
 import org.springframework.jdbc.datasource.init.DataSourceInitializer;
 import org.springframework.jdbc.datasource.init.ResourceDatabasePopulator;
@@ -60,6 +51,14 @@ import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.annotation.EnableTransactionManagement;
 import org.springframework.transaction.annotation.Transactional;
 import org.testcontainers.containers.PostgreSQLContainer;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityManagerFactory;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.NamedStoredProcedureQuery;
+import jakarta.persistence.ParameterMode;
+import jakarta.persistence.StoredProcedureParameter;
 
 /**
  * Testcase to verify {@link org.springframework.jdbc.object.StoredProcedure}s work with Postgres.
@@ -155,7 +154,6 @@ class PostgresStoredProcedureIntegrationTests {
 
 		Map results = repository.positionalInOut(1, 2);
 
-		// TODO: Check result format
 		assertThat(results.get("2")).isEqualTo(2);
 		assertThat(results.get("3")).isEqualTo(3);
 	}

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/procedures/PostgresStoredProcedureIntegrationTests.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/procedures/PostgresStoredProcedureIntegrationTests.java
@@ -28,6 +28,7 @@ import jakarta.persistence.StoredProcedureParameter;
 
 import java.math.BigDecimal;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Properties;
 
@@ -152,11 +153,11 @@ class PostgresStoredProcedureIntegrationTests {
 	@Test // 3460
 	void testPositionalInOutParameter() {
 
-		Object[] results = repository.positionalInOut(1, 2);
+		Map results = repository.positionalInOut(1, 2);
 
-		assertThat(results).containsExactly( //
-				2, //
-				3);
+		// TODO: Check result format
+		assertThat(results.get("2")).isEqualTo(2);
+		assertThat(results.get("3")).isEqualTo(3);
 	}
 
 	@Entity
@@ -252,7 +253,7 @@ class PostgresStoredProcedureIntegrationTests {
 		List<Employee> entityListFromNamedProcedure();
 
 		@Procedure(name = "positional_inout")
-		Object[] positionalInOut(Integer in, Integer inout);
+		Map positionalInOut(Integer in, Integer inout);
 	}
 
 	@EnableJpaRepositories(considerNestedRepositories = true,

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/StoredProcedureAttributesUnitTests.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/StoredProcedureAttributesUnitTests.java
@@ -34,7 +34,7 @@ class StoredProcedureAttributesUnitTests {
 	void usesSyntheticOutputParameterNameForAdhocProcedureWithoutOutputName() {
 
 		StoredProcedureAttributes attributes = new StoredProcedureAttributes("procedure",
-				new ProcedureParameter(null, ParameterMode.OUT, Long.class));
+				new ProcedureParameter(null, 1, ParameterMode.OUT, Long.class));
 		assertThat(attributes.getOutputProcedureParameters().get(0).getName()).isEqualTo(SYNTHETIC_OUTPUT_PARAMETER_NAME);
 	}
 }

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/StoredProcedureAttributesUnitTests.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/StoredProcedureAttributesUnitTests.java
@@ -27,6 +27,7 @@ import org.junit.jupiter.api.Test;
  *
  * @author Oliver Gierke
  * @author Jens Schauder
+ * @author Thorben Janssen
  */
 class StoredProcedureAttributesUnitTests {
 

--- a/spring-data-jpa/src/test/resources/scripts/postgres-stored-procedures.sql
+++ b/spring-data-jpa/src/test/resources/scripts/postgres-stored-procedures.sql
@@ -34,3 +34,21 @@ BEGIN
     OPEN ref FOR SELECT * FROM employee WHERE employee.ID = 3;
 END;
 $BODY$;;
+
+CREATE OR REPLACE PROCEDURE get_employees_count(OUT results integer)
+    LANGUAGE 'plpgsql'
+AS
+$BODY$
+BEGIN
+    results = (SELECT COUNT(*) FROM employee);
+END;
+$BODY$;;
+
+CREATE OR REPLACE PROCEDURE positional_inout_parameter_issue3460(IN inParam integer, INOUT inoutParam integer, OUT outParam integer)
+    LANGUAGE 'plpgsql'
+AS
+$BODY$
+BEGIN
+    outParam = 3;
+END;
+$BODY$;;


### PR DESCRIPTION
Fix handling of position INOUT parameters when extracting output parameters (issue 3460)

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).


Added position information to `ProcedureParameter` class, set it in `StoredProcedureAttributeSource.extractOutputParametersFrom(...)`, and use that position in `StoredProcedureJpaQuery.extractOutputParameterValue` to get the result value.
This change is based on the assumption that `NamedStoredProcedureQuery.parameters()` returns the parameters in the correct order. As far as I understand the rest of the code, it already makes this assumption when using positional parameters.