### PR TITLE
Support converting underscores column name to camel case property name for projecting native query

### DIFF
--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/domain/sample/User.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/domain/sample/User.java
@@ -33,6 +33,7 @@ import java.util.Set;
  * @author Jeff Sheets
  * @author JyotirmoyVS
  * @author Greg Turnquist
+ * @author Yanming Zhou
  */
 @Entity
 @NamedEntityGraphs({ @NamedEntityGraph(name = "User.overview", attributeNodes = { @NamedAttributeNode("roles") }),
@@ -100,6 +101,8 @@ public class User {
 	@Temporal(TemporalType.TIMESTAMP) private Date createdAt;
 
 	@Column(nullable = false, unique = true) private String emailAddress;
+
+	@Column(name = "secondary_email_address") private String secondaryEmailAddress;
 
 	@ManyToMany(cascade = { CascadeType.PERSIST, CascadeType.MERGE }) private Set<User> colleagues;
 
@@ -171,6 +174,14 @@ public class User {
 	public void setEmailAddress(String emailAddress) {
 
 		this.emailAddress = emailAddress;
+	}
+
+	public String getSecondaryEmailAddress() {
+		return secondaryEmailAddress;
+	}
+
+	public void setSecondaryEmailAddress(String secondaryEmailAddress) {
+		this.secondaryEmailAddress = secondaryEmailAddress;
 	}
 
 	public void setActive(boolean active) {

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/UserRepositoryTests.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/UserRepositoryTests.java
@@ -95,6 +95,7 @@ import org.springframework.transaction.annotation.Transactional;
  * @author Simon Paradies
  * @author Geoffrey Deremetz
  * @author Krzysztof Krason
+ * @author Yanming Zhou
  */
 @ExtendWith(SpringExtension.class)
 @ContextConfiguration("classpath:application-context.xml")
@@ -2967,6 +2968,24 @@ class UserRepositoryTests {
 		assertThat(emailAddress) //
 				.isEqualTo(user.getEmailAddress()) //
 				.as("ensuring email is actually not null") //
+				.isNotNull();
+	}
+
+	@Test // DATAJPA-3462
+	void supportsProjectionsWithNativeQueriesAndUnderscoresColumnNameToCamelCaseProperty() {
+
+		User user = new User();
+		user.setEmailAddress("primary@something");
+		user.setSecondaryEmailAddress("secondary@something");
+		em.persist(user);
+
+		UserRepository.EmailOnly result = repository.findEmailOnlyByNativeQuery(user.getId());
+
+		String secondaryEmailAddress = result.getSecondaryEmailAddress();
+
+		assertThat(secondaryEmailAddress) //
+				.isEqualTo(user.getSecondaryEmailAddress()) //
+				.as("ensuring secondary email is actually not null") //
 				.isNotNull();
 	}
 

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/sample/UserRepository.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/sample/UserRepository.java
@@ -62,6 +62,7 @@ import org.springframework.transaction.annotation.Transactional;
  * @author Simon Paradies
  * @author Diego Krupitza
  * @author Geoffrey Deremetz
+ * @author Yanming Zhou
  */
 public interface UserRepository extends JpaRepository<User, Integer>, JpaSpecificationExecutor<User>,
 		UserRepositoryCustom, ListQuerydslPredicateExecutor<User> {
@@ -555,7 +556,7 @@ public interface UserRepository extends JpaRepository<User, Integer>, JpaSpecifi
 	NameOnly findByNativeQuery(Integer id);
 
 	// DATAJPA-1248
-	@Query(value = "SELECT emailaddress FROM SD_User WHERE id = ?1", nativeQuery = true)
+	@Query(value = "SELECT emailaddress, secondary_email_address FROM SD_User WHERE id = ?1", nativeQuery = true)
 	EmailOnly findEmailOnlyByNativeQuery(Integer id);
 
 	// DATAJPA-1235
@@ -721,6 +722,8 @@ public interface UserRepository extends JpaRepository<User, Integer>, JpaSpecifi
 
 	interface EmailOnly {
 		String getEmailAddress();
+
+		String getSecondaryEmailAddress();
 	}
 
 	interface IdOnly {


### PR DESCRIPTION
> By default, Spring Boot configures the physical naming strategy with CamelCaseToUnderscoresNamingStrategy.

Then we should convert underscores back to camel case.

Fix GH-3462
