### PR TITLE
Fix handling of null predicate in Specification.not()

### DIFF
--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/domain/Specification.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/domain/Specification.java
@@ -56,7 +56,13 @@ public interface Specification<T> extends Serializable {
 
 		return spec == null //
 				? (root, query, builder) -> null //
-				: (root, query, builder) -> builder.not(spec.toPredicate(root, query, builder));
+				: (root, query, builder) -> {
+			Predicate predicate = spec.toPredicate(root, query, builder);
+			if(predicate != null) {
+				return builder.not(predicate);
+			}
+			return builder.disjunction();
+		};
 	}
 
 	/**

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/domain/SpecificationUnitTests.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/domain/SpecificationUnitTests.java
@@ -214,6 +214,17 @@ class SpecificationUnitTests {
 		verify(builder).or(firstPredicate, secondPredicate);
 	}
 
+	@Test // #3849
+	void notWithNullPredicate() {
+		Specification<Object> spec = (r, q, cb) -> null;
+
+		Specification<Object> notSpec = Specification.not(spec);
+
+		notSpec.toPredicate(root, query, builder);
+		
+		verify(builder).disjunction();
+	}
+
 	static class SerializableSpecification implements Serializable, Specification<Object> {
 
 		@Override


### PR DESCRIPTION
When toPredicate() returns null, Specification.not() now returns builder.disjunction() instead of builder.not(null). This change ensures proper handling of null predicates in negated specifications.

Closes #3849
