### PR TITLE
Suppress selection item aliasing for the actual count query

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-jpa-parent</artifactId>
-	<version>3.4.0-SNAPSHOT</version>
+	<version>3.4.0-GH-3536-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data JPA Parent</name>

--- a/spring-data-envers/pom.xml
+++ b/spring-data-envers/pom.xml
@@ -5,12 +5,12 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-envers</artifactId>
-	<version>3.4.0-SNAPSHOT</version>
+	<version>3.4.0-GH-3536-SNAPSHOT</version>
 
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-jpa-parent</artifactId>
-		<version>3.4.0-SNAPSHOT</version>
+		<version>3.4.0-GH-3536-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-jpa-distribution/pom.xml
+++ b/spring-data-jpa-distribution/pom.xml
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-jpa-parent</artifactId>
-		<version>3.4.0-SNAPSHOT</version>
+		<version>3.4.0-GH-3536-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-jpa-performance/pom.xml
+++ b/spring-data-jpa-performance/pom.xml
@@ -15,7 +15,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-jpa-parent</artifactId>
-		<version>3.4.0-SNAPSHOT</version>
+		<version>3.4.0-GH-3536-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-jpa/pom.xml
+++ b/spring-data-jpa/pom.xml
@@ -6,7 +6,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-jpa</artifactId>
-	<version>3.4.0-SNAPSHOT</version>
+	<version>3.4.0-GH-3536-SNAPSHOT</version>
 
 	<name>Spring Data JPA</name>
 	<description>Spring Data module for JPA repositories.</description>
@@ -15,7 +15,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-jpa-parent</artifactId>
-		<version>3.4.0-SNAPSHOT</version>
+		<version>3.4.0-GH-3536-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/EqlCountQueryTransformer.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/EqlCountQueryTransformer.java
@@ -15,9 +15,7 @@
  */
 package org.springframework.data.jpa.repository.query;
 
-import static org.springframework.data.jpa.repository.query.QueryTokens.TOKEN_CLOSE_PAREN;
-import static org.springframework.data.jpa.repository.query.QueryTokens.TOKEN_COMMA;
-import static org.springframework.data.jpa.repository.query.QueryTokens.TOKEN_COUNT_FUNC;
+import static org.springframework.data.jpa.repository.query.QueryTokens.*;
 
 import org.springframework.data.jpa.repository.query.QueryRenderer.QueryRendererBuilder;
 import org.springframework.data.jpa.repository.query.QueryTransformers.CountSelectionTokenStream;
