### PR TITLE
Qualify identifier used in `SimpleJpaRepository.deleteAllByIdInBatch(…)` JPQL

### DIFF
--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/QueryUtils.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/QueryUtils.java
@@ -94,7 +94,7 @@ public abstract class QueryUtils {
 
 	public static final String COUNT_QUERY_STRING = "select count(%s) from %s x";
 	public static final String DELETE_ALL_QUERY_STRING = "delete from %s x";
-	public static final String DELETE_ALL_QUERY_BY_ID_STRING = "delete from %s x where %s in :ids";
+	public static final String DELETE_ALL_QUERY_BY_ID_STRING = "delete from %s x where x.%s in :ids";
 
 	// Used Regex/Unicode categories (see https://www.unicode.org/reports/tr18/#General_Category_Property):
 	// Z Separator

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/support/EclipseLinkDeleteAllByIdInBatchSimpleIdTests.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/support/EclipseLinkDeleteAllByIdInBatchSimpleIdTests.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2008-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.jpa.repository.support;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.data.jpa.domain.sample.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.transaction.annotation.Transactional;
+
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration({"classpath:infrastructure.xml", "classpath:eclipselink-h2.xml"})
+@Transactional
+class EclipseLinkDeleteAllByIdInBatchSimpleIdTests {
+
+    @PersistenceContext
+    EntityManager em;
+
+    private JpaRepository<User, Integer> users;
+
+    @BeforeEach
+    void setUp() {
+        users = new JpaRepositoryFactory(em).getRepository(UserRepository.class);
+    }
+
+    @Test // GH-3990
+    void deleteAllByIdInBatchShouldWorkOnEclipseLinkWithSimpleId() {
+        User one = new User("one", "eins", "one@test.com");
+        User two = new User("two", "zwei", "two@test.com");
+        User three = new User("three", "drei", "three@test.com");
+
+        users.saveAll(List.of(one, two, three));
+        users.flush();
+
+        users.deleteAllByIdInBatch(List.of(one.getId(), three.getId()));
+
+        assertThat(users.findAll()).containsExactly(two);
+    }
+
+    private interface UserRepository extends JpaRepository<User, Integer> {
+    }
+}


### PR DESCRIPTION
This PR addresses GH-3990 by adding a regression test and refining the JPQL used for deleteAllByIdInBatch.

### Background
EclipseLink can fail when the JPQL DELETE uses an unqualified state field in the WHERE clause. Qualifying the field with the range variable alias makes the query portable.

### Changes
- Qualify the delete-by-id JPQL:
  `delete from %s x where x.%s in :ids`
- Add `EclipseLinkDeleteAllByIdInBatchSimpleIdTests`:
  - Save 3 users and flush to allocate IDs
  - Delete two using `deleteAllByIdInBatch`
  - Assert the remaining entity is the expected one

### Verification
Built and tested locally with `./mvnw clean install` (JDK 17+).

Closes #3990