### PR TITLE
Enable AOT repository generation by default

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,6 +37,7 @@
 		<h2>2.3.232</h2>
 		<jakarta-persistence-api>3.2.0</jakarta-persistence-api>
 		<jsqlparser>5.2</jsqlparser>
+		<junit-pioneer>2.3.0</junit-pioneer>
 		<mysql-connector-java>9.2.0</mysql-connector-java>
 		<postgresql>42.7.5</postgresql>
 		<oracle>23.8.0.25.04</oracle>
@@ -182,6 +183,12 @@
 				<version>${testcontainers}</version>
 				<type>pom</type>
 				<scope>import</scope>
+			</dependency>
+			<dependency>
+				<groupId>org.junit-pioneer</groupId>
+				<artifactId>junit-pioneer</artifactId>
+				<version>${junit-pioneer}</version>
+				<scope>test</scope>
 			</dependency>
 		</dependencies>
 	</dependencyManagement>

--- a/spring-data-jpa/pom.xml
+++ b/spring-data-jpa/pom.xml
@@ -101,6 +101,12 @@
 		</dependency>
 
 		<dependency>
+			<groupId>org.junit-pioneer</groupId>
+			<artifactId>junit-pioneer</artifactId>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
 			<groupId>org.springframework</groupId>
 			<artifactId>spring-core-test</artifactId>
 			<scope>test</scope>

--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/config/JpaRepositoryConfigExtension.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/config/JpaRepositoryConfigExtension.java
@@ -39,6 +39,7 @@ import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import org.springframework.aot.AotDetector;
 import org.springframework.aot.generate.GenerationContext;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.aot.BeanRegistrationAotProcessor;
@@ -87,6 +88,7 @@ import org.springframework.util.StringUtils;
  * @author Thomas Darimont
  * @author Christoph Strobl
  * @author Mark Paluch
+ * @author Hyunsang Han
  */
 public class JpaRepositoryConfigExtension extends RepositoryConfigurationExtensionSupport {
 
@@ -338,8 +340,10 @@ public class JpaRepositoryConfigExtension extends RepositoryConfigurationExtensi
 
 			Environment environment = repositoryContext.getEnvironment();
 
+			String enabledByDefault = AotDetector.useGeneratedArtifacts() ? "true" : "false";
+
 			boolean enabled = Boolean
-					.parseBoolean(environment.getProperty(AotContext.GENERATED_REPOSITORIES_ENABLED, "false"));
+					.parseBoolean(environment.getProperty(AotContext.GENERATED_REPOSITORIES_ENABLED, enabledByDefault));
 			if (!enabled) {
 				return null;
 			}

--- a/src/main/antora/modules/ROOT/pages/jpa/aot.adoc
+++ b/src/main/antora/modules/ROOT/pages/jpa/aot.adoc
@@ -44,7 +44,12 @@ Do not use them directly in your code as generation and implementation details m
 === Running with AOT Repositories
 
 AOT is a mandatory step to transform a Spring application to a native executable, so it is automatically enabled when running in this mode.
-It is also possible to use those optimizations on the JVM by setting the `spring.aot.enabled` and `spring.aot.repositories.enabled` properties to `true`.
+When AOT is enabled (either for native compilation or by setting `spring.aot.enabled=true`), AOT repositories are automatically enabled by default.
+
+You can explicitly control AOT repository generation by setting the `spring.aot.repositories.enabled` property:
+
+* `spring.aot.repositories.enabled=true` - Explicitly enable AOT repositories
+* `spring.aot.repositories.enabled=false` - Disable AOT repositories even when AOT is enabled
 
 AOT repositories contribute configuration changes to the actual repository bean registration to register the generated repository fragment.
 


### PR DESCRIPTION
Resolves: #3899 

Currently, to leverage AOT optimized repositories on the JVM with Spring Data JPA, users need to explicitly set both `spring.aot.enabled=true` and `spring.aot.repositories.enabled=true`.

This change updates the behavior so that if Spring Framework's AOT processing is active (e.g., `spring.aot.enabled=true` is set, or the application is being prepared for a native image), Spring Data JPA's AOT repository generation (`spring.aot.repositories.enabled`) will also be **enabled by default**.