### PR TITLE
refactor: Improve exists check in JpaQueryExecution

### DIFF
--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/JpaQueryExecution.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/JpaQueryExecution.java
@@ -313,7 +313,10 @@ public abstract class JpaQueryExecution {
 
 		@Override
 		protected Object doExecute(AbstractJpaQuery query, JpaParametersParameterAccessor accessor) {
-			return !query.createQuery(accessor).getResultList().isEmpty();
+			return query.createQuery(accessor)
+					.getResultStream()
+					.findFirst()
+					.isPresent();
 		}
 	}
 


### PR DESCRIPTION
### Changes
Updated getResultList().isEmpty() to getResultStream().findFirst().isPresent() for checking query existence.
Improved performance by processing only the first result.

### Reason

It seems that this method is only meant to check if the query exists. Therefore, fetching the entire query result does not seem necessary.
Avoids loading all results into memory, reducing overhead and improving efficiency.

### Testing
Verified with existing test cases, ensuring identical results.

### Review Request
Please review and share any feedback. 🙇‍♂️