### PR TITLE
Fix `limit` of `FetchableFluentQueryBySpecification`.

### DIFF
--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/support/FetchableFluentQueryBySpecification.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/support/FetchableFluentQueryBySpecification.java
@@ -98,7 +98,7 @@ class FetchableFluentQueryBySpecification<S, R> extends FluentQuerySupport<S, R>
 
 		Assert.isTrue(limit >= 0, "Limit must not be negative");
 
-		return new FetchableFluentQueryBySpecification<>(spec, entityType, resultType, this.sort.and(sort), limit,
+		return new FetchableFluentQueryBySpecification<>(spec, entityType, resultType, sort, limit,
 				properties, finder, scroll, countOperation, existsOperation, entityManager, projectionFactory);
 	}
 


### PR DESCRIPTION
A very simple fix that closes #3600

This fix makes the two implementations of `FluentQuery.FetchableFluentQuery` behave the same (which they formerly don't), so I think it's not an API change.

<!--

Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
Make sure that:

-->

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [ ] You submit test cases (unit or integration tests) that back your changes.
- [ ] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
