### PR TITLE
Backport Specification.unrestricted() from main branch.

### DIFF
--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/domain/Specification.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/domain/Specification.java
@@ -45,6 +45,16 @@ public interface Specification<T> extends Serializable {
 	@Serial long serialVersionUID = 1L;
 
 	/**
+	 * Simple static factory method to create a specification matching all objects.
+	 *
+	 * @param <T> the type of the {@link Root} the resulting {@literal Specification} operates on.
+	 * @return guaranteed to be not {@literal null}.
+	 */
+	static <T> Specification<T> unrestricted() {
+		return (root, query, builder) -> null;
+	}
+
+	/**
 	 * Negates the given {@link Specification}.
 	 *
 	 * @apiNote with 4.0, this method will no longer accept {@literal null} specifications.
@@ -72,7 +82,8 @@ public interface Specification<T> extends Serializable {
 	 * @param spec can be {@literal null}.
 	 * @return guaranteed to be not {@literal null}.
 	 * @since 2.0
-	 * @deprecated since 3.5, to be removed with 4.0 as we no longer want to support {@literal null} specifications.
+	 * @deprecated since 3.5, to be removed with 4.0 as we no longer want to support {@literal null} specifications. Use
+	 *             {@link #unrestricted()} instead.
 	 */
 	@Deprecated(since = "3.5.0", forRemoval = true)
 	static <T> Specification<T> where(@Nullable Specification<T> spec) {


### PR DESCRIPTION
This would allow 3.5 users to rework their code ahead of the 4.0 release. 'where(null)' was deprecated and should be replaced with unrestricted()

<!--

Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
Make sure that:

-->

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [ ] You submit test cases (unit or integration tests) that back your changes.
- [ ] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
