### PR TITLE
Enhance BeanDefinitionNames with additional bean names

### DIFF
--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/domain/support/AuditingBeanFactoryPostProcessor.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/domain/support/AuditingBeanFactoryPostProcessor.java
@@ -15,6 +15,7 @@
  */
 package org.springframework.data.jpa.domain.support;
 
+import static org.springframework.context.annotation.aspectj.SpringConfiguredConfiguration.*;
 import static org.springframework.data.jpa.util.BeanDefinitionUtils.*;
 import static org.springframework.util.StringUtils.*;
 
@@ -34,8 +35,6 @@ import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
  * @author Thomas Darimont
  */
 public class AuditingBeanFactoryPostProcessor implements BeanFactoryPostProcessor {
-
-	public static final String BEAN_CONFIGURER_ASPECT_BEAN_NAME = "org.springframework.context.config.internalBeanConfigurerAspect";
 
 	@Override
 	public void postProcessBeanFactory(ConfigurableListableBeanFactory beanFactory) {

--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/config/AuditingBeanDefinitionParser.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/config/AuditingBeanDefinitionParser.java
@@ -16,6 +16,7 @@
 package org.springframework.data.jpa.repository.config;
 
 import static org.springframework.beans.factory.support.BeanDefinitionBuilder.*;
+import static org.springframework.data.jpa.repository.config.BeanDefinitionNames.*;
 
 import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.beans.factory.parsing.BeanComponentDefinition;
@@ -81,12 +82,6 @@ public class AuditingBeanDefinitionParser implements BeanDefinitionParser {
 	 * @author Juergen Hoeller
 	 */
 	private static class SpringConfiguredBeanDefinitionParser implements BeanDefinitionParser {
-
-		/**
-		 * The bean name of the internally managed bean configurer aspect.
-		 */
-		private static final String BEAN_CONFIGURER_ASPECT_BEAN_NAME = "org.springframework.context.config.internalBeanConfigurerAspect";
-
 		private static final String BEAN_CONFIGURER_ASPECT_CLASS_NAME = "org.springframework.beans.factory.aspectj.AnnotationBeanConfigurerAspect";
 
 		@Override

--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/config/BeanDefinitionNames.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/config/BeanDefinitionNames.java
@@ -27,4 +27,6 @@ interface BeanDefinitionNames {
 	String JPA_MAPPING_CONTEXT_BEAN_NAME = "jpaMappingContext";
 	String JPA_CONTEXT_BEAN_NAME = "jpaContext";
 	String EM_BEAN_DEFINITION_REGISTRAR_POST_PROCESSOR_BEAN_NAME = "emBeanDefinitionRegistrarPostProcessor";
+	String DEFAULT_TRANSACTION_MANAGER_BEAN_NAME = "transactionManager";
+	String BEAN_CONFIGURER_ASPECT_BEAN_NAME = "org.springframework.context.config.internalBeanConfigurerAspect";
 }

--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/config/JpaRepositoryConfigExtension.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/config/JpaRepositoryConfigExtension.java
@@ -79,7 +79,6 @@ import org.springframework.util.StringUtils;
 public class JpaRepositoryConfigExtension extends RepositoryConfigurationExtensionSupport {
 
 	private static final Class<?> PAB_POST_PROCESSOR = PersistenceAnnotationBeanPostProcessor.class;
-	private static final String DEFAULT_TRANSACTION_MANAGER_BEAN_NAME = "transactionManager";
 	private static final String ENABLE_DEFAULT_TRANSACTIONS_ATTRIBUTE = "enableDefaultTransactions";
 	private static final String JPA_METAMODEL_CACHE_CLEANUP_CLASSNAME = "org.springframework.data.jpa.util.JpaMetamodelCacheCleanup";
 	private static final String ESCAPE_CHARACTER_PROPERTY = "escapeCharacter";

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/domain/support/AuditingBeanFactoryPostProcessorUnitTests.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/domain/support/AuditingBeanFactoryPostProcessorUnitTests.java
@@ -16,6 +16,7 @@
 package org.springframework.data.jpa.domain.support;
 
 import static org.assertj.core.api.Assertions.*;
+import static org.springframework.context.annotation.aspectj.SpringConfiguredConfiguration.*;
 
 import jakarta.persistence.EntityManagerFactory;
 
@@ -63,7 +64,7 @@ class AuditingBeanFactoryPostProcessorUnitTests {
 
 		processor.postProcessBeanFactory(beanFactory);
 
-		assertThat(beanFactory.isBeanNameInUse(AuditingBeanFactoryPostProcessor.BEAN_CONFIGURER_ASPECT_BEAN_NAME)).isTrue();
+		assertThat(beanFactory.isBeanNameInUse(BEAN_CONFIGURER_ASPECT_BEAN_NAME)).isTrue();
 	}
 
 	@Test // DATAJPA-265
@@ -83,7 +84,7 @@ class AuditingBeanFactoryPostProcessorUnitTests {
 			BeanDefinition emfDefinition = beanFactory.getBeanDefinition(emfDefinitionName);
 			assertThat(emfDefinition).isNotNull();
 			assertThat(emfDefinition.getDependsOn())
-					.containsExactly(AuditingBeanFactoryPostProcessor.BEAN_CONFIGURER_ASPECT_BEAN_NAME);
+					.containsExactly(BEAN_CONFIGURER_ASPECT_BEAN_NAME);
 		}
 	}
 

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/config/JpaAuditingRegistrarUnitTests.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/config/JpaAuditingRegistrarUnitTests.java
@@ -17,6 +17,7 @@ package org.springframework.data.jpa.repository.config;
 
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.Mockito.*;
+import static org.springframework.data.jpa.repository.config.BeanDefinitionNames.*;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -67,7 +68,7 @@ class JpaAuditingRegistrarUnitTests {
 		AnnotationMetadata annotationMetadata = reader.getAnnotationMetadata();
 
 		// Given a bean already present
-		String beanName = AuditingBeanFactoryPostProcessor.BEAN_CONFIGURER_ASPECT_BEAN_NAME;
+		String beanName = BEAN_CONFIGURER_ASPECT_BEAN_NAME;
 		when(registry.containsBeanDefinition(beanName)).thenReturn(true);
 
 		// When invoking configuration


### PR DESCRIPTION
Enhance BeanDefinitionNames with additional bean names

- Add missing bean names to BeanDefinitionNames interface
- Improve code organization and readability
- Ensure all commonly used bean names are centralized

This change helps maintain a single source of truth for bean names used throughout the Spring Data JPA module, reducing the risk of typos and inconsistencies in bean name references.

```java
interface BeanDefinitionNames {
	String JPA_MAPPING_CONTEXT_BEAN_NAME = "jpaMappingContext";
	String JPA_CONTEXT_BEAN_NAME = "jpaContext";
	String EM_BEAN_DEFINITION_REGISTRAR_POST_PROCESSOR_BEAN_NAME = "emBeanDefinitionRegistrarPostProcessor";
	String DEFAULT_TRANSACTION_MANAGER_BEAN_NAME = "transactionManager";
	String BEAN_CONFIGURER_ASPECT_BEAN_NAME = "org.springframework.context.config.internalBeanConfigurerAspect";
}
```