@@ -98,7 +96,7 @@ class EqlCountQueryTransformer extends EqlQueryRenderer {
 	private QueryRendererBuilder getDistinctCountSelection(QueryTokenStream selectionListbuilder) {
 
 		QueryRendererBuilder nested = new QueryRendererBuilder();
-		CountSelectionTokenStream countSelection = QueryTransformers.filterCountSelection(selectionListbuilder);
+		CountSelectionTokenStream countSelection = CountSelectionTokenStream.create(selectionListbuilder);
 
 		if (countSelection.requiresPrimaryAlias()) {
 			// constructor

--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/HqlCountQueryTransformer.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/HqlCountQueryTransformer.java
@@ -251,7 +251,7 @@ class HqlCountQueryTransformer extends HqlQueryRenderer {
 	private QueryRendererBuilder getDistinctCountSelection(QueryTokenStream selectionListbuilder) {
 
 		QueryRendererBuilder nested = new QueryRendererBuilder();
-		CountSelectionTokenStream countSelection = QueryTransformers.filterCountSelection(selectionListbuilder);
+		CountSelectionTokenStream countSelection = CountSelectionTokenStream.create(selectionListbuilder);
 
 		if (countSelection.requiresPrimaryAlias()) {
 			// constructor

--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/HqlCountQueryTransformer.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/HqlCountQueryTransformer.java
@@ -15,12 +15,7 @@
  */
 package org.springframework.data.jpa.repository.query;
 
-import static org.springframework.data.jpa.repository.query.QueryTokens.TOKEN_AS;
-import static org.springframework.data.jpa.repository.query.QueryTokens.TOKEN_CLOSE_PAREN;
-import static org.springframework.data.jpa.repository.query.QueryTokens.TOKEN_COUNT_FUNC;
-import static org.springframework.data.jpa.repository.query.QueryTokens.TOKEN_DOUBLE_UNDERSCORE;
-import static org.springframework.data.jpa.repository.query.QueryTokens.TOKEN_OPEN_PAREN;
-import static org.springframework.data.jpa.repository.query.QueryTokens.TOKEN_SELECT_COUNT;
+import static org.springframework.data.jpa.repository.query.QueryTokens.*;
 
 import org.springframework.data.jpa.repository.query.HqlParser.SelectClauseContext;
 import org.springframework.data.jpa.repository.query.QueryRenderer.QueryRendererBuilder;
@@ -209,6 +204,22 @@ class HqlCountQueryTransformer extends HqlQueryRenderer {
 	}
 
 	@Override
+	public QueryTokenStream visitSelection(HqlParser.SelectionContext ctx) {
+
+		if (isSubquery(ctx)) {
+			return super.visitSelection(ctx);
+		}
+
+		QueryRendererBuilder builder = QueryRenderer.builder();
+
+		builder.append(visit(ctx.selectExpression()));
+
+		// do not append variables to skip AS field aliasing
+
+		return builder;
+	}
+
+	@Override
 	public QueryRendererBuilder visitQueryOrder(HqlParser.QueryOrderContext ctx) {
 
 		QueryRendererBuilder builder = QueryRenderer.builder();
@@ -247,7 +258,7 @@ class HqlCountQueryTransformer extends HqlQueryRenderer {
 			nested.append(QueryTokens.token(primaryFromAlias));
 		} else {
 			// keep all the select items to distinct against
-			nested.append(countSelection);
+			nested.append(selectionListbuilder);
 		}
 		return nested;
 	}

--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/JpqlCountQueryTransformer.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/JpqlCountQueryTransformer.java
@@ -96,7 +96,7 @@ class JpqlCountQueryTransformer extends JpqlQueryRenderer {
 	private QueryRendererBuilder getDistinctCountSelection(QueryTokenStream selectionListbuilder) {
 
 		QueryRendererBuilder nested = new QueryRendererBuilder();
-		CountSelectionTokenStream countSelection = QueryTransformers.filterCountSelection(selectionListbuilder);
+		CountSelectionTokenStream countSelection = CountSelectionTokenStream.create(selectionListbuilder);
 
 		if (countSelection.requiresPrimaryAlias()) {
 			// constructor

--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/QueryTransformers.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/QueryTransformers.java
@@ -29,46 +29,46 @@ import java.util.List;
  */
 class QueryTransformers {
 
-	static CountSelectionTokenStream filterCountSelection(QueryTokenStream selection) {
-
-		List<QueryToken> target = new ArrayList<>(selection.size());
-		boolean skipNext = false;
-		boolean containsNew = false;
-
-		for (QueryToken token : selection) {
-
-			if (skipNext) {
-				skipNext = false;
-				continue;
-			}
-
-			if (token.equals(TOKEN_AS)) {
-				skipNext = true;
-				continue;
-			}
-
-			if (!token.equals(TOKEN_COMMA) && token.isExpression()) {
-				token = QueryTokens.token(token.value());
-			}
-
-			if (!containsNew && token.value().contains("new")) {
-				containsNew = true;
-			}
-
-			target.add(token);
-		}
-
-		return new CountSelectionTokenStream(target, containsNew);
-	}
-
 	static class CountSelectionTokenStream implements QueryTokenStream {
 
 		private final List<QueryToken> tokens;
 		private final boolean requiresPrimaryAlias;
 
-		public CountSelectionTokenStream(List<QueryToken> tokens, boolean requiresPrimaryAlias) {
+		CountSelectionTokenStream(List<QueryToken> tokens, boolean requiresPrimaryAlias) {
 			this.tokens = tokens;
 			this.requiresPrimaryAlias = requiresPrimaryAlias;
+		}
+
+		static CountSelectionTokenStream create(QueryTokenStream selection) {
+
+			List<QueryToken> target = new ArrayList<>(selection.size());
+			boolean skipNext = false;
+			boolean containsNew = false;
+
+			for (QueryToken token : selection) {
+
+				if (skipNext) {
+					skipNext = false;
+					continue;
+				}
+
+				if (token.equals(TOKEN_AS)) {
+					skipNext = true;
+					continue;
+				}
+
+				if (!token.equals(TOKEN_COMMA) && token.isExpression()) {
+					token = QueryTokens.token(token.value());
+				}
+
+				if (!containsNew && token.value().contains("new")) {
+					containsNew = true;
+				}
+
+				target.add(token);
+			}
+
+			return new CountSelectionTokenStream(target, containsNew);
 		}
 
 		@Override

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/EqlQueryTransformerTests.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/EqlQueryTransformerTests.java
@@ -98,7 +98,7 @@ class EqlQueryTransformerTests {
 	}
 
 	@Test
-	void applyCountToAlreadySorteQuery() {
+	void applyCountToAlreadySortedQuery() {
 
 		// given
 		var original = "SELECT e FROM Employee e where e.name = :name ORDER BY e.modified_date";

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/JpqlQueryTransformerTests.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/JpqlQueryTransformerTests.java
@@ -99,7 +99,7 @@ class JpqlQueryTransformerTests {
 	}
 
 	@Test
-	void applyCountToAlreadySorteQuery() {
+	void applyCountToAlreadySortedQuery() {
 
 		// given
 		var original = "SELECT e FROM Employee e where e.name = :name ORDER BY e.modified_date";


### PR DESCRIPTION
We now no longer apply count selection filtering but rather skip select field aliasing when rendering a count query to drop the field alias within a count query.

Previously, we removed field aliasing by filtering the token stream, which also removed the AS keyword from cast operators.

Closes #3536