### PR TITLE
GH-3864: Add support for Set-Returning Functions (SRF) in HQL parser

### DIFF
--- a/spring-data-jpa/src/main/antlr4/org/springframework/data/jpa/repository/query/Hql.g4
+++ b/spring-data-jpa/src/main/antlr4/org/springframework/data/jpa/repository/query/Hql.g4
@@ -114,7 +114,12 @@ joinSpecifier
 fromRoot
     : entityName variable?
     | LATERAL? '(' subquery ')' variable?
+    | functionCallAsFromSource variable?
     ;
+
+functionCallAsFromSource
+    : identifier '(' (expression (',' expression)*)? ')'
+    ;    
 
 join
     : joinType JOIN FETCH? joinTarget joinRestriction? // Spec BNF says joinType isn't optional, but text says that it is.
@@ -123,6 +128,11 @@ join
 joinTarget
     : path variable?                        # JoinPath
     | LATERAL? '(' subquery ')' variable?   # JoinSubquery
+    | functionCallAsJoinTarget variable?    # JoinFunctionCall
+    ;
+
+functionCallAsJoinTarget
+    : identifier '(' (expression (',' expression)*)? ')'
     ;
 
 // https://docs.jboss.org/hibernate/orm/6.1/userguide/html_single/Hibernate_User_Guide.html#hql-update

--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/HibernateQueryInformation.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/HibernateQueryInformation.java
@@ -23,19 +23,29 @@ import org.springframework.lang.Nullable;
  * Hibernate-specific query details capturing common table expression details.
  *
  * @author Mark Paluch
+ * @author oscar.fanchin
  * @since 3.5
  */
 class HibernateQueryInformation extends QueryInformation {
 
 	private final boolean hasCte;
+	
+	private final boolean hasFromFunction;
+	
 
 	public HibernateQueryInformation(@Nullable String alias, List<QueryToken> projection,
-			boolean hasConstructorExpression, boolean hasCte) {
+			boolean hasConstructorExpression, boolean hasCte,boolean hasFromFunction) {
 		super(alias, projection, hasConstructorExpression);
 		this.hasCte = hasCte;
+		this.hasFromFunction = hasFromFunction;
 	}
 
 	public boolean hasCte() {
 		return hasCte;
 	}
+	
+	public boolean hasFromFunction() {
+		return hasFromFunction;
+	}
+	
 }

--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/HqlQueryIntrospector.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/HqlQueryIntrospector.java
@@ -28,6 +28,7 @@ import org.springframework.lang.Nullable;
  * {@link ParsedQueryIntrospector} for HQL queries.
  *
  * @author Mark Paluch
+ * @author oscar.fanchin
  */
 @SuppressWarnings({ "UnreachableCode", "ConstantValue" })
 class HqlQueryIntrospector extends HqlBaseVisitor<Void> implements ParsedQueryIntrospector<HibernateQueryInformation> {
@@ -39,11 +40,12 @@ class HqlQueryIntrospector extends HqlBaseVisitor<Void> implements ParsedQueryIn
 	private boolean projectionProcessed;
 	private boolean hasConstructorExpression = false;
 	private boolean hasCte = false;
+	private boolean hasFromFunction = false;
 
 	@Override
 	public HibernateQueryInformation getParsedQueryInformation() {
 		return new HibernateQueryInformation(primaryFromAlias, projection == null ? Collections.emptyList() : projection,
-				hasConstructorExpression, hasCte);
+				hasConstructorExpression, hasCte, hasFromFunction);
 	}
 
 	@Override
@@ -61,6 +63,12 @@ class HqlQueryIntrospector extends HqlBaseVisitor<Void> implements ParsedQueryIn
 	public Void visitCte(HqlParser.CteContext ctx) {
 		this.hasCte = true;
 		return super.visitCte(ctx);
+	}
+	
+	@Override
+	public Void visitFunctionCallAsFromSource(HqlParser.FunctionCallAsFromSourceContext ctx) {
+		this.hasFromFunction = true;
+		return super.visitFunctionCallAsFromSource(ctx);
 	}
 
 	@Override

--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/HqlQueryRenderer.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/HqlQueryRenderer.java
@@ -31,6 +31,7 @@ import org.springframework.util.ObjectUtils;
  *
  * @author Greg Turnquist
  * @author Christoph Strobl
