### PR TITLE
Improve detection of entity state

### DIFF
--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/domain/sample/SampleWithPrimitiveVersion.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/domain/sample/SampleWithPrimitiveVersion.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2013-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.jpa.domain.sample;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Version;
+
+/**
+ * @author Yanming Zhou
+ */
+@Entity
+public class SampleWithPrimitiveVersion {
+
+	@Id private Long id;
+
+	@Version private long version = -1;
+
+	public void setId(Long id) {
+		this.id = id;
+	}
+
+	public long getVersion() {
+		return version;
+	}
+
+	public void setVersion(long version) {
+		this.version = version;
+	}
+}

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/support/EclipseLinkJpaMetamodelEntityInformationIntegrationTests.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/support/EclipseLinkJpaMetamodelEntityInformationIntegrationTests.java
@@ -24,6 +24,8 @@ import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.data.jpa.domain.AbstractPersistable;
+import org.springframework.data.jpa.domain.sample.SampleWithPrimitiveVersion;
+import org.springframework.data.repository.core.EntityInformation;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
@@ -33,6 +35,7 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
  * @author Oliver Gierke
  * @author Jens Schauder
  * @author Greg Turnquist
+ * @author Yanming Zhou
  */
 @ExtendWith(SpringExtension.class)
 @ContextConfiguration({ "classpath:infrastructure.xml", "classpath:eclipselink.xml" })
@@ -79,4 +82,21 @@ class EclipseLinkJpaMetamodelEntityInformationIntegrationTests extends JpaMetamo
 	@Override
 	@Disabled
 	void prefersPrivateGetterOverFieldAccess() {}
+
+	@Override
+	@Disabled
+	// superseded by #nonPositiveVersionedEntityIsNew()
+	void considersEntityAsNotNewWhenHavingIdSetAndUsingPrimitiveTypeForVersionProperty() {}
+
+	@Test
+	void nonPositiveVersionedEntityIsNew() {
+		EntityInformation<SampleWithPrimitiveVersion, Long> information = new JpaMetamodelEntityInformation<>(SampleWithPrimitiveVersion.class,
+				em.getMetamodel(), em.getEntityManagerFactory().getPersistenceUnitUtil());
+
+		SampleWithPrimitiveVersion entity = new SampleWithPrimitiveVersion();
+		entity.setId(23L); // assigned
+		assertThat(information.isNew(entity)).isTrue();
+		entity.setVersion(0);
+		assertThat(information.isNew(entity)).isTrue();
+	}
 }

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/support/HibernateJpaMetamodelEntityInformationIntegrationTests.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/support/HibernateJpaMetamodelEntityInformationIntegrationTests.java
@@ -17,14 +17,19 @@ package org.springframework.data.jpa.repository.support;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.data.jpa.domain.sample.SampleWithPrimitiveVersion;
 import org.springframework.data.jpa.util.DisabledOnHibernate61;
+import org.springframework.data.repository.core.EntityInformation;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Hibernate execution for {@link JpaMetamodelEntityInformationIntegrationTests}.
  *
  * @author Greg Turnquist
+ * @author Yanming Zhou
  */
 @ExtendWith(SpringExtension.class)
 @ContextConfiguration("classpath:infrastructure.xml")
@@ -54,5 +59,15 @@ class HibernateJpaMetamodelEntityInformationIntegrationTests extends JpaMetamode
 	@Override
 	void findsIdClassOnMappedSuperclass() {
 		super.findsIdClassOnMappedSuperclass();
+	}
+
+	@Test
+	void negativeVersionedEntityIsNew() {
+		EntityInformation<SampleWithPrimitiveVersion, Long> information = new JpaMetamodelEntityInformation<>(SampleWithPrimitiveVersion.class,
+				em.getMetamodel(), em.getEntityManagerFactory().getPersistenceUnitUtil());
+
+		SampleWithPrimitiveVersion entity = new SampleWithPrimitiveVersion();
+		entity.setId(23L); // assigned
+		assertThat(information.isNew(entity)).isTrue();
 	}
 }

--- a/spring-data-jpa/src/test/resources/META-INF/persistence.xml
+++ b/spring-data-jpa/src/test/resources/META-INF/persistence.xml
@@ -46,6 +46,7 @@
 		<class>org.springframework.data.jpa.domain.sample.SampleEntityPK</class>
 		<class>org.springframework.data.jpa.domain.sample.SampleWithIdClass</class>
 		<class>org.springframework.data.jpa.domain.sample.SampleWithPrimitiveId</class>
+		<class>org.springframework.data.jpa.domain.sample.SampleWithPrimitiveVersion</class>
 		<class>org.springframework.data.jpa.domain.sample.SampleWithTimestampVersion</class>
 		<class>org.springframework.data.jpa.domain.sample.Site</class>
 		<class>org.springframework.data.jpa.domain.sample.SpecialUser</class>


### PR DESCRIPTION
Hibernate use 0 or user provided positive initial value as seed of integer version. 
EclipseLink always use 1 as seed of integer version.
