### PR TITLE
Add convenient method `JpaRepository::clear` as companion of `flush`

### DIFF
--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/JpaRepository.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/JpaRepository.java
@@ -41,7 +41,14 @@ import org.springframework.data.repository.query.QueryByExampleExecutor;
 public interface JpaRepository<T, ID> extends ListCrudRepository<T, ID>, ListPagingAndSortingRepository<T, ID>, QueryByExampleExecutor<T> {
 
 	/**
+	 * Clear the persistence context.
+	 * @see EntityManager#clear()
+	 */
+	void clear();
+
+	/**
 	 * Flushes all pending changes to the database.
+	 *  @see EntityManager#flush()
 	 */
 	void flush();
 

--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/support/SimpleJpaRepository.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/support/SimpleJpaRepository.java
@@ -667,6 +667,11 @@ public class SimpleJpaRepository<T, ID> implements JpaRepositoryImplementation<T
 		return result;
 	}
 
+	@Override
+	public void clear() {
+		entityManager.clear();
+	}
+
 	@Transactional
 	@Override
 	public void flush() {


### PR DESCRIPTION
Sometimes we need to clear persistence context, especially for writing unit tests. We need to inject `EntityManager` before this commit, it is a bit inconvenient.