### PR TITLE
Optimize entity deletion in SimpleJpaRepository

### DIFF
--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/support/SimpleJpaRepository.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/support/SimpleJpaRepository.java
@@ -93,6 +93,7 @@ import org.springframework.util.Assert;
  * @author Yanming Zhou
  * @author Ernst-Jan van der Laan
  * @author Diego Krupitza
+ * @author Seol-JY
  */
 @Repository
 @Transactional(readOnly = true)

--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/support/SimpleJpaRepository.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/support/SimpleJpaRepository.java
@@ -196,14 +196,16 @@ public class SimpleJpaRepository<T, ID> implements JpaRepositoryImplementation<T
 
 		Class<?> type = ProxyUtils.getUserClass(entity);
 
-		T existing = (T) entityManager.find(type, entityInformation.getId(entity));
-
-		// if the entity to be deleted doesn't exist, delete is a NOOP
-		if (existing == null) {
+		if (entityManager.contains(entity)) {
+			entityManager.remove(entity);
 			return;
 		}
 
-		entityManager.remove(entityManager.contains(entity) ? entity : entityManager.merge(entity));
+		// if the entity to be deleted doesn't exist, delete is a NOOP
+		T existing = (T) entityManager.find(type, entityInformation.getId(entity));
+		if (existing != null) {
+			entityManager.remove(entityManager.merge(entity));
+		}
 	}
 
 	@Override


### PR DESCRIPTION
Optimize the `delete` method in `SimpleJpaRepository` to improve performance in certain scenarios. The main change is to first check if the entity is already managed by the EntityManager before performing any database operations.

- Reordered the deletion logic to prioritize managed entities
- Added a check for `entityManager.contains(entity)` at the beginning of the method
- Moved the database lookup (`entityManager.find()`) to only occur for non-managed entities

The goal of this change is to reduce unnecessary database lookups when deleting managed entities, potentially improving performance in high-throughput scenarios.

I think this optimization is particularly effective when using the `deleteById` method:

Please point out any potential risks or edge cases where this change might lead to unexpected behavior.