### PR TITLE
Fix Hql-Queries using CEILING and LN.

### DIFF
--- a/spring-data-jpa/src/main/antlr4/org/springframework/data/jpa/repository/query/Hql.g4
+++ b/spring-data-jpa/src/main/antlr4/org/springframework/data/jpa/repository/query/Hql.g4
@@ -25,7 +25,7 @@ grammar Hql;
  * management of complex rules in the generated Visitor. Finally, there are labels applied to rule elements (op=('+'|'-')
  * to simplify the processing.
  *
- * @author Greg Turnquist
+ * @author Greg Turnquist, Yannick Brandt
  * @since 3.1
  */
 }

--- a/spring-data-jpa/src/main/antlr4/org/springframework/data/jpa/repository/query/Hql.g4
+++ b/spring-data-jpa/src/main/antlr4/org/springframework/data/jpa/repository/query/Hql.g4
@@ -1133,6 +1133,7 @@ reservedWord
     | BY
     | CASE
     | CAST
+    | CEILING
     | COLLATE
     | CONTAINS
     | COUNT
@@ -1206,6 +1207,7 @@ reservedWord
     | LIMIT
     | LIST
     | LISTAGG
+    | LN
     | LOCAL
     | LOCAL_DATE
     | LOCAL_DATETIME

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/HqlQueryRendererTests.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/HqlQueryRendererTests.java
@@ -1509,6 +1509,16 @@ class HqlQueryRendererTests {
 		});
 	}
 
+	@Test
+	void ceilingFunctionShouldWork() {
+		assertQuery("select ceiling(1.5) from Element a");
+	}
+
+	@Test
+	void lnFunctionSouldWork() {
+		assertQuery("select ln(7.5) from Element a");
+	}
+
 	@Test // GH-2981
 	void cteWithClauseShouldWork() {
 

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/HqlQueryRendererTests.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/HqlQueryRendererTests.java
@@ -37,7 +37,7 @@ import org.junit.jupiter.params.provider.ValueSource;
  *
  * @author Greg Turnquist
  * @author Christoph Strobl
- * @author Mark Paluch
+ * @author Mark Paluch, Yannick Brandt
  * @since 3.1
  */
 class HqlQueryRendererTests {


### PR DESCRIPTION
The Hibernate functions [ceiling](https://docs.jboss.org/hibernate/stable/orm/userguide/html_single/Hibernate_User_Guide.html#:~:text=%E2%9C%93-,ceiling(),-Ceiling%20function) and [ln](https://docs.jboss.org/hibernate/stable/orm/userguide/html_single/Hibernate_User_Guide.html#:~:text=%E2%9C%93-,ln(),-Natural%20logarithm) are currently breaking the spring-data Query validation.

Problem: CEILING and LN were defined as reserved identifiers in the hql grammar file but never used.
Solution: This Pull Request adds CEILING and LN to the List of reserved words for use as a function name or identifier.

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
