### PR TITLE
doc: fix typo in README.adoc

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -143,7 +143,7 @@ https://github.com/spring-projects/spring-data-jpa/issues[issue tracker] to see 
 * If the issue doesn’t exist already, https://github.com/spring-projects/spring-data-jpa/issues[create a new issue].
 * Please provide as much information as possible with the issue report, we like to know the version of Spring Data that you are using and JVM version, complete stack traces and any relevant configuration information.
 * If you need to paste code, or include a stack trace format it as code using triple backtick.
-* If possible try to create a test-case or project that replicates the issue. Attach a link to your code or a compressed file containing your code. Use an in-memory datatabase if possible or set the database up using https://github.com/testcontainers[Testcontainers].
+* If possible try to create a test-case or project that replicates the issue. Attach a link to your code or a compressed file containing your code. Use an in-memory database if possible or set the database up using https://github.com/testcontainers[Testcontainers].
 
 == Building from Source
 


### PR DESCRIPTION
This pull request fixes a small typo in the `README.adoc` file:

- Corrected: `datatabase` → `database`

This is a trivial documentation change that improves clarity.  
No code or logic changes are included.

---

- [x] I have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] This change does **not** affect any source code, formatting, or tests.
- [x] No author or license headers were modified, as this is a documentation-only fix.
