### PR TITLE
Add support for Set-Returning Functions (SRF) in HQL parser

### DIFF
--- a/spring-data-jpa/src/main/antlr4/org/springframework/data/jpa/repository/query/Hql.g4
+++ b/spring-data-jpa/src/main/antlr4/org/springframework/data/jpa/repository/query/Hql.g4
@@ -114,7 +114,12 @@ joinSpecifier
 fromRoot
     : entityName variable?
     | LATERAL? '(' subquery ')' variable?
+    | functionCallAsFromSource variable?
     ;
+
+functionCallAsFromSource
+    : identifier '(' (expression (',' expression)*)? ')'
+    ;    
 
 join
     : joinType JOIN FETCH? joinTarget joinRestriction? // Spec BNF says joinType isn't optional, but text says that it is.
@@ -123,6 +128,11 @@ join
 joinTarget
     : path variable?                        # JoinPath
     | LATERAL? '(' subquery ')' variable?   # JoinSubquery
+    | functionCallAsJoinTarget variable?    # JoinFunctionCall
+    ;
+
+functionCallAsJoinTarget
+    : identifier '(' (expression (',' expression)*)? ')'
     ;
 
 // https://docs.jboss.org/hibernate/orm/6.1/userguide/html_single/Hibernate_User_Guide.html#hql-update

--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/HibernateQueryInformation.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/HibernateQueryInformation.java
@@ -23,19 +23,29 @@ import org.jspecify.annotations.Nullable;
  * Hibernate-specific query details capturing common table expression details.
  *
  * @author Mark Paluch
+ * @author oscar.fanchin
  * @since 3.5
  */
 class HibernateQueryInformation extends QueryInformation {
 
 	private final boolean hasCte;
+	
+	private final boolean hasFromFunction;
+	
 
 	public HibernateQueryInformation(@Nullable String alias, List<QueryToken> projection,
-			boolean hasConstructorExpression, boolean hasCte) {
+			boolean hasConstructorExpression, boolean hasCte,boolean hasFromFunction) {
 		super(alias, projection, hasConstructorExpression);
 		this.hasCte = hasCte;
+		this.hasFromFunction = hasFromFunction;
 	}
 
 	public boolean hasCte() {
 		return hasCte;
 	}
+	
+	public boolean hasFromFunction() {
+		return hasFromFunction;
+	}
+	
 }

--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/HqlCountQueryTransformer.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/HqlCountQueryTransformer.java
@@ -30,6 +30,7 @@ import org.springframework.data.jpa.repository.query.QueryTransformers.CountSele
  * @author Greg Turnquist
  * @author Christoph Strobl
  * @author Mark Paluch
+ * @author oscar.fanchin
  * @since 3.1
  */
 @SuppressWarnings("ConstantValue")
@@ -38,11 +39,13 @@ class HqlCountQueryTransformer extends HqlQueryRenderer {
 	private final @Nullable String countProjection;
 	private final @Nullable String primaryFromAlias;
 	private final boolean containsCTE;
+	private final boolean containsFromFunction;
 
 	HqlCountQueryTransformer(@Nullable String countProjection, HibernateQueryInformation queryInformation) {
 		this.countProjection = countProjection;
 		this.primaryFromAlias = queryInformation.getAlias();
 		this.containsCTE = queryInformation.hasCte();
+		this.containsFromFunction = queryInformation.hasFromFunction();
 	}
 
 	@Override
@@ -151,7 +154,15 @@ class HqlCountQueryTransformer extends HqlQueryRenderer {
 			if (ctx.variable() != null) {
 				builder.appendExpression(visit(ctx.variable()));
 			}
+		} else if (ctx.functionCallAsFromSource() != null) {
+
+			builder.appendExpression(visit(ctx.functionCallAsFromSource()));
+
+			if (ctx.variable() != null) {
+				builder.appendExpression(visit(ctx.variable()));
+			}
 		}
+
 
 		return builder;
 	}
