### PR TITLE
Clarify transaction boundary recommendation

### DIFF
--- a/src/main/antora/modules/ROOT/pages/jpa/transactions.adoc
+++ b/src/main/antora/modules/ROOT/pages/jpa/transactions.adoc
@@ -89,3 +89,7 @@ Typically, you want the `readOnly` flag to be set to `true`, as most of the quer
 You can use transactions for read-only queries and mark them as such by setting the `readOnly` flag. Doing so does not, however, act as a check that you do not trigger a manipulating query (although some databases reject `INSERT` and `UPDATE` statements inside a read-only transaction). The `readOnly` flag is instead propagated as a hint to the underlying JDBC driver for performance optimizations. Furthermore, Spring performs some optimizations on the underlying JPA provider. For example, when used with Hibernate, the flush mode is set to `NEVER` when you configure a transaction as `readOnly`, which causes Hibernate to skip dirty checks (a noticeable improvement on large object trees).
 ====
 
+[NOTE]
+====
+While this example shows `@Transactional` on the repository interface, we generally recommend defining transaction boundaries at the service layer to reflect business logic units and ensure consistency.
+====


### PR DESCRIPTION
This PR clarifies the intent of the documentation regarding the usage of `@Transactional` in the repository layer.

It adds a note to explain that while the example shows `@Transactional` on repository methods for read-only defaults, it is generally recommended to define transaction boundaries at the service layer to reflect business logic and ensure proper control.

Fixes #3842

<!--

Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
Make sure that:

-->

- [ ] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [ ] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [ ] You submit test cases (unit or integration tests) that back your changes.
- [ ] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
