### PR TITLE
Enhance Batch Deletion Logic by Handling Entities and IDs in Persistence Context

### DIFF
--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/support/SimpleJpaRepository.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/support/SimpleJpaRepository.java
@@ -93,6 +93,7 @@ import org.springframework.util.Assert;
  * @author Ernst-Jan van der Laan
  * @author Diego Krupitza
  * @author Seol-JY
+ * @author SangMin Lee
  */
 @Repository
 @Transactional(readOnly = true)

--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/support/SimpleJpaRepository.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/support/SimpleJpaRepository.java
@@ -275,6 +275,15 @@ public class SimpleJpaRepository<T, ID> implements JpaRepositoryImplementation<T
 			return;
 		}
 
+		for (T entity : entities) {
+			if (entityManager.contains(entity)) {
+				entityManager.remove(entity);
+				entityManager.detach(entity);
+			}
+		}
+
+		entityManager.clear();
+
 		applyAndBind(getQueryString(DELETE_ALL_QUERY_STRING, entityInformation.getEntityName()), entities, entityManager)
 				.executeUpdate();
 	}

--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/support/SimpleJpaRepository.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/support/SimpleJpaRepository.java
@@ -237,6 +237,15 @@ public class SimpleJpaRepository<T, ID> implements JpaRepositoryImplementation<T
 			deleteAllInBatch(entities);
 		} else {
 
+			ids.forEach(id -> {
+				T entity = entityManager.find(entityInformation.getJavaType(), id);
+				if (entity != null) {
+					entityManager.remove(entity);
+				}
+			});
+
+			entityManager.clear();
+
 			String queryString = String.format(DELETE_ALL_QUERY_BY_ID_STRING, entityInformation.getEntityName(),
 					entityInformation.getIdAttribute().getName());
 

--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/support/SimpleJpaRepository.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/support/SimpleJpaRepository.java
@@ -288,7 +288,6 @@ public class SimpleJpaRepository<T, ID> implements JpaRepositoryImplementation<T
 		for (T entity : entities) {
 			if (entityManager.contains(entity)) {
 				entityManager.remove(entity);
-				entityManager.detach(entity);
 			}
 		}
 

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/UserRepositoryTests.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/UserRepositoryTests.java
@@ -3416,6 +3416,20 @@ class UserRepositoryTests {
 				.map(User::getAge).contains(30);
 	}
 
+	@Test // GH-3360
+	void removeWhenDeleteAllInBatchWithEntities() {
+
+		flushTestUsers();
+		List<User> userList = repository.findAll();
+
+		repository.deleteAllInBatch(userList);
+
+		userList.forEach(user ->
+				assertThat(em.contains(user)).isFalse()
+		);
+
+	}
+
 	private Page<User> executeSpecWithSort(Sort sort) {
 
 		flushTestUsers();

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/UserRepositoryTests.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/UserRepositoryTests.java
@@ -97,6 +97,7 @@ import org.springframework.transaction.annotation.Transactional;
  * @author Geoffrey Deremetz
  * @author Krzysztof Krason
  * @author Yanming Zhou
+ * @author SangMin Lee
  */
 @ExtendWith(SpringExtension.class)
 @ContextConfiguration("classpath:application-context.xml")

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/UserRepositoryTests.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/UserRepositoryTests.java
@@ -3430,6 +3430,21 @@ class UserRepositoryTests {
 
 	}
 
+	@Test // GH-3360
+	void removeWhenDeleteAllByIdInBatch() {
+
+		flushTestUsers();
+		List<User> userList = repository.findAll();
+		List<Integer> userIds = userList.stream().map(User::getId).toList();
+
+		repository.deleteAllByIdInBatch(userIds);
+
+		userList.forEach(user ->
+				assertThat(em.contains(user)).isFalse()
+		);
+
+	}
+
 	private Page<User> executeSpecWithSort(Sort sort) {
 
 		flushTestUsers();


### PR DESCRIPTION
<!--

Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
Make sure that:

-->

This contribution improves the batch deletion functionality in JPA repositories by ensuring that both entities and their IDs passed to deleteAllInBatch and deleteAllByIdInBatch methods are properly handled within the persistence context.

related: #3360 

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
