### PR TITLE
Fix #{#entityName} to return table name for native queries

### DIFF
--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/DefaultJpaEntityMetadata.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/DefaultJpaEntityMetadata.java
@@ -16,6 +16,7 @@
 package org.springframework.data.jpa.repository.query;
 
 import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
 
 import org.springframework.core.annotation.AnnotatedElementUtils;
 import org.springframework.util.Assert;
@@ -52,5 +53,12 @@ public class DefaultJpaEntityMetadata<T> implements JpaEntityMetadata<T> {
 
 		Entity entity = AnnotatedElementUtils.findMergedAnnotation(domainType, Entity.class);
 		return null != entity && StringUtils.hasText(entity.name()) ? entity.name() : domainType.getSimpleName();
+	}
+
+	@Override
+	public String getTableName() {
+		
+		Table table = AnnotatedElementUtils.findMergedAnnotation(domainType, Table.class);
+		return null != table && StringUtils.hasText(table.name()) ? table.name() : getEntityName();
 	}
 }

--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/JpaEntityMetadata.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/JpaEntityMetadata.java
@@ -30,4 +30,14 @@ public interface JpaEntityMetadata<T> extends EntityMetadata<T> {
 	 * @return
 	 */
 	String getEntityName();
+
+	/**
+	 * Returns the table name from the @Table annotation or defaults to the entity name.
+	 *
+	 * @return the table name
+	 * @since 4.0
+	 */
+	default String getTableName() {
+		return getEntityName();
+	}
 }

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/UserRepositoryTests.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/UserRepositoryTests.java
@@ -783,6 +783,14 @@ class UserRepositoryTests {
 		assertThat(repository.findNativeByLastname("Matthews")).containsOnly(thirdUser);
 	}
 
+	@Test // GH-3979
+	void executesNativeQueryWithSelectStarCorrectly() {
+
+		flushTestUsers();
+
+		assertThat(repository.findNativeWithSelectStar("Matthews")).containsOnly(thirdUser);
+	}
+
 	@Test // DATAJPA-132
 	void executesFinderWithTrueKeywordCorrectly() {
 

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/sample/UserRepository.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/sample/UserRepository.java
@@ -676,6 +676,10 @@ public interface UserRepository extends JpaRepository<User, Integer>, JpaSpecifi
 	@Query(value = "VALUES (1)", nativeQuery = true)
 	List<Integer> valuesStatementNative();
 
+	// GH-3979
+	@Query(value = "select * from #{#entityName} where lastname = ?1", nativeQuery = true)
+	List<User> findNativeWithSelectStar(String lastname);
+
 	// GH-2578
 	@Query(value = "with sample_data as ( Select * from SD_User u where u.age > 30  ) \n select * from sample_data",
 			nativeQuery = true)


### PR DESCRIPTION
Fixes #3979

`#{#entityName}` was returning entity name instead of table name for native queries, causing failures with `SELECT *`.

Changes:
- Add `getTableName()` to `JpaEntityMetadata` interface
- Return table name for native queries, entity name for JPQL queries
- Add test case