### PR TITLE
Use constant-first equals in QueryTransformers

### DIFF
--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/QueryTransformers.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/QueryTransformers.java
@@ -52,16 +52,16 @@ class QueryTransformers {
 					continue;
 				}
 
-				if (token.equals(TOKEN_AS)) {
+				if (TOKEN_AS.equals(token)) {
 					skipNext = true;
 					continue;
 				}
 
-				if (!token.equals(TOKEN_COMMA) && token.isExpression()) {
+				if (!TOKEN_COMMA.equals(token) && token.isExpression()) {
 					token = QueryTokens.token(token.value());
 				}
 
-				if (!containsNew && token.equals(TOKEN_NEW)) {
+				if (!containsNew && TOKEN_NEW.equals(token)) {
 					containsNew = true;
 				}
 
@@ -89,12 +89,12 @@ class QueryTransformers {
 
 			for (QueryToken token : this) {
 
-				if (token.equals(TOKEN_OPEN_PAREN)) {
+				if (TOKEN_OPEN_PAREN.equals(token)) {
 					nestingLevel++;
 					continue;
 				}
 
-				if (token.equals(TOKEN_CLOSE_PAREN)) {
+				if (TOKEN_CLOSE_PAREN.equals(token)) {
 					nestingLevel--;
 					continue;
 				}


### PR DESCRIPTION
#4047

Refactors QueryTransformers to use constant-first equals() calls. This is a common best practice to prevent potential NullPointerExceptions if the variable (token) were to be null.

```java
class QueryTokens {
    // ...
    static final QueryToken TOKEN_COMMA = token(", ");
    static final QueryToken TOKEN_AS = expression("AS");
    // ...
}
```

Before:
```java
if (token.equals(TOKEN_AS)) {
     // ...
 }
```

After:
```java
if (TOKEN_AS.equals(token)) {
    // ...
}
```

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
