### PR TITLE
Fix #3997: Allow block comments in @Query annotations

### DIFF
--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/JpaQueryMethod.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/JpaQueryMethod.java
@@ -62,6 +62,7 @@ import org.springframework.util.StringUtils;
  * @author Réda Housni Alaoui
  * @author Greg Turnquist
  * @author Aleksei Elin
+ * @author 2heunxun
  */
 public class JpaQueryMethod extends QueryMethod {
 

--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/JpaQueryMethod.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/JpaQueryMethod.java
@@ -90,6 +90,19 @@ public class JpaQueryMethod extends QueryMethod {
 	private final Lazy<JpaEntityMetadata<?>> entityMetadata;
 	private final Lazy<Optional<Meta>> metaAnnotation;
 
+
+	/**
+	 * ticket issue #3997
+	 * writer : 2heunxun
+	 */
+	private static String stripBlockComments(@Nullable String query) {
+		if(query == null || !query.contains("/*")) {
+			return query;
+		}
+		// Add the (?s) flag to the beginning of the regex
+		return query.replaceAll("(?s)/\\*.*?\\*/", " ");
+	}
+
 	/**
 	 * Creates a {@link JpaQueryMethod}.
 	 *
@@ -311,7 +324,8 @@ public class JpaQueryMethod extends QueryMethod {
 	public @Nullable String getAnnotatedQuery() {
 
 		String query = getAnnotationValue("value", String.class);
-		return StringUtils.hasText(query) ? query : null;
+		// The next line is the only change you need to make.
+		return StringUtils.hasText(query) ? stripBlockComments(query) : null;
 	}
 
 	/**

--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/JpaQueryMethod.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/JpaQueryMethod.java
@@ -96,10 +96,9 @@ public class JpaQueryMethod extends QueryMethod {
 	 * writer : 2heunxun
 	 */
 	private static String stripBlockComments(@Nullable String query) {
-		if(query == null || !query.contains("/*")) {
+		if (query == null || !query.contains("/*")) {
 			return query;
 		}
-		// Add the (?s) flag to the beginning of the regex
 		return query.replaceAll("(?s)/\\*.*?\\*/", " ");
 	}
 

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/CommentedQueryIntegrationTests.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/CommentedQueryIntegrationTests.java
@@ -1,0 +1,86 @@
+package org.springframework.data.jpa.repository.query;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.data.jpa.domain.sample.User;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.jpa.repository.support.JpaRepositoryFactory;
+import org.springframework.data.repository.Repository;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Integration tests for parsing JPQL queries containing block comments.
+ *
+ * @see <https://github.com/spring-projects/spring-data-jpa/issues/3997>
+ */
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration("classpath:infrastructure.xml")
+@Transactional
+class CommentedQueryIntegrationTests {
+
+    @PersistenceContext
+    EntityManager em;
+
+    /**
+     * Test repository interface with various commented query methods.
+     */
+    interface CommentedQueryRepository extends Repository<User, Integer> {
+
+        /**
+         * A query method that contains a simple inline block comment.
+         */
+        @Query("SELECT u FROM User u WHERE /* A simple inline comment */ u.firstname = :firstname")
+        List<User> findUsersWithInlineComment(String firstname);
+
+        /**
+         * A query method that contains a multi-line block comment and another inline comment.
+         */
+        @Query("""
+				SELECT /*
+				 * This is a multi-line
+				 * block comment.
+				 */ u
+				FROM User u
+				WHERE u.lastname = :lastname /* Another inline comment */
+				""")
+        List<User> findUsersWithMultiLineAndInlineComments(String lastname);
+    }
+
+    @BeforeEach
+    void setup() {
+        // Persist a sample user for the tests
+        if (em.createQuery("select count(u) from User u where u.firstname = 'Dave'", Long.class).getSingleResult() == 0) {
+            User dave = new User("Dave", "Matthews", "dave@dmband.com");
+            em.persist(dave);
+        }
+    }
+
+    @Test
+    void shouldParseQueriesWithVariousCommentStyles() {
+
+        CommentedQueryRepository repository = new JpaRepositoryFactory(em).getRepository(CommentedQueryRepository.class);
+
+        // --- 1. Test a query with an inline comment ---
+        List<User> result1 = repository.findUsersWithInlineComment("Dave");
+
+        assertThat(result1).hasSize(1);
+        assertThat(result1.get(0).getFirstname()).isEqualTo("Dave");
+        System.out.println(" Query with inline comment parsed successfully!");
+
+        // --- 2. Test a query with multi-line and mixed comments ---
+        List<User> result2 = repository.findUsersWithMultiLineAndInlineComments("Matthews");
+
+        assertThat(result2).hasSize(1);
+        assertThat(result2.get(0).getLastname()).isEqualTo("Matthews");
+        System.out.println(" Query with multi-line and mixed comments parsed successfully!");
+    }
+}

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/CommentedQueryIntegrationTests.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/CommentedQueryIntegrationTests.java
@@ -45,13 +45,13 @@ class CommentedQueryIntegrationTests {
          * A query method that contains a multi-line block comment and another inline comment.
          */
         @Query("""
-				SELECT /*
-				 * This is a multi-line
-				 * block comment.
-				 */ u
-				FROM User u
-				WHERE u.lastname = :lastname /* Another inline comment */
-				""")
+                SELECT /*
+                 * This is a multi-line
+                 * block comment.
+                 */ u
+                FROM User u
+                WHERE u.lastname = :lastname /* Another inline comment */
+                """)
         List<User> findUsersWithMultiLineAndInlineComments(String lastname);
     }
 

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/CommentedQueryIntegrationTests.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/CommentedQueryIntegrationTests.java
@@ -21,6 +21,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * Integration tests for parsing JPQL queries containing block comments.
  *
  * @see <https://github.com/spring-projects/spring-data-jpa/issues/3997>
+ * @author 2heunxun
  */
 @ExtendWith(SpringExtension.class)
 @ContextConfiguration("classpath:infrastructure.xml")


### PR DESCRIPTION
Resolves #3997

## Issue Description

Currently, JPQL queries defined in the `@Query` annotation fail during the parsing phase if they contain C-style block comments (`/* ... */`). This behavior results in a `BadJpqlGrammarException`, preventing users from annotating complex queries with comments for maintainability.

## Proposed Solution

This pull request adds support for both single-line and multi-line block comments within `@Query` definitions.

The solution is implemented by stripping comments from the query string before it is processed by the JPQL parser. A private static helper method, `stripBlockComments(String query)`, has been introduced in the `JpaQueryMethod` class. This method utilizes the regular expression `(?s)/\\*.*?\\*/` to correctly handle multi-line comments.

This helper method is invoked within `getAnnotatedQuery()`, ensuring that the comment stripping occurs at the earliest stage of query retrieval from the annotation. This guarantees that all subsequent processing and parsing logic receives a clean query string.

## Verification

A new integration test, `CommentedQueryIntegrationTests`, has been added to validate this functionality. The test includes cases for queries containing both inline and multi-line block comments. With the implemented changes, these new tests and all other relevant tests pass successfully.

## Local Build Notes

The `spring-data-jpa` module builds successfully on its own. However, to run the full project build (`mvn clean install`), certain environment-specific integration tests (e.g., `OracleVectorIntegrationTests`, `PgVectorIntegrationTests`, `MySqlStoredProcedureIntegrationTests`) that require a local Docker environment were excluded.

The full test suite is expected to pass on the project's CI server, which is configured with the necessary database services.