### PR TITLE
Add `delete(Predicate)` to `QuerydslJpaPredicateExecutor`

### DIFF
--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/support/QuerydslContributor.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/support/QuerydslContributor.java
@@ -54,7 +54,7 @@ enum QuerydslContributor implements JpaRepositoryFragmentsContributor {
 					resolver, null);
 
 			return RepositoryComposition.RepositoryFragments
-					.of(RepositoryFragment.implemented(QuerydslPredicateExecutor.class, executor));
+					.of(RepositoryFragment.implemented(QuerydslJpaPredicateExecutor.class, executor));
 		}
 
 		return RepositoryComposition.RepositoryFragments.empty();
@@ -65,7 +65,7 @@ enum QuerydslContributor implements JpaRepositoryFragmentsContributor {
 
 		if (isQuerydslRepository(metadata)) {
 			return RepositoryComposition.RepositoryFragments
-					.of(RepositoryFragment.structural(QuerydslPredicateExecutor.class, QuerydslJpaPredicateExecutor.class));
+					.of(RepositoryFragment.structural(QuerydslJpaPredicateExecutor.class, QuerydslJpaPredicateExecutor.class));
 		}
 
 		return RepositoryComposition.RepositoryFragments.empty();

--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/support/QuerydslJpaPredicateExecutor.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/support/QuerydslJpaPredicateExecutor.java
@@ -263,6 +263,33 @@ public class QuerydslJpaPredicateExecutor<T> implements QuerydslPredicateExecuto
 		return createQuery(predicate).fetchCount();
 	}
 
+	/**
+	 * Delete entities by the given {@link Predicate} by loading and removing these.
+	 * <p>
+	 * This method is useful for a small amount of entities. For large amounts of entities, consider using batch deletes
+	 * by declaring a delete query yourself.
+	 *
+	 * @param predicate the {@link Predicate} to delete entities by, must not be {@literal null}.
+	 * @return number of deleted entities.
+	 * @since 4.0
+	 */
+	public long delete(Predicate predicate) {
+
+		Assert.notNull(predicate, PREDICATE_MUST_NOT_BE_NULL);
+
+		List<T> results = (List<T>) createQuery(predicate).fetch();
+
+		int deleted = 0;
+
+		for (T entity : results) {
+			if (SimpleJpaRepository.doDelete(entityManager, entityInformation, entity)) {
+				deleted++;
+			}
+		}
+
+		return deleted;
+	}
+
 	@Override
 	public boolean exists(Predicate predicate) {
 		return createQuery(predicate).select(Expressions.ONE).fetchFirst() != null;

--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/support/SimpleJpaRepository.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/support/SimpleJpaRepository.java
@@ -205,13 +205,18 @@ public class SimpleJpaRepository<T, ID> implements JpaRepositoryImplementation<T
 
 		Assert.notNull(entity, ENTITY_MUST_NOT_BE_NULL);
 
+		doDelete(entityManager, entityInformation, entity);
+	}
+
+	static <T> boolean doDelete(EntityManager entityManager, JpaEntityInformation<T, ?> entityInformation, T entity) {
+
 		if (entityInformation.isNew(entity)) {
-			return;
+			return false;
 		}
 
 		if (entityManager.contains(entity)) {
 			entityManager.remove(entity);
-			return;
+			return true;
 		}
 
 		Class<?> type = ProxyUtils.getUserClass(entity);
@@ -220,7 +225,11 @@ public class SimpleJpaRepository<T, ID> implements JpaRepositoryImplementation<T
 		T existing = (T) entityManager.find(type, entityInformation.getId(entity));
 		if (existing != null) {
 			entityManager.remove(entityManager.merge(entity));
+
+			return true;
 		}
+
+		return false;
 	}
 
 	@Override

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/UserRepositoryTests.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/UserRepositoryTests.java
@@ -2859,6 +2859,17 @@ class UserRepositoryTests {
 				);
 	}
 
+	@Test // GH-3877
+	void delete() {
+
+		flushTestUsers();
+		em.clear();
+
+		long delete = repository.delete(QUser.user.firstname.eq(firstUser.getFirstname()));
+
+		assertThat(delete).isEqualTo(1);
+	}
+
 	@Test // GH-2820
 	void findByFluentPredicateWithProjectionAndPageRequest() {
 

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/aot/AotContributionIntegrationTests.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/aot/AotContributionIntegrationTests.java
@@ -60,7 +60,7 @@ class AotContributionIntegrationTests {
 		String json = isr.getContentAsString(StandardCharsets.UTF_8);
 
 		assertThatJson(json).inPath("$.methods[?(@.name == 'findBy')].fragment").isArray().first().isObject()
-				.containsEntry("interface", "org.springframework.data.querydsl.QuerydslPredicateExecutor")
+				.containsEntry("interface", "org.springframework.data.jpa.repository.support.QuerydslJpaPredicateExecutor")
 				.containsEntry("fragment", "org.springframework.data.jpa.repository.support.QuerydslJpaPredicateExecutor");
 
 		assertThatJson(json).inPath("$.methods[?(@.name == 'existsById')].fragment").isArray().first().isObject()

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/sample/UserRepository.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/sample/UserRepository.java
@@ -55,6 +55,8 @@ import org.springframework.data.repository.CrudRepository;
 import org.springframework.data.repository.query.Param;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.querydsl.core.types.Predicate;
+
 /**
  * Repository interface for {@code User}s.
  *
@@ -773,6 +775,9 @@ public interface UserRepository extends JpaRepository<User, Integer>, JpaSpecifi
 
 	List<User> findWithParameterNameByLastnameStartingWithOrLastnameEndingWith(@Param("l1") String l1,
 			@Param("l2") String l2);
+
+	// surface QuerydslJpaPredicateExecutor.delete(…) method
+	long delete(Predicate predicate);
 
 	@Retention(RetentionPolicy.RUNTIME)
 	@Query("select u, count(r) from User u left outer join u.roles r group by u")

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/support/QuerydslJpaPredicateExecutorUnitTests.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/support/QuerydslJpaPredicateExecutorUnitTests.java
@@ -551,6 +551,17 @@ class QuerydslJpaPredicateExecutorUnitTests {
 		assertThat(users).allMatch(u -> u.getRoles().isEmpty());
 	}
 
+	@Test // GH-3877
+	void deleteShouldDeleteUsers() {
+
+		long deleted = predicateExecutor.delete(user.dateOfBirth.isNull());
+
+		assertThat(deleted).isEqualTo(3);
+		em.flush();
+
+		assertThat(predicateExecutor.findAll(user.dateOfBirth.isNull())).isEmpty();
+	}
+
 	private interface UserProjectionInterfaceBased {
 
 		String getFirstname();


### PR DESCRIPTION
We now define a delete method to remove entities using a Querydsl Predicate and return the count of deleted elements.

Closes #3877