@@ -196,7 +207,7 @@ class HqlCountQueryTransformer extends HqlQueryRenderer {
 			} else {
 
 				// with CTE primary alias fails with hibernate (WITH entities AS (…) SELECT count(c) FROM entities c)
-				if (containsCTE) {
+				if (containsCTE || containsFromFunction) {
 					nested.append(QueryTokens.token("*"));
 				} else {
 

--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/HqlQueryIntrospector.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/HqlQueryIntrospector.java
@@ -29,6 +29,7 @@ import org.jspecify.annotations.Nullable;
  * {@link ParsedQueryIntrospector} for HQL queries.
  *
  * @author Mark Paluch
+ * @author oscar.fanchin
  */
 @SuppressWarnings({ "UnreachableCode", "ConstantValue" })
 class HqlQueryIntrospector extends HqlBaseVisitor<Void> implements ParsedQueryIntrospector<HibernateQueryInformation> {
@@ -40,11 +41,12 @@ class HqlQueryIntrospector extends HqlBaseVisitor<Void> implements ParsedQueryIn
 	private boolean projectionProcessed;
 	private boolean hasConstructorExpression = false;
 	private boolean hasCte = false;
+	private boolean hasFromFunction = false;
 
 	@Override
 	public HibernateQueryInformation getParsedQueryInformation() {
 		return new HibernateQueryInformation(primaryFromAlias, projection == null ? Collections.emptyList() : projection,
-				hasConstructorExpression, hasCte);
+				hasConstructorExpression, hasCte, hasFromFunction);
 	}
 
 	@Override
@@ -62,6 +64,12 @@ class HqlQueryIntrospector extends HqlBaseVisitor<Void> implements ParsedQueryIn
 	public Void visitCte(HqlParser.CteContext ctx) {
 		this.hasCte = true;
 		return super.visitCte(ctx);
+	}
+	
+	@Override
+	public Void visitFunctionCallAsFromSource(HqlParser.FunctionCallAsFromSourceContext ctx) {
+		this.hasFromFunction = true;
+		return super.visitFunctionCallAsFromSource(ctx);
 	}
 
 	@Override

--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/HqlSortedQueryTransformer.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/HqlSortedQueryTransformer.java
@@ -32,6 +32,7 @@ import org.springframework.util.ObjectUtils;
  *
  * @author Greg Turnquist
  * @author Christoph Strobl
+ * @author oscar.fanchin
  * @since 3.1
  */
 @SuppressWarnings("ConstantValue")
@@ -122,6 +123,19 @@ class HqlSortedQueryTransformer extends HqlQueryRenderer {
 
 		return tokens;
 	}
+	
+	@Override
+	public QueryTokenStream visitJoinFunctionCall(HqlParser.JoinFunctionCallContext ctx) {
+
+		QueryTokenStream tokens = super.visitJoinFunctionCall(ctx);
+
+		if (ctx.variable() != null && !tokens.isEmpty()) {
+			transformerSupport.registerAlias(tokens.getLast());
+		}
+
+		return tokens;
+	}
+	
 
 	@Override
 	public QueryTokenStream visitVariable(HqlParser.VariableContext ctx) {

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/HqlQueryRendererTests.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/HqlQueryRendererTests.java
@@ -39,6 +39,7 @@ import org.junit.jupiter.params.provider.ValueSource;
  * @author Christoph Strobl
  * @author Mark Paluch
  * @author Yannick Brandt
+ * @author oscar.fanchin
  * @since 3.1
  */
 class HqlQueryRendererTests {
@@ -2361,4 +2362,254 @@ class HqlQueryRendererTests {
 		assertQuery("select ie from ItemExample ie left join ie.object io where io.object = :externalId");
 		assertQuery("select ie from ItemExample ie where ie.status = com.app.domain.object.Status.UP");
 	}
+
+	@Test // GH-3864 - Added support for Set Return function (SRF) support H7 parsing and
+			// rendering
+	void fromSRFWithAlias() {
+		assertQuery("""
+					select new com.example.dto.SampleDto(d.idFunction, d.nameFunction)
+					from some_function(:date , :integerValue ) d
+				""");
+
+		assertQuery("""
+					select new com.example.dto.SampleDto(d.idFunction, d.nameFunction)
+					from some_function(:date ) d
+				""");
+
+		assertQuery("""
+					select new com.example.dto.SampleDto(d.idFunction, d.nameFunction)
+					from some_function() d
+				""");
+
+		assertQuery("""
+					select new com.example.dto.SampleDto(d.idFunction, d.nameFunction)
+					from some_function(:date , :integerValue , :longValue ) d
+				""");
+	}
+
+	@Test // GH-3864 - Added support for Set Return function support H7 parsing and
+			// rendering
+	void fromSRFWithoutAlias() {
+		assertQuery("""
+					select new com.example.dto.SampleDto(d.idFunction, d.nameFunction)
+					from some_function(:date , :integerValue )
+				""");
+
+		assertQuery("""
+					select new com.example.dto.SampleDto(d.idFunction, d.nameFunction)
+					from some_function(:date )
+				""");
+
+		assertQuery("""
+					select new com.example.dto.SampleDto(d.idFunction, d.nameFunction)
+					from some_function()
+				""");
+
+		assertQuery("""
+					select new com.example.dto.SampleDto(d.idFunction, d.nameFunction)
+					from some_function(:date , :integerValue , :longValue )
+				""");
+	}
+
+	@Test // GH-3864 - Added support for Set Return function support H7 parsing and
+			// rendering
+	void joinEntityToSRFWithFunctionAlias() {
+		assertQuery("""
+					select new com.example.dto.SampleDto(d.idFunction, d.nameFunction)
+					from EntityClass e join some_function(:date , :integerValue ) d on (e.id = d.idFunction)
+				""");
+
+		assertQuery("""
+					select new com.example.dto.SampleDto(d.idFunction, d.nameFunction)
+					from EntityClass e join some_function(:date ) d on (e.id = d.idFunction)
+				""");
+
+		assertQuery("""
+					select new com.example.dto.SampleDto(d.idFunction, d.nameFunction)
+					from EntityClass e join some_function() d on (e.id = d.idFunction)
+				""");
+
+		assertQuery(
+				"""
+							select new com.example.dto.SampleDto(d.idFunction, d.nameFunction)
+							from EntityClass e join some_function(:date , :integerValue , :longValue ) d on (e.id = d.idFunction)
+						""");
+	}
+
+	@Test // GH-3864 - Added support for Set Return function support H7 parsing and
+			// rendering
+	void joinEntityToSRFWithoutFunctionAlias() {
+		assertQuery("""
+					select new com.example.dto.SampleDto(d.idFunction, d.nameFunction)
+					from EntityClass e join some_function(:date , :integerValue ) on (e.id = idFunction)
+				""");
+
+		assertQuery("""
+					select new com.example.dto.SampleDto(d.idFunction, d.nameFunction)
+					from EntityClass e join some_function(:date ) on (e.id = idFunction)
+				""");
+
+		assertQuery("""
+					select new com.example.dto.SampleDto(d.idFunction, d.nameFunction)
+					from EntityClass e join some_function() on (e.id = idFunction)
+				""");
+
+		assertQuery("""
+					select new com.example.dto.SampleDto(d.idFunction, d.nameFunction)
+					from EntityClass e join some_function(:date , :integerValue , :longValue ) on (e.id = idFunction)
+				""");
+	}
+
+	@Test // GH-3864 - Added support for Set Return function support H7 parsing and
+			// rendering
+	void joinSRFToEntityWithoutFunctionWithAlias() {
+		assertQuery("""
+					select new com.example.dto.SampleDto(d.idFunction, d.nameFunction)
+					from some_function(:date , :integerValue ) d join EntityClass e on (e.id = d.idFunction)
+				""");
+
+		assertQuery("""
+					select new com.example.dto.SampleDto(d.idFunction, d.nameFunction)
+					from some_function(:date ) d join EntityClass e on (e.id = idFunction)
+				""");
+
+		assertQuery("""
+					select new com.example.dto.SampleDto(d.idFunction, d.nameFunction)
+					from some_function() d join EntityClass e on (e.id = idFunction)
+				""");
+
+		assertQuery("""
+			    	select new com.example.dto.SampleDto(d.idFunction, d.nameFunction)
+			    	from some_function(:date , :integerValue , :longValue ) d join EntityClass e on (e.id = d.idFunction)
+				""");
+	}
+
+	@Test // GH-3864 - Added support for Set Return function support H7 parsing and
+			// rendering
+	void joinSRFToEntityWithoutFunctionWithoutAlias() {
+		assertQuery("""
+					select new com.example.dto.SampleDto(d.idFunction, d.nameFunction)
+					from some_function(:date , :integerValue ) join EntityClass e on (e.id = idFunction)
+				""");
+
+		assertQuery("""
+					select new com.example.dto.SampleDto(d.idFunction, d.nameFunction)
+					from some_function(:date ) join EntityClass e on (e.id = idFunction)
+				""");
+
+		assertQuery("""
+					select new com.example.dto.SampleDto(d.idFunction, d.nameFunction)
+					from some_function() join EntityClass e on (e.id = idFunction)
+				""");
+
+		assertQuery("""
+					select new com.example.dto.SampleDto(d.idFunction, d.nameFunction)
+					from some_function(:date , :integerValue , :longValue ) join EntityClass e on (e.id = idFunction)
+				""");
+	}
+
+	@Test // GH-3864 - Added support for Set Return function support H7 parsing and
+			// rendering
+	void selectSRFIntoSubquery() {
+		assertQuery("""
+					select new com.example.dto.SampleDto(d.idFunction, d.nameFunction)
+					from (select x.idFunction idFunction, x.nameFunction nameFunction
+					from some_function(:date , :integerValue ) x) d
+				""");
+
+		assertQuery("""
+					select new com.example.dto.SampleDto(d.idFunction, d.nameFunction)
+					from (select x.idFunction idFunction, x.nameFunction nameFunction
+					from some_function(:date ) x) d
+				""");
+
+		assertQuery("""
+					select new com.example.dto.SampleDto(d.idFunction, d.nameFunction)
+					from (select x.idFunction idFunction, x.nameFunction nameFunction
+					from some_function() x) d
+				""");
+
+		assertQuery("""
+					select new com.example.dto.SampleDto(d.idFunction, d.nameFunction)
+					from (select x.idFunction idFunction, x.nameFunction nameFunction
+					from some_function(:date , :integerValue , :longValue ) x) d
+				""");
+	}
+
+	@Test // GH-3864 - Added support for Set Return function support H7 parsing and
+			// rendering
+	void joinEntityToSRFIntoSubquery() {
+		assertQuery("""
+				   select new com.example.dto.SampleDto(k.id, d.nameFunction)
+				   from EntityClass k
+				   inner join (select x.idFunction idFunction, x.nameFunction nameFunction
+				   from some_function(:date , :integerValue ) x ) d on (k.id = d.idFunction)
+				""");
+
+		assertQuery("""
+				   select new com.example.dto.SampleDto(k.id, d.nameFunction)
+				   from EntityClass k
+				   inner join (select x.idFunction idFunction, x.nameFunction nameFunction
+				   from some_function(:date ) x ) d on (k.id = d.idFunction)
+				""");
+
+		assertQuery("""
+				   select new com.example.dto.SampleDto(k.id, d.nameFunction)
+				   from EntityClass k
+				   inner join (select x.idFunction idFunction, x.nameFunction nameFunction
+				   from some_function() x ) d on (k.id = d.idFunction)
+				""");
+
+		assertQuery("""
+				   select new com.example.dto.SampleDto(k.id, d.nameFunction)
+				   from EntityClass k
+				   inner join (select x.idFunction idFunction, x.nameFunction nameFunction
+				   from some_function(:date , :integerValue , :longValue ) x ) d on (k.id = d.idFunction)
+				""");
+	}
+
+	@Test // GH-3864 - Added support for Set Return function support H7 parsing and
+			// rendering
+	void joinLateralEntityToSRF() {
+		assertQuery("""
+				   select new com.example.dto.SampleDto(k.id, d.nameFunction)
+				   from EntityClass k
+				   join lateral (select x.idFunction idFunction, x.nameFunction nameFunction
+				   from some_function(:date , :integerValue ) x where x.idFunction = k.id ) d
+				""");
+
+		assertQuery("""
+				   select new com.example.dto.SampleDto(k.id, d.nameFunction)
+				   from EntityClass k
+				   join lateral (select x.idFunction idFunction, x.nameFunction nameFunction
+				   from some_function(:date ) x where x.idFunction = k.id ) d
+				""");
+
+		assertQuery("""
+				   select new com.example.dto.SampleDto(k.id, d.nameFunction)
+				   from EntityClass k
+				   join lateral (select x.idFunction idFunction, x.nameFunction nameFunction
+				   from some_function() x where x.idFunction = k.id ) d
+				""");
+
+		assertQuery("""
+				   select new com.example.dto.SampleDto(k.id, d.nameFunction)
+				   from EntityClass k
+				   join lateral (select x.idFunction idFunction, x.nameFunction nameFunction
+				   from some_function(:date , :integerValue , :longValue ) x where x.idFunction = k.id ) d
+				""");
+
+	}
+
+	@Test // GH-3864 - Added support for Set Return function support H7 parsing and
+			// rendering
+	void joinTwoFunctions() {
+		assertQuery("""
+				   select new com.example.dto.SampleDto(d.idFunction, d.nameFunction) 
+				   from some_function(:date , :integerValue ) d 
+				   inner join some_function_single_param(:date ) k on (d.idFunction = k.idFunctionSP)
+				""");
+
+	}
+
 }

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/HqlQueryTransformerTests.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/HqlQueryTransformerTests.java
@@ -1133,6 +1133,33 @@ class HqlQueryTransformerTests {
 		assertCountQuery("select distinct substring(e.firstname, 1, position('a' in e.lastname)) as x from from Employee",
 				"select count(distinct substring(e.firstname, 1, position('a' in e.lastname))) from from Employee");
 	}
+	
+	
+	@Test // GH-3864
+	void testCountFromFunctionWithAlias() {
+
+		// given
+		var original = "select x.id, x.value from some_function(:date , :integerValue ) x";
+
+		// when
+		var results = createCountQueryFor(original);
+
+		// then
+		assertThat(results).contains("select count(*) from some_function(:date , :integerValue ) x");
+	}	
+	
+	@Test // GH-3864
+	void testCountFromFunctionNoAlias() {
+
+		// given
+		var original = "select id, value from some_function(:date , :integerValue )";
+
+		// when
+		var results = createCountQueryFor(original);
+
+		// then
+		assertThat(results).contains("select count(*) from some_function(:date , :integerValue )");
+	}
 
 	@Test // GH-3427
 	void sortShouldBeAppendedWithSpacingInCaseOfSetOperator() {


### PR DESCRIPTION
This PR replaces the previous one (#3866) and contains a rebased version of the SRF support feature for Fixes [issue #3864](https://github.com/spring-projects/spring-data-jpa/issues/3864) 
The branch is now based on the updated 4.0.x branch to ensure compatibility and avoid conflicts.
Let me know if there's anything else I should adjust. Thanks for your support!

