### PR TITLE
Avoid early `EntityManager` initialization during `PersistenceProvider` lookup

### DIFF
--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/provider/PersistenceProvider.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/provider/PersistenceProvider.java
@@ -56,6 +56,7 @@ import org.springframework.util.ConcurrentReferenceHashMap;
  * @author Jens Schauder
  * @author Greg Turnquist
  * @author Yuriy Tsarkov
+ * @author Ariel Morelli Andres (Atlassian US, Inc.)
  */
 public enum PersistenceProvider implements QueryExtractor, ProxyIdAccessor, QueryComment {
 
@@ -316,7 +317,7 @@ public enum PersistenceProvider implements QueryExtractor, ProxyIdAccessor, Quer
 	}
 
 	/**
-	 * Determines the {@link PersistenceProvider} from the given {@link EntityManager}. If no special one can be
+	 * Determines the {@link PersistenceProvider} from the given {@link EntityManagerFactory}. If no special one can be
 	 * determined {@link #GENERIC_JPA} will be returned.
 	 *
 	 * @param emf must not be {@literal null}.
@@ -324,7 +325,7 @@ public enum PersistenceProvider implements QueryExtractor, ProxyIdAccessor, Quer
 	 */
 	public static PersistenceProvider fromEntityManagerFactory(EntityManagerFactory emf) {
 
-		Assert.notNull(emf, "EntityManager must not be null");
+		Assert.notNull(emf, "EntityManagerFactory must not be null");
 
 		Class<?> entityManagerType = emf.getPersistenceUnitUtil().getClass();
 		PersistenceProvider cachedProvider = CACHE.get(entityManagerType);

--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/AbstractJpaQuery.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/AbstractJpaQuery.java
@@ -70,6 +70,7 @@ import org.springframework.util.ClassUtils;
  * @author Wonchul Heo
  * @author Julia Lee
  * @author Yanming Zhou
+ * @author Ariel Morelli Andres (Atlassian US, Inc.)
  */
 public abstract class AbstractJpaQuery implements RepositoryQuery {
 
@@ -95,7 +96,7 @@ public abstract class AbstractJpaQuery implements RepositoryQuery {
 		this.method = method;
 		this.em = em;
 		this.metamodel = JpaMetamodel.of(em.getMetamodel());
-		this.provider = PersistenceProvider.fromEntityManager(em);
+		this.provider = PersistenceProvider.fromEntityManagerFactory(em.getEntityManagerFactory());
 		this.execution = Lazy.of(() -> {
 
 			if (method.isStreamQuery()) {

--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/support/JpaRepositoryFactory.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/support/JpaRepositoryFactory.java
@@ -67,6 +67,7 @@ import com.querydsl.core.types.EntityPath;
  * @author Réda Housni Alaoui
  * @author Gabriel Basilio
  * @author Greg Turnquist
+ * @author Ariel Morelli Andres (Atlassian US, Inc.)
  */
 public class JpaRepositoryFactory extends RepositoryFactorySupport {
 
@@ -91,7 +92,8 @@ public class JpaRepositoryFactory extends RepositoryFactorySupport {
 		Assert.notNull(entityManager, "EntityManager must not be null");
 
 		this.entityManager = entityManager;
-		PersistenceProvider extractor = PersistenceProvider.fromEntityManager(entityManager);
+		PersistenceProvider extractor = PersistenceProvider
+				.fromEntityManagerFactory(entityManager.getEntityManagerFactory());
 		this.crudMethodMetadataPostProcessor = new CrudMethodMetadataPostProcessor();
 		this.entityPathResolver = SimpleEntityPathResolver.INSTANCE;
 		this.queryMethodFactory = new DefaultJpaQueryMethodFactory(extractor);

--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/support/Querydsl.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/support/Querydsl.java
@@ -40,7 +40,6 @@ import com.querydsl.jpa.JPQLQuery;
 import com.querydsl.jpa.JPQLTemplates;
 import com.querydsl.jpa.impl.AbstractJPAQuery;
 import com.querydsl.jpa.impl.JPAQuery;
-import org.jspecify.annotations.Nullable;
 
 /**
  * Helper instance to ease access to Querydsl JPA query API.
@@ -51,6 +50,7 @@ import org.jspecify.annotations.Nullable;
  * @author Christoph Strobl
  * @author Marcus Voltolim
  * @author Donghun Shin
+ * @author Ariel Morelli Andres (Atlassian US, Inc.)
  */
 public class Querydsl {
 
@@ -70,7 +70,7 @@ public class Querydsl {
 		Assert.notNull(builder, "PathBuilder must not be null");
 
 		this.em = em;
-		this.provider = PersistenceProvider.fromEntityManager(em);
+		this.provider = PersistenceProvider.fromEntityManagerFactory(em.getEntityManagerFactory());
 		this.builder = builder;
 	}
 
@@ -87,7 +87,8 @@ public class Querydsl {
 	 * Obtains the {@link JPQLTemplates} for the configured {@link EntityManager}. Can return {@literal null} to use the
 	 * default templates.
 	 *
-	 * @return the {@link JPQLTemplates} for the configured {@link EntityManager}, {@link JPQLTemplates#DEFAULT} by default.
+	 * @return the {@link JPQLTemplates} for the configured {@link EntityManager}, {@link JPQLTemplates#DEFAULT} by
+	 *         default.
 	 * @since 3.5
 	 */
 	public JPQLTemplates getTemplates() {

--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/support/SimpleJpaRepository.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/support/SimpleJpaRepository.java
@@ -104,6 +104,7 @@ import org.springframework.util.Assert;
  * @author Diego Krupitza
  * @author Seol-JY
  * @author Joshua Chen
+ * @author Ariel Morelli Andres (Atlassian US, Inc.)
  */
 @Repository
 @Transactional(readOnly = true)
@@ -138,7 +139,7 @@ public class SimpleJpaRepository<T, ID> implements JpaRepositoryImplementation<T
 
 		this.entityInformation = entityInformation;
 		this.entityManager = entityManager;
-		this.provider = PersistenceProvider.fromEntityManager(entityManager);
+		this.provider = PersistenceProvider.fromEntityManagerFactory(entityManager.getEntityManagerFactory());
 		this.projectionFactory = new SpelAwareProxyProjectionFactory();
 	}
 

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/CrudMethodMetadataUnitTests.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/CrudMethodMetadataUnitTests.java
@@ -23,6 +23,7 @@ import java.util.Map;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.EntityManagerFactory;
 import jakarta.persistence.LockModeType;
+import jakarta.persistence.PersistenceUnitUtil;
 import jakarta.persistence.TypedQuery;
 import jakarta.persistence.criteria.CriteriaBuilder;
 import jakarta.persistence.criteria.CriteriaQuery;
@@ -47,6 +48,7 @@ import org.springframework.data.jpa.repository.support.JpaRepositoryFactory;
  *
  * @author Oliver Gierke
  * @author Thomas Darimont
+ * @author Ariel Morelli Andres (Atlassian US, Inc.)
  */
 @ExtendWith(MockitoExtension.class)
 @MockitoSettings(strictness = Strictness.LENIENT)
@@ -54,6 +56,7 @@ class CrudMethodMetadataUnitTests {
 
 	@Mock EntityManager em;
 	@Mock EntityManagerFactory emf;
+	@Mock PersistenceUnitUtil persistenceUnitUtil;
 	@Mock CriteriaBuilder builder;
 	@Mock CriteriaQuery<Role> criteriaQuery;
 	@Mock JpaEntityInformation<Role, Integer> information;
@@ -72,6 +75,7 @@ class CrudMethodMetadataUnitTests {
 		when(em.getDelegate()).thenReturn(em);
 		when(em.getEntityManagerFactory()).thenReturn(emf);
 		when(emf.createEntityManager()).thenReturn(em);
+		when(emf.getPersistenceUnitUtil()).thenReturn(persistenceUnitUtil);
 
 		JpaRepositoryFactory factory = new JpaRepositoryFactory(em) {
 			@Override

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/HibernateCurrentTenantIdentifierResolver.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/HibernateCurrentTenantIdentifierResolver.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2011-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.jpa.repository;
+
+import java.util.Optional;
+
+import org.hibernate.context.spi.CurrentTenantIdentifierResolver;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * {@code CurrentTenantIdentifierResolver} instance for testing
+ *
+ * @author Ariel Morelli Andres (Atlassian US, Inc.)
+ */
+public class HibernateCurrentTenantIdentifierResolver implements CurrentTenantIdentifierResolver<String> {
+	private static final ThreadLocal<@Nullable String> CURRENT_TENANT_IDENTIFIER = new ThreadLocal<>();
+
+	public static void setTenantIdentifier(String tenantIdentifier) {
+		CURRENT_TENANT_IDENTIFIER.set(tenantIdentifier);
+	}
+
+	public static void removeTenantIdentifier() {
+		CURRENT_TENANT_IDENTIFIER.remove();
+	}
+
+	@Override
+	public String resolveCurrentTenantIdentifier() {
+		return Optional.ofNullable(CURRENT_TENANT_IDENTIFIER.get())
+				.orElseThrow(() -> new IllegalArgumentException("Could not resolve current tenant identifier"));
+	}
+
+	@Override
+	public boolean validateExistingCurrentSessions() {
+		return true;
+	}
+}

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/HibernateMultitenancyTests.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/HibernateMultitenancyTests.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2011-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.jpa.repository;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assumptions.*;
+
+import java.util.List;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.context.annotation.ImportResource;
+import org.springframework.data.jpa.domain.sample.Role;
+import org.springframework.data.jpa.provider.PersistenceProvider;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+import org.springframework.data.jpa.repository.sample.RoleRepository;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.transaction.annotation.Transactional;
+
+import jakarta.persistence.EntityManager;
+
+/**
+ * Tests for repositories that use multi-tenancy. This tests verifies that repositories can be created an injected
+ * despite not having a tenant available at creation time
+ *
+ * @author Ariel Morelli Andres (Atlassian US, Inc.)
+ */
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration()
+class HibernateMultitenancyTests {
+
+	@Autowired RoleRepository roleRepository;
+	@Autowired EntityManager em;
+
+	@AfterEach
+	void tearDown() {
+		HibernateCurrentTenantIdentifierResolver.removeTenantIdentifier();
+	}
+
+	@Test
+	void testPersistenceProviderFromFactoryWithoutTenant() {
+		PersistenceProvider provider = PersistenceProvider.fromEntityManagerFactory(em.getEntityManagerFactory());
+		assumeThat(provider).isEqualTo(PersistenceProvider.HIBERNATE);
+	}
+
+	@Test
+	void testRepositoryWithTenant() {
+		HibernateCurrentTenantIdentifierResolver.setTenantIdentifier("tenant-id");
+		assertThatNoException().isThrownBy(() -> roleRepository.findAll());
+	}
+
+	@Test
+	void testRepositoryWithoutTenantFails() {
+		assertThatThrownBy(() -> roleRepository.findAll()).isInstanceOf(RuntimeException.class);
+	}
+
+	@Transactional
+	List<Role> insertAndQuery() {
+		roleRepository.save(new Role("DRUMMER"));
+		roleRepository.flush();
+		return roleRepository.findAll();
+	}
+
+	@ImportResource({ "classpath:multitenancy-test.xml" })
+	@Configuration
+	@EnableJpaRepositories(basePackageClasses = HibernateRepositoryTests.class, considerNestedRepositories = true,
+			includeFilters = @ComponentScan.Filter(classes = { RoleRepository.class }, type = FilterType.ASSIGNABLE_TYPE))
+	static class TestConfig {}
+}

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/AbstractStringBasedJpaQueryUnitTests.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/AbstractStringBasedJpaQueryUnitTests.java
@@ -18,6 +18,8 @@ package org.springframework.data.jpa.repository.query;
 import static org.mockito.Mockito.*;
 
 import jakarta.persistence.EntityManager;
+import jakarta.persistence.EntityManagerFactory;
+import jakarta.persistence.PersistenceUnitUtil;
 import jakarta.persistence.metamodel.Metamodel;
 
 import java.lang.reflect.Method;
@@ -52,6 +54,7 @@ import org.springframework.util.ReflectionUtils;
  *
  * @author Christoph Strobl
  * @author Mark Paluch
+ * @author Ariel Morelli Andres (Atlassian US, Inc.)
  */
 class AbstractStringBasedJpaQueryUnitTests {
 
@@ -137,10 +140,14 @@ class AbstractStringBasedJpaQueryUnitTests {
 				public EntityManager get() {
 
 					EntityManager em = Mockito.mock(EntityManager.class);
+					EntityManagerFactory emf = Mockito.mock(EntityManagerFactory.class);
+					PersistenceUnitUtil puu = Mockito.mock(PersistenceUnitUtil.class);
 
 					Metamodel meta = mock(Metamodel.class);
 					when(em.getMetamodel()).thenReturn(meta);
 					when(em.getDelegate()).thenReturn(new Object()); // some generic jpa
+					when(em.getEntityManagerFactory()).thenReturn(emf);
+					when(emf.getPersistenceUnitUtil()).thenReturn(puu); // some generic jpa
 
 					return em;
 				}

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/JpaQueryLookupStrategyUnitTests.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/JpaQueryLookupStrategyUnitTests.java
@@ -20,6 +20,7 @@ import static org.mockito.Mockito.*;
 
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.EntityManagerFactory;
+import jakarta.persistence.PersistenceUnitUtil;
 import jakarta.persistence.metamodel.Metamodel;
 
 import java.lang.reflect.Method;
@@ -58,6 +59,7 @@ import org.springframework.data.repository.query.ValueExpressionDelegate;
  * @author Jens Schauder
  * @author Réda Housni Alaoui
  * @author Greg Turnquist
+ * @author Ariel Morelli Andres (Atlassian US, Inc.)
  */
 @ExtendWith(MockitoExtension.class)
 @MockitoSettings(strictness = Strictness.LENIENT)
@@ -68,6 +70,7 @@ class JpaQueryLookupStrategyUnitTests {
 
 	@Mock EntityManager em;
 	@Mock EntityManagerFactory emf;
+	@Mock PersistenceUnitUtil puu;
 	@Mock QueryExtractor extractor;
 	@Mock NamedQueries namedQueries;
 	@Mock Metamodel metamodel;
@@ -81,6 +84,7 @@ class JpaQueryLookupStrategyUnitTests {
 		when(em.getMetamodel()).thenReturn(metamodel);
 		when(em.getEntityManagerFactory()).thenReturn(emf);
 		when(emf.createEntityManager()).thenReturn(em);
+		when(emf.getPersistenceUnitUtil()).thenReturn(puu);
 		when(em.getDelegate()).thenReturn(em);
 		queryMethodFactory = new DefaultJpaQueryMethodFactory(extractor);
 	}

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/NamedQueryUnitTests.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/NamedQueryUnitTests.java
@@ -20,6 +20,7 @@ import static org.mockito.Mockito.*;
 
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.EntityManagerFactory;
+import jakarta.persistence.PersistenceUnitUtil;
 import jakarta.persistence.TypedQuery;
 import jakarta.persistence.metamodel.Metamodel;
 
@@ -36,7 +37,6 @@ import org.mockito.quality.Strictness;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.provider.QueryExtractor;
-import org.springframework.data.jpa.repository.QueryRewriter;
 import org.springframework.data.projection.ProjectionFactory;
 import org.springframework.data.projection.SpelAwareProxyProjectionFactory;
 import org.springframework.data.repository.core.RepositoryMetadata;
@@ -51,6 +51,7 @@ import org.springframework.data.util.TypeInformation;
  * @author Thomas Darimont
  * @author Mark Paluch
  * @author Erik Pellizzon
+ * @author Ariel Morelli Andres (Atlassian US, Inc.)
  */
 @ExtendWith(MockitoExtension.class)
 @MockitoSettings(strictness = Strictness.LENIENT)
@@ -63,6 +64,7 @@ class NamedQueryUnitTests {
 	@Mock QueryExtractor extractor;
 	@Mock EntityManager em;
 	@Mock EntityManagerFactory emf;
+	@Mock PersistenceUnitUtil puu;
 	@Mock Metamodel metamodel;
 
 	private ProjectionFactory projectionFactory = new SpelAwareProxyProjectionFactory();
@@ -84,6 +86,7 @@ class NamedQueryUnitTests {
 		when(em.getEntityManagerFactory()).thenReturn(emf);
 		when(em.getDelegate()).thenReturn(em);
 		when(emf.createEntityManager()).thenReturn(em);
+		when(emf.getPersistenceUnitUtil()).thenReturn(puu);
 	}
 
 	@Test

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/NativeJpaQueryUnitTests.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/NativeJpaQueryUnitTests.java
@@ -20,6 +20,7 @@ import static org.mockito.Mockito.*;
 
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.EntityManagerFactory;
+import jakarta.persistence.PersistenceUnitUtil;
 import jakarta.persistence.metamodel.Metamodel;
 
 import java.lang.reflect.Method;
@@ -44,12 +45,14 @@ import org.springframework.util.ReflectionUtils;
  * Unit tests for {@link NativeJpaQuery}.
  *
  * @author Mark Paluch
+ * @author Ariel Morelli Andres (Atlassian US, Inc.)
  */
 @MockitoSettings(strictness = Strictness.LENIENT)
 class NativeJpaQueryUnitTests {
 
 	@Mock EntityManager em;
 	@Mock EntityManagerFactory emf;
+	@Mock PersistenceUnitUtil puu;
 	@Mock Metamodel metamodel;
 
 	@BeforeEach
@@ -58,6 +61,7 @@ class NativeJpaQueryUnitTests {
 		when(em.getMetamodel()).thenReturn(metamodel);
 		when(em.getEntityManagerFactory()).thenReturn(emf);
 		when(em.getDelegate()).thenReturn(em);
+		when(emf.getPersistenceUnitUtil()).thenReturn(puu);
 	}
 
 	@Test // GH-3546
@@ -71,11 +75,9 @@ class NativeJpaQueryUnitTests {
 				queryExtractor);
 
 		NativeJpaQuery query = new NativeJpaQuery(queryMethod, em, queryMethod.getRequiredDeclaredQuery(),
-				queryMethod.getDeclaredCountQuery(),
-				new JpaQueryConfiguration(QueryRewriterProvider.simple(), QueryEnhancerSelector.DEFAULT_SELECTOR,
-						ValueExpressionDelegate.create(), EscapeCharacter.DEFAULT));
-		QueryProvider sql = query.getSortedQuery(Sort.by("foo", "bar"),
-				queryMethod.getResultProcessor().getReturnedType());
+				queryMethod.getDeclaredCountQuery(), new JpaQueryConfiguration(QueryRewriterProvider.simple(),
+						QueryEnhancerSelector.DEFAULT_SELECTOR, ValueExpressionDelegate.create(), EscapeCharacter.DEFAULT));
+		QueryProvider sql = query.getSortedQuery(Sort.by("foo", "bar"), queryMethod.getResultProcessor().getReturnedType());
 
 		assertThat(sql.getQueryString()).isEqualTo("SELECT e FROM Employee e order by e.foo asc, e.bar asc");
 	}

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/SimpleJpaQueryUnitTests.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/SimpleJpaQueryUnitTests.java
@@ -20,6 +20,7 @@ import static org.mockito.Mockito.*;
 
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.EntityManagerFactory;
+import jakarta.persistence.PersistenceUnitUtil;
 import jakarta.persistence.Tuple;
 import jakarta.persistence.TypedQuery;
 import jakarta.persistence.metamodel.EntityType;
@@ -74,6 +75,7 @@ import org.springframework.data.repository.query.ValueExpressionDelegate;
  * @author Erik Pellizzon
  * @author Christoph Strobl
  * @author Danny van den Elshout
+ * @author Ariel Morelli Andres (Atlassian US, Inc.)
  */
 @ExtendWith(MockitoExtension.class)
 @MockitoSettings(strictness = Strictness.LENIENT)
@@ -88,6 +90,7 @@ class SimpleJpaQueryUnitTests {
 
 	@Mock EntityManager em;
 	@Mock EntityManagerFactory emf;
+	@Mock PersistenceUnitUtil puu;
 	@Mock QueryExtractor extractor;
 	@Mock jakarta.persistence.Query query;
 	@Mock TypedQuery<Long> typedQuery;
@@ -107,6 +110,7 @@ class SimpleJpaQueryUnitTests {
 		when(em.getEntityManagerFactory()).thenReturn(emf);
 		when(em.getDelegate()).thenReturn(em);
 		when(emf.createEntityManager()).thenReturn(em);
+		when(emf.getPersistenceUnitUtil()).thenReturn(puu);
 
 		metadata = AbstractRepositoryMetadata.getMetadata(SampleRepository.class);
 

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/support/JpaRepositoryFragmentsContributorUnitTests.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/support/JpaRepositoryFragmentsContributorUnitTests.java
@@ -19,6 +19,8 @@ import static org.assertj.core.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 import jakarta.persistence.EntityManager;
+import jakarta.persistence.EntityManagerFactory;
+import jakarta.persistence.PersistenceUnitUtil;
 
 import java.util.Iterator;
 
@@ -40,6 +42,7 @@ import com.querydsl.core.types.EntityPath;
  * Unit tests for {@link JpaRepositoryFragmentsContributor}.
  *
  * @author Mark Paluch
+ * @author Ariel Morelli Andres (Atlassian US, Inc.)
  */
 class JpaRepositoryFragmentsContributorUnitTests {
 
@@ -53,7 +56,11 @@ class JpaRepositoryFragmentsContributorUnitTests {
 		when(entityPathResolver.createPath(any())).thenReturn((EntityPath) QCustomer.customer);
 
 		EntityManager entityManager = mock(EntityManager.class);
+		EntityManagerFactory emf = mock(EntityManagerFactory.class);
+		PersistenceUnitUtil persistenceUnitUtil = mock(PersistenceUnitUtil.class);
 		when(entityManager.getDelegate()).thenReturn(entityManager);
+		when(entityManager.getEntityManagerFactory()).thenReturn(emf);
+		when(emf.getPersistenceUnitUtil()).thenReturn(persistenceUnitUtil);
 
 		RepositoryComposition.RepositoryFragments fragments = contributor.contribute(
 				AbstractRepositoryMetadata.getMetadata(QuerydslUserRepository.class),

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/support/SimpleJpaRepositoryUnitTests.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/support/SimpleJpaRepositoryUnitTests.java
@@ -31,7 +31,6 @@ import jakarta.persistence.criteria.CriteriaQuery;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.util.Arrays;
-import java.util.Optional;
 import java.util.stream.Stream;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -44,7 +43,6 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
-
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.jpa.domain.Specification;
 import org.springframework.data.jpa.domain.sample.User;
@@ -61,6 +59,7 @@ import org.springframework.transaction.annotation.Transactional;
  * @author Jens Schauder
  * @author Greg Turnquist
  * @author Yanming Zhou
+ * @author Ariel Morelli Andres (Atlassian US, Inc.)
  */
 @ExtendWith(MockitoExtension.class)
 @MockitoSettings(strictness = Strictness.LENIENT)
@@ -85,6 +84,9 @@ class SimpleJpaRepositoryUnitTests {
 	void setUp() {
 
 		when(em.getDelegate()).thenReturn(em);
+		when(em.getEntityManagerFactory()).thenReturn(entityManagerFactory);
+
+		when(entityManagerFactory.getPersistenceUnitUtil()).thenReturn(persistenceUnitUtil);
 
 		when(information.getJavaType()).thenReturn(User.class);
 		when(em.getCriteriaBuilder()).thenReturn(builder);

--- a/spring-data-jpa/src/test/resources/multitenancy-test.xml
+++ b/spring-data-jpa/src/test/resources/multitenancy-test.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:jdbc="http://www.springframework.org/schema/jdbc"
+	xsi:schemaLocation="http://www.springframework.org/schema/jdbc https://www.springframework.org/schema/jdbc/spring-jdbc.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd">
+	
+	<import resource="hibernate.xml" />
+	
+	<bean id="entityManagerFactory"
+		class="org.springframework.orm.jpa.LocalContainerEntityManagerFactoryBean">
+		<property name="dataSource" ref="dataSource" />
+		<property name="persistenceUnitName" value="spring-data-jpa" />
+		<property name="jpaVendorAdapter" ref="vendorAdaptor" />
+		<property name="jpaProperties">
+			<props>
+				<prop key="hibernate.tenant_identifier_resolver">
+					org.springframework.data.jpa.repository.HibernateCurrentTenantIdentifierResolver
+				</prop>
+			</props>
+		</property>
+	</bean>
+	
+	<bean id="abstractVendorAdaptor" abstract="true">
+		<property name="generateDdl" value="true" />
+		<property name="database" value="HSQL" />
+	</bean>
+	
+	<bean id="transactionManager" class="org.springframework.orm.jpa.JpaTransactionManager">
+		<property name="entityManagerFactory" ref="entityManagerFactory" />
+	</bean>	
+
+	<bean name="sampleEvaluationContextExtension" class="org.springframework.data.jpa.repository.sample.SampleEvaluationContextExtension"/>
+	
+	<jdbc:embedded-database id="dataSource" type="HSQL" generate-name="true">
+		<jdbc:script execution="INIT" separator="/;" location="classpath:scripts/hsqldb-init.sql"/>
+		<jdbc:script execution="INIT" separator="/;" location="classpath:scripts/schema-stored-procedures.sql"/>
+	</jdbc:embedded-database>
+
+</beans>


### PR DESCRIPTION
Changes into the mechanism of `PersistenceProvider.fromEntityManager` to prevent the initialization of a hibernate session which would result in an exception on boot if multi-tenancy is enabled and no tenant context information has been provided.

This is a fix for bug: https://github.com/spring-projects/spring-data-jpa/issues/3425
Existing test cases were adjusted to account for the new resolution strategy.

PS: If this change gets accepted, would it be possible to cherry-pick the fix to a patch version?

<!--

Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
Make sure that:

-->

- [X] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [X] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [X] You submit test cases (unit or integration tests) that back your changes.
- [X] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