+ * @author Oscar Fanchin
  * @since 3.1
  */
 @SuppressWarnings({ "ConstantConditions", "DuplicatedCode", "UnreachableCode" })
@@ -61,6 +62,24 @@ class HqlQueryRenderer extends HqlBaseVisitor<QueryTokenStream> {
 	@Override
 	public QueryTokenStream visitStart(HqlParser.StartContext ctx) {
 		return visit(ctx.ql_statement());
+	}
+
+	@Override
+	public QueryTokenStream visitFunctionCallAsFromSource(HqlParser.FunctionCallAsFromSourceContext ctx) {
+
+		QueryRendererBuilder builder = QueryRenderer.builder();
+
+		builder.append(visit(ctx.identifier()));
+
+		builder.append(TOKEN_OPEN_PAREN);
+
+		if (!ctx.expression().isEmpty()) {
+			builder.append(QueryTokenStream.concatExpressions(ctx.expression(), this::visit, TOKEN_COMMA));
+		}
+
+		builder.append(TOKEN_CLOSE_PAREN);
+
+		return builder;
 	}
 
 	@Override
@@ -386,6 +405,14 @@ class HqlQueryRenderer extends HqlBaseVisitor<QueryTokenStream> {
 			if (ctx.variable() != null) {
 				builder.appendExpression(visit(ctx.variable()));
 			}
+
+		} else if (ctx.functionCallAsFromSource() != null) {
+
+			builder.appendExpression(visit(ctx.functionCallAsFromSource()));
+
+			if (ctx.variable() != null) {
+				builder.appendExpression(visit(ctx.variable()));
+			}
 		}
 
 		return builder;
@@ -444,6 +471,39 @@ class HqlQueryRenderer extends HqlBaseVisitor<QueryTokenStream> {
 		if (ctx.variable() != null) {
 			builder.appendExpression(visit(ctx.variable()));
 		}
+
+		return builder;
+	}
+
+	@Override
+	public QueryTokenStream visitJoinFunctionCall(HqlParser.JoinFunctionCallContext ctx) {
+
+		QueryRendererBuilder builder = QueryRenderer.builder();
+
+		builder.append(visit(ctx.functionCallAsJoinTarget()));
+
+		if (ctx.variable() != null) {
+			builder.appendExpression(visit(ctx.variable()));
+		}
+
+		return builder;
+
+	}
+
+	@Override
+	public QueryTokenStream visitFunctionCallAsJoinTarget(HqlParser.FunctionCallAsJoinTargetContext ctx) {
+
+		QueryRendererBuilder builder = QueryRenderer.builder();
+
+		builder.append(visit(ctx.identifier()));
+
+		builder.append(TOKEN_OPEN_PAREN);
+
+		if (!ctx.expression().isEmpty()) {
+			builder.append(QueryTokenStream.concatExpressions(ctx.expression(), this::visit, TOKEN_COMMA));
+		}
+
+		builder.append(TOKEN_CLOSE_PAREN);
 
 		return builder;
 	}

--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/HqlSortedQueryTransformer.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/HqlSortedQueryTransformer.java
@@ -31,6 +31,7 @@ import org.springframework.util.ObjectUtils;
  *
  * @author Greg Turnquist
  * @author Christoph Strobl
+ * @author oscar.fanchin
  * @since 3.1
  */
 @SuppressWarnings("ConstantValue")
@@ -121,6 +122,19 @@ class HqlSortedQueryTransformer extends HqlQueryRenderer {
 
 		return tokens;
 	}
+	
+	@Override
+	public QueryTokenStream visitJoinFunctionCall(HqlParser.JoinFunctionCallContext ctx) {
+
+		QueryTokenStream tokens = super.visitJoinFunctionCall(ctx);
+
+		if (ctx.variable() != null && !tokens.isEmpty()) {
+			transformerSupport.registerAlias(tokens.getLast());
+		}
+
+		return tokens;
+	}
+	
 
 	@Override
 	public QueryTokenStream visitVariable(HqlParser.VariableContext ctx) {

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/HqlQueryRendererTests.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/HqlQueryRendererTests.java
@@ -37,6 +37,7 @@ import org.junit.jupiter.params.provider.ValueSource;
  * @author Christoph Strobl
  * @author Mark Paluch
  * @author Yannick Brandt
+ * @author oscar.fanchin
  * @since 3.1
  */
 class HqlQueryRendererTests {
@@ -1944,4 +1945,254 @@ class HqlQueryRendererTests {
 		assertQuery("select ie from ItemExample ie left join ie.object io where io.object = :externalId");
 		assertQuery("select ie from ItemExample ie where ie.status = com.app.domain.object.Status.UP");
 	}
+
+	@Test // GH-3864 - Added support for Set Return function (SRF) support H7 parsing and
+			// rendering
+	void fromSRFWithAlias() {
+		assertQuery("""
+					select new com.example.dto.SampleDto(d.idFunction, d.nameFunction)
+					from some_function(:date , :integerValue ) d
+				""");
+
+		assertQuery("""
+					select new com.example.dto.SampleDto(d.idFunction, d.nameFunction)
+					from some_function(:date ) d
+				""");
+
+		assertQuery("""
+					select new com.example.dto.SampleDto(d.idFunction, d.nameFunction)
+					from some_function() d
+				""");
+
+		assertQuery("""
+					select new com.example.dto.SampleDto(d.idFunction, d.nameFunction)
+					from some_function(:date , :integerValue , :longValue ) d
+				""");
+	}
+
+	@Test // GH-3864 - Added support for Set Return function support H7 parsing and
+			// rendering
+	void fromSRFWithoutAlias() {
+		assertQuery("""
+					select new com.example.dto.SampleDto(d.idFunction, d.nameFunction)
+					from some_function(:date , :integerValue )
+				""");
+
+		assertQuery("""
+					select new com.example.dto.SampleDto(d.idFunction, d.nameFunction)
+					from some_function(:date )
+				""");
+
+		assertQuery("""
+					select new com.example.dto.SampleDto(d.idFunction, d.nameFunction)
+					from some_function()
+				""");
+
+		assertQuery("""
+					select new com.example.dto.SampleDto(d.idFunction, d.nameFunction)
+					from some_function(:date , :integerValue , :longValue )
+				""");
+	}
+
+	@Test // GH-3864 - Added support for Set Return function support H7 parsing and
+			// rendering
+	void joinEntityToSRFWithFunctionAlias() {
+		assertQuery("""
+					select new com.example.dto.SampleDto(d.idFunction, d.nameFunction)
+					from EntityClass e join some_function(:date , :integerValue ) d on (e.id = d.idFunction)
+				""");
+
+		assertQuery("""
+					select new com.example.dto.SampleDto(d.idFunction, d.nameFunction)
+					from EntityClass e join some_function(:date ) d on (e.id = d.idFunction)
+				""");
+
+		assertQuery("""
+					select new com.example.dto.SampleDto(d.idFunction, d.nameFunction)
+					from EntityClass e join some_function() d on (e.id = d.idFunction)
+				""");
+
+		assertQuery(
+				"""
+							select new com.example.dto.SampleDto(d.idFunction, d.nameFunction)
+							from EntityClass e join some_function(:date , :integerValue , :longValue ) d on (e.id = d.idFunction)
+						""");
+	}
+
+	@Test // GH-3864 - Added support for Set Return function support H7 parsing and
+			// rendering
+	void joinEntityToSRFWithoutFunctionAlias() {
+		assertQuery("""
+					select new com.example.dto.SampleDto(d.idFunction, d.nameFunction)
+					from EntityClass e join some_function(:date , :integerValue ) on (e.id = idFunction)
+				""");
+
+		assertQuery("""
+					select new com.example.dto.SampleDto(d.idFunction, d.nameFunction)
+					from EntityClass e join some_function(:date ) on (e.id = idFunction)
+				""");
+
+		assertQuery("""
+					select new com.example.dto.SampleDto(d.idFunction, d.nameFunction)
+					from EntityClass e join some_function() on (e.id = idFunction)
+				""");
+
+		assertQuery("""
+					select new com.example.dto.SampleDto(d.idFunction, d.nameFunction)
+					from EntityClass e join some_function(:date , :integerValue , :longValue ) on (e.id = idFunction)
+				""");
+	}
+
+	@Test // GH-3864 - Added support for Set Return function support H7 parsing and
+			// rendering
+	void joinSRFToEntityWithoutFunctionWithAlias() {
+		assertQuery("""
+					select new com.example.dto.SampleDto(d.idFunction, d.nameFunction)
+					from some_function(:date , :integerValue ) d join EntityClass e on (e.id = d.idFunction)
+				""");
+
+		assertQuery("""
+					select new com.example.dto.SampleDto(d.idFunction, d.nameFunction)
+					from some_function(:date ) d join EntityClass e on (e.id = idFunction)
+				""");
+
+		assertQuery("""
+					select new com.example.dto.SampleDto(d.idFunction, d.nameFunction)
+					from some_function() d join EntityClass e on (e.id = idFunction)
+				""");
+
+		assertQuery("""
+			    	select new com.example.dto.SampleDto(d.idFunction, d.nameFunction)
+			    	from some_function(:date , :integerValue , :longValue ) d join EntityClass e on (e.id = d.idFunction)
+				""");
+	}
+
+	@Test // GH-3864 - Added support for Set Return function support H7 parsing and
+			// rendering
+	void joinSRFToEntityWithoutFunctionWithoutAlias() {
+		assertQuery("""
+					select new com.example.dto.SampleDto(d.idFunction, d.nameFunction)
+					from some_function(:date , :integerValue ) join EntityClass e on (e.id = idFunction)
+				""");
+
+		assertQuery("""
+					select new com.example.dto.SampleDto(d.idFunction, d.nameFunction)
+					from some_function(:date ) join EntityClass e on (e.id = idFunction)
+				""");
+
+		assertQuery("""
+					select new com.example.dto.SampleDto(d.idFunction, d.nameFunction)
+					from some_function() join EntityClass e on (e.id = idFunction)
+				""");
+
+		assertQuery("""
+					select new com.example.dto.SampleDto(d.idFunction, d.nameFunction)
+					from some_function(:date , :integerValue , :longValue ) join EntityClass e on (e.id = idFunction)
+				""");
+	}
+
+	@Test // GH-3864 - Added support for Set Return function support H7 parsing and
+			// rendering
+	void selectSRFIntoSubquery() {
+		assertQuery("""
+					select new com.example.dto.SampleDto(d.idFunction, d.nameFunction)
+					from (select x.idFunction idFunction, x.nameFunction nameFunction
+					from some_function(:date , :integerValue ) x) d
+				""");
+
+		assertQuery("""
+					select new com.example.dto.SampleDto(d.idFunction, d.nameFunction)
+					from (select x.idFunction idFunction, x.nameFunction nameFunction
+					from some_function(:date ) x) d
+				""");
+
+		assertQuery("""
+					select new com.example.dto.SampleDto(d.idFunction, d.nameFunction)
+					from (select x.idFunction idFunction, x.nameFunction nameFunction
+					from some_function() x) d
+				""");
+
+		assertQuery("""
+					select new com.example.dto.SampleDto(d.idFunction, d.nameFunction)
+					from (select x.idFunction idFunction, x.nameFunction nameFunction
+					from some_function(:date , :integerValue , :longValue ) x) d
+				""");
+	}
+
+	@Test // GH-3864 - Added support for Set Return function support H7 parsing and
+			// rendering
+	void joinEntityToSRFIntoSubquery() {
+		assertQuery("""
+				   select new com.example.dto.SampleDto(k.id, d.nameFunction)
+				   from EntityClass k
+				   inner join (select x.idFunction idFunction, x.nameFunction nameFunction
+				   from some_function(:date , :integerValue ) x ) d on (k.id = d.idFunction)
+				""");
+
+		assertQuery("""
+				   select new com.example.dto.SampleDto(k.id, d.nameFunction)
+				   from EntityClass k
+				   inner join (select x.idFunction idFunction, x.nameFunction nameFunction
+				   from some_function(:date ) x ) d on (k.id = d.idFunction)
+				""");
+
+		assertQuery("""
+				   select new com.example.dto.SampleDto(k.id, d.nameFunction)
+				   from EntityClass k
+				   inner join (select x.idFunction idFunction, x.nameFunction nameFunction
+				   from some_function() x ) d on (k.id = d.idFunction)
+				""");
+
+		assertQuery("""
+				   select new com.example.dto.SampleDto(k.id, d.nameFunction)
+				   from EntityClass k
+				   inner join (select x.idFunction idFunction, x.nameFunction nameFunction
+				   from some_function(:date , :integerValue , :longValue ) x ) d on (k.id = d.idFunction)
+				""");
+	}
+
+	@Test // GH-3864 - Added support for Set Return function support H7 parsing and
+			// rendering
+	void joinLateralEntityToSRF() {
+		assertQuery("""
+				   select new com.example.dto.SampleDto(k.id, d.nameFunction)
+				   from EntityClass k
+				   join lateral (select x.idFunction idFunction, x.nameFunction nameFunction
+				   from some_function(:date , :integerValue ) x where x.idFunction = k.id ) d
+				""");
+
+		assertQuery("""
+				   select new com.example.dto.SampleDto(k.id, d.nameFunction)
+				   from EntityClass k
+				   join lateral (select x.idFunction idFunction, x.nameFunction nameFunction
+				   from some_function(:date ) x where x.idFunction = k.id ) d
+				""");
+
+		assertQuery("""
+				   select new com.example.dto.SampleDto(k.id, d.nameFunction)
+				   from EntityClass k
+				   join lateral (select x.idFunction idFunction, x.nameFunction nameFunction
+				   from some_function() x where x.idFunction = k.id ) d
+				""");
+
+		assertQuery("""
+				   select new com.example.dto.SampleDto(k.id, d.nameFunction)
+				   from EntityClass k
+				   join lateral (select x.idFunction idFunction, x.nameFunction nameFunction
+				   from some_function(:date , :integerValue , :longValue ) x where x.idFunction = k.id ) d
+				""");
+
+	}
+
+	@Test // GH-3864 - Added support for Set Return function support H7 parsing and
+			// rendering
+	void joinTwoFunctions() {
+		assertQuery("""
+				   select new com.example.dto.SampleDto(d.idFunction, d.nameFunction) 
+				   from some_function(:date , :integerValue ) d 
+				   inner join some_function_single_param(:date ) k on (d.idFunction = k.idFunctionSP)
+				""");
+
+	}
+
 }

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/HqlQueryTransformerTests.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/HqlQueryTransformerTests.java
@@ -1129,6 +1129,33 @@ class HqlQueryTransformerTests {
 		assertCountQuery("select distinct substring(e.firstname, 1, position('a' in e.lastname)) as x from from Employee",
 				"select count(distinct substring(e.firstname, 1, position('a' in e.lastname))) from from Employee");
 	}
+	
+	
+	@Test // GH-3864
+	void testCountFromFunctionWithAlias() {
+
+		// given
+		var original = "select x.id, x.value from some_function(:date , :integerValue ) x";
+
+		// when
+		var results = createCountQueryFor(original);
+
+		// then
+		assertThat(results).contains("select count(*) from some_function(:date , :integerValue ) x");
+	}	
+	
+	@Test // GH-3864
+	void testCountFromFunctionNoAlias() {
+
+		// given
+		var original = "select id, value from some_function(:date , :integerValue )";
+
+		// when
+		var results = createCountQueryFor(original);
+
+		// then
+		assertThat(results).contains("select count(*) from some_function(:date , :integerValue )");
+	}
 
 	@Test // GH-3427
 	void sortShouldBeAppendedWithSpacingInCaseOfSetOperator() {


### PR DESCRIPTION
Hello, an implentation for Fixes [issue #3864](https://github.com/spring-projects/spring-data-jpa/issues/3864) ,

I used the sample project provided in the issue description (https://github.com/spring-projects/spring-data-jpa/issues/3864) as a base to build and validate the integration tests with SRF support.

### Details

-- Introduced grammar rules for set-returning functions in FROM and JOIN clauses.
-- Updated HqlQueryRenderer to support SRF syntax.
-- Added support for SRF in For count and sort.
-- Implemented QueryRenderer logic for proper spacing in function parameter rendering.
-- Added internal tests to verify SRF parsing and rendering logic.

### Notes

This is my first contribution to the Spring Data project. I'm open to feedback and happy to make any necessary adjustments or improvements.

To run the tests locally, I had to:
- Add an explicit dependency on `org.hamcrest:hamcrest` to resolve a `NoClassDefFoundError`.
- Temporarily ignore `HqlParserUnitTests`, as the ANTLR-generated parser class is always created as `public`, causing a mismatch with the expected `package-private` visibility. 

These changes were **not committed**, as I assumed they are specific to my local environment and not required for others.

Thanks for reviewing!

- [ X] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [ X] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [ X] You submit test cases (unit or integration tests) that back your changes.
- [ X] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
