### PR TITLE
Reintroduce Specification.where(Specification)

### DIFF
--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/domain/Specification.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/domain/Specification.java
@@ -48,6 +48,7 @@ import org.springframework.util.Assert;
  * @author Jens Schauder
  * @author Daniel Shuy
  * @author Sergey Rukin
+ * @author Heeeun Cho
  */
 @FunctionalInterface
 public interface Specification<T> extends Serializable {
@@ -76,6 +77,21 @@ public interface Specification<T> extends Serializable {
 		Assert.notNull(spec, "PredicateSpecification must not be null");
 
 		return (root, update, criteriaBuilder) -> spec.toPredicate(root, criteriaBuilder);
+	}
+
+	/**
+	 * Creates a {@link Specification} from the given {@link Specification}. This is a factory method for fluent composition.
+	 *
+	 * @param <T> the type of the {@link Root} the resulting {@literal Specification} operates on.
+	 * @param spec must not be {@literal null}.
+	 * @return the given specification.
+	 * @since 4.1
+	 */
+	static <T> Specification<T> where(Specification<T> spec) {
+
+		Assert.notNull(spec, "Specification must not be null");
+
+		return spec;
 	}
 
 	/**


### PR DESCRIPTION
Reintroduce the `Specification.where(Specification)` overload to improve the migration path for users upgrading to Spring Data JPA 4.0 and to restore the intuitive fluent API.

Closes #3992 

---

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).