### PR TITLE
Modify getQuery(Specification, Pageable)

### DIFF
--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/support/SimpleJpaRepository.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/support/SimpleJpaRepository.java
@@ -426,11 +426,6 @@ public class SimpleJpaRepository<T, ID> implements JpaRepositoryImplementation<T
 
 	@Override
 	public Page<T> findAll(Pageable pageable) {
-
-		if (pageable.isUnpaged()) {
-			return new PageImpl<>(findAll());
-		}
-
 		return findAll((Specification<T>) null, pageable);
 	}
 
@@ -717,8 +712,7 @@ public class SimpleJpaRepository<T, ID> implements JpaRepositoryImplementation<T
 	 */
 	protected TypedQuery<T> getQuery(@Nullable Specification<T> spec, Pageable pageable) {
 
-		Sort sort = pageable.isPaged() ? pageable.getSort() : Sort.unsorted();
-		return getQuery(spec, getDomainClass(), sort);
+		return getQuery(spec, getDomainClass(), pageable.getSort());
 	}
 
 	/**
@@ -731,8 +725,7 @@ public class SimpleJpaRepository<T, ID> implements JpaRepositoryImplementation<T
 	protected <S extends T> TypedQuery<S> getQuery(@Nullable Specification<S> spec, Class<S> domainClass,
 			Pageable pageable) {
 
-		Sort sort = pageable.isPaged() ? pageable.getSort() : Sort.unsorted();
-		return getQuery(spec, domainClass, sort);
+		return getQuery(spec, domainClass, pageable.getSort());
 	}
 
 	/**

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/UserRepositoryTests.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/UserRepositoryTests.java
@@ -2887,6 +2887,18 @@ class UserRepositoryTests {
 		assertThat(exists).isFalse();
 	}
 
+	@Test // GH-3476
+	void unPagedSortedQuery() {
+
+		flushTestUsers();
+
+		Sort sort = Sort.by(DESC, "firstname");
+		Page<User> firstPage = repository.findAll(PageRequest.of(0, 10, sort));
+		Page<User> secondPage = repository.findAll(Pageable.unpaged(sort));
+		assertThat(firstPage.getContent()).isEqualTo(secondPage.getContent());
+	}
+
+
 	@Test // DATAJPA-905
 	void executesPagedSpecificationSettingAnOrder() {
 


### PR DESCRIPTION
#3476 

This problem is not just happening with ```findAll(pageable pageable)```
also occur in ```findAll(Specification<T> spec, Pageable pageable)```

How about fixing it like this?
```java
@Override
public Page<T> findAll(Pageable pageable) {
	return findAll((Specification<T>) null, pageable);
}
```

```java
protected TypedQuery<T> getQuery(@Nullable Specification<T> spec, Pageable pageable) {
	return getQuery(spec, getDomainClass(), pageable.getSort());
}
```


<!--

Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
Make sure that:

-->

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
