### PR TITLE
Fix typo in assertion message

### DIFF
--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/support/SimpleJpaRepository.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/support/SimpleJpaRepository.java
@@ -590,7 +590,7 @@ public class SimpleJpaRepository<T, ID> implements JpaRepositoryImplementation<T
 	@Override
 	public <S extends T, R> R findBy(Example<S> example, Function<FetchableFluentQuery<S>, R> queryFunction) {
 
-		Assert.notNull(example, "Sample must not be null");
+		Assert.notNull(example, "Example must not be null");
 		Assert.notNull(queryFunction, "Query function must not be null");
 
 		ExampleSpecification<S> spec = new ExampleSpecification<>(example, escapeCharacter);


### PR DESCRIPTION
Addresses a minor typographical error in the assertion message within the code. The message "Sample must not be null" has been corrected to "Example must not be null".