### PR TITLE
Remove unnecessary semicolons from the `Instant` field of the `DefaultRevisionMetadataUnitTests` class

### DIFF
--- a/spring-data-envers/src/test/java/org/springframework/data/envers/repository/support/DefaultRevisionMetadataUnitTests.java
+++ b/spring-data-envers/src/test/java/org/springframework/data/envers/repository/support/DefaultRevisionMetadataUnitTests.java
@@ -31,10 +31,11 @@ import org.junit.jupiter.api.Test;
  * @author Benedikt Ritter
  * @author Jens Schauder
  * @author Mark Paluch
+ * @author Seungjun Choi
  */
 class DefaultRevisionMetadataUnitTests {
 
-	private static final Instant NOW = Instant.now();;
+	private static final Instant NOW = Instant.now();
 
 	@Test // #112
 	void createsLocalDateTimeFromTimestamp() {


### PR DESCRIPTION
Closes #3669 

```java
class DefaultRevisionMetadataUnitTests {

	private static final Instant NOW = Instant.now();;
```
I found a semicolon in the Instant field of the DefaultRevisionMetadataUnitTests class that is being used unnecessarily.

```java
class DefaultRevisionMetadataUnitTests {

	private static final Instant NOW = Instant.now();
```
So I tried to remove one unnecessary semicolon.