### PR TITLE
Code Clean-Up and Refactoring Suggestions in JpaMetamodel

### DIFF
--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/util/JpaMetamodel.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/util/JpaMetamodel.java
@@ -17,6 +17,7 @@ package org.springframework.data.jpa.util;
 
 import java.util.Collection;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -38,6 +39,7 @@ import org.springframework.util.Assert;
  * @author Oliver Gierke
  * @author Mark Paluch
  * @author Sylvère Richard
+ * @author Aref Behboodi
  */
 public class JpaMetamodel {
 
@@ -45,8 +47,8 @@ public class JpaMetamodel {
 
 	private final Metamodel metamodel;
 
-	private Lazy<Collection<Class<?>>> managedTypes;
-	private Lazy<Collection<Class<?>>> jpaEmbeddables;
+	private final Lazy<Collection<Class<?>>> managedTypes;
+	private final Lazy<Collection<Class<?>>> jpaEmbeddables;
 
 	/**
 	 * Creates a new {@link JpaMetamodel} for the given JPA {@link Metamodel}.
@@ -61,12 +63,12 @@ public class JpaMetamodel {
 
 		this.managedTypes = Lazy.of(() -> metamodel.getManagedTypes().stream() //
 				.map(ManagedType::getJavaType) //
-				.filter(it -> it != null) //
+				.filter(Objects::nonNull) //
 				.collect(StreamUtils.toUnmodifiableSet()));
 
 		this.jpaEmbeddables = Lazy.of(() -> metamodel.getEmbeddables().stream() //
 				.map(ManagedType::getJavaType)
-				.filter(it -> it != null)
+				.filter(Objects::nonNull)
 				.filter(it -> AnnotatedElementUtils.isAnnotated(it, Embeddable.class))
 				.collect(StreamUtils.toUnmodifiableSet()));
 	}
@@ -101,7 +103,7 @@ public class JpaMetamodel {
 		return metamodel.getEntities().stream() //
 				.filter(it -> entity.equals(it.getJavaType())) //
 				.findFirst() //
-				.flatMap(it -> getSingularIdAttribute(it)) //
+				.flatMap(JpaMetamodel::getSingularIdAttribute) //
 				.filter(it -> it.getJavaType().equals(attributeType)) //
 				.map(it -> it.getName().equals(name)) //
 				.orElse(false);


### PR DESCRIPTION
This pull request includes minor improvements to the JpaMetamodel for better readability and maintainability:

1. Defined `managedTypes` and `jpaEmbeddables` fields as final.
2. Replaced lambda expressions with method references where applicable.

Closes [#3555](https://github.com/spring-projects/spring-data-jpa/issues/3555)