### PR TITLE
Removed throw Exception code that does not occur

### DIFF
--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/JpaQueryLookupStrategy.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/JpaQueryLookupStrategy.java
@@ -312,7 +312,6 @@ public final class JpaQueryLookupStrategy {
 			case CREATE_IF_NOT_FOUND -> new CreateIfNotFoundQueryLookupStrategy(em, queryMethodFactory,
 					new CreateQueryLookupStrategy(em, queryMethodFactory, configuration),
 					new DeclaredQueryLookupStrategy(em, queryMethodFactory, configuration), configuration);
-			default -> throw new IllegalArgumentException(String.format("Unsupported query lookup strategy %s", key));
 		};
 	}
 


### PR DESCRIPTION
Description
---
When selecting `QueryLookupStrategy` using a `switch` statement with Enum-defined values, if null is passed, it defaults to `CreateIfNotFoundQueryLookupStrategy`, which means the switch statement's default case cannot occur. Therefore, I determined that the corresponding throw Exception would never be executed.

So, I removed the code that performs the throw Exception.

Changes
---
Removed the throw exception part in the `default` case of the `switch` statement.