### PR TITLE
Refactor type checks and improve code readability

### DIFF
--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/config/JpaRepositoryConfigExtension.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/config/JpaRepositoryConfigExtension.java
@@ -195,7 +195,7 @@ public class JpaRepositoryConfigExtension extends RepositoryConfigurationExtensi
 
 		registerIfNotAlreadyRegistered(() -> {
 
-			Object value = AnnotationRepositoryConfigurationSource.class.isInstance(config) //
+			Object value = config instanceof AnnotationRepositoryConfigurationSource //
 					? config.getRequiredAttribute(ESCAPE_CHARACTER_PROPERTY, Character.class) //
 					: config.getAttribute(ESCAPE_CHARACTER_PROPERTY).orElse("\\");
 

--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/support/EntityManagerBeanDefinitionRegistrarPostProcessor.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/support/EntityManagerBeanDefinitionRegistrarPostProcessor.java
@@ -55,13 +55,7 @@ public class EntityManagerBeanDefinitionRegistrarPostProcessor implements BeanFa
 	@Override
 	public void postProcessBeanFactory(ConfigurableListableBeanFactory beanFactory) throws BeansException {
 
-		if (!ConfigurableListableBeanFactory.class.isInstance(beanFactory)) {
-			return;
-		}
-
-		ConfigurableListableBeanFactory factory = beanFactory;
-
-		for (EntityManagerFactoryBeanDefinition definition : getEntityManagerFactoryBeanDefinitions(factory)) {
+		for (EntityManagerFactoryBeanDefinition definition : getEntityManagerFactoryBeanDefinitions(beanFactory)) {
 
 			BeanFactory definitionFactory = definition.getBeanFactory();
 

--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/support/SimpleJpaRepository.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/support/SimpleJpaRepository.java
@@ -247,7 +247,7 @@ public class SimpleJpaRepository<T, ID> implements JpaRepositoryImplementation<T
 			 * Some JPA providers require {@code ids} to be a {@link Collection} so we must convert if it's not already.
 			 */
 
-			if (Collection.class.isInstance(ids)) {
+			if (ids instanceof Collection) {
 				query.setParameter("ids", ids);
 			} else {
 				Collection<ID> idsCollection = StreamSupport.stream(ids.spliterator(), false)


### PR DESCRIPTION
- Replace isInstance() method calls with instanceof operator for improved readability
- Remove unnecessary type checks and castings in postProcessBeanFactory method

Some changes to `instanceof refactoring` are already covered here https://github.com/spring-projects/spring-data-jpa/pull/3465