### PR TITLE
Fix typo in README.adoc

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -55,7 +55,7 @@ public class MyService {
     repository.save(person);
 
     List<Person> lastNameResults = repository.findByLastname("Gierke");
-    List<Person> firstNameResults = repository.findByFirstnameLike("Oli*");
+    List<Person> firstNameResults = repository.findByFirstnameLike("Oli%");
  }
 }
 


### PR DESCRIPTION
Hi team,

This PR addresses an issue in the README file related to the usage example of the `findByFirstnameLike` method in Spring Data JPA.

**Before**
```java
List<Person> firstNameResults = repository.findByFirstnameLike("Oli*");
```
**After**
```java
List<Person> firstNameResults = repository.findByFirstnameLike("Oli%");
```
Using an asterisk (*) in the LIKE clause does not work for pattern matching in SQL. The proper wildcard character for the LIKE clause in SQL is the percentage symbol (%).

Thank you.