### PR TITLE
Fix NEGATING_SIMPLE_PROPERTY to use IS NOT NULL when argument is null

### DIFF
--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/JpaQueryCreator.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/JpaQueryCreator.java
@@ -56,6 +56,7 @@ import org.springframework.util.Assert;
  * @author Moritz Becker
  * @author Andrey Kovalev
  * @author Greg Turnquist
+ * @author Jinmyeong Kim
  */
 public class JpaQueryCreator extends AbstractQueryCreator<CriteriaQuery<? extends Object>, Predicate> {
 
@@ -311,8 +312,10 @@ public class JpaQueryCreator extends AbstractQueryCreator<CriteriaQuery<? extend
 					return expression.isIsNullParameter() ? path.isNull()
 							: builder.equal(upperIfIgnoreCase(path), upperIfIgnoreCase(expression.getExpression()));
 				case NEGATING_SIMPLE_PROPERTY:
-					return builder.notEqual(upperIfIgnoreCase(getTypedPath(root, part)),
-							upperIfIgnoreCase(provider.next(part).getExpression()));
+					ParameterMetadata<Object> negatedExpression = provider.next(part);
+					Expression<Object> negatedPath = getTypedPath(root, part);
+					return negatedExpression.isIsNullParameter() ? negatedPath.isNotNull()
+							: builder.notEqual(upperIfIgnoreCase(negatedPath), upperIfIgnoreCase(negatedExpression.getExpression()));
 				case IS_EMPTY:
 				case IS_NOT_EMPTY:
 


### PR DESCRIPTION
When a query method uses NEGATING_SIMPLE_PROPERTY and the argument is null, the generated query should now use `IS NOT NULL` instead of `<>`. This ensures consistent behavior when handling null values across queries.

Changes:
- Updated `JpaQueryCreator` to handle null arguments in `NEGATING_SIMPLE_PROPERTY` by rewriting `<>` to `IS NOT NULL`.

Closes #3675

<!--

Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
Make sure that:

-->

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [ ] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
