### PR TITLE
Prevent sorting and count queries for non-SELECT statements.

### DIFF
--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/DefaultQueryEnhancer.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/DefaultQueryEnhancer.java
@@ -15,38 +15,82 @@
  */
 package org.springframework.data.jpa.repository.query;
 
+import java.util.Locale;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
 import org.jspecify.annotations.Nullable;
 
 /**
  * The implementation of the Regex-based {@link QueryEnhancer} using {@link QueryUtils}.
  *
  * @author Diego Krupitza
+ * @author kssumin
  * @since 2.7.0
  */
 class DefaultQueryEnhancer implements QueryEnhancer {
+
+	private static final Pattern STATEMENT_TYPE_PATTERN = Pattern.compile(
+			"^\\s*(SELECT|FROM|INSERT|UPDATE|DELETE|MERGE)", Pattern.CASE_INSENSITIVE);
 
 	private final QueryProvider query;
 	private final boolean hasConstructorExpression;
 	private final @Nullable  String alias;
 	private final String projection;
+	private final StatementType statementType;
 
 	public DefaultQueryEnhancer(QueryProvider query) {
 		this.query = query;
 		this.hasConstructorExpression = QueryUtils.hasConstructorExpression(query.getQueryString());
 		this.alias = QueryUtils.detectAlias(query.getQueryString());
 		this.projection = QueryUtils.getProjection(this.query.getQueryString());
+		this.statementType = detectStatementType(query.getQueryString());
 	}
 
 	@Override
 	public String rewrite(QueryRewriteInformation rewriteInformation) {
+
+		if (statementType != StatementType.SELECT && !rewriteInformation.getSort().isUnsorted()) {
+			throw new IllegalStateException(String.format(
+					"Cannot apply sorting to %s statement. Sorting is only supported for SELECT statements.",
+					statementType));
+		}
+
 		return QueryUtils.applySorting(this.query.getQueryString(), rewriteInformation.getSort(), alias);
 	}
 
 	@Override
 	public String createCountQueryFor(@Nullable String countProjection) {
 
+		if (statementType != StatementType.SELECT) {
+			throw new IllegalStateException(String.format(
+					"Cannot derive count query for %s statement. Count queries are only supported for SELECT statements.",
+					statementType));
+		}
+
 		boolean nativeQuery = this.query instanceof DeclaredQuery dc ? dc.isNative() : true;
 		return QueryUtils.createCountQueryFor(this.query.getQueryString(), countProjection, nativeQuery);
+	}
+
+	private static StatementType detectStatementType(String query) {
+
+		Matcher matcher = STATEMENT_TYPE_PATTERN.matcher(query);
+		if (matcher.find()) {
+			String type = matcher.group(1).toUpperCase(Locale.ENGLISH);
+			return switch (type) {
+				case "SELECT", "FROM" -> StatementType.SELECT; // FROM is also a SELECT in JPQL
+				case "INSERT" -> StatementType.INSERT;
+				case "UPDATE" -> StatementType.UPDATE;
+				case "DELETE" -> StatementType.DELETE;
+				case "MERGE" -> StatementType.MERGE;
+				default -> StatementType.OTHER;
+			};
+		}
+		return StatementType.OTHER;
+	}
+
+	enum StatementType {
+		SELECT, INSERT, UPDATE, DELETE, MERGE, OTHER
 	}
 
 	@Override

--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/EqlQueryIntrospector.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/EqlQueryIntrospector.java
@@ -28,6 +28,7 @@ import org.jspecify.annotations.Nullable;
  *
  * @author Mark Paluch
  * @author Christoph Strobl
+ * @author kssumin
  */
 @SuppressWarnings("UnreachableCode")
 class EqlQueryIntrospector extends EqlBaseVisitor<Void> implements ParsedQueryIntrospector<QueryInformation> {
@@ -38,11 +39,36 @@ class EqlQueryIntrospector extends EqlBaseVisitor<Void> implements ParsedQueryIn
 	private @Nullable List<QueryToken> projection;
 	private boolean projectionProcessed;
 	private boolean hasConstructorExpression = false;
+	private QueryInformation.StatementType statementType = QueryInformation.StatementType.SELECT;
 
 	@Override
 	public QueryInformation getParsedQueryInformation() {
 		return new QueryInformation(primaryFromAlias, projection == null ? Collections.emptyList() : projection,
-				hasConstructorExpression);
+				hasConstructorExpression, statementType);
+	}
+
+	@Override
+	public Void visitSelectQuery(EqlParser.SelectQueryContext ctx) {
+		statementType = QueryInformation.StatementType.SELECT;
+		return super.visitSelectQuery(ctx);
+	}
+
+	@Override
+	public Void visitFromQuery(EqlParser.FromQueryContext ctx) {
+		statementType = QueryInformation.StatementType.SELECT;
+		return super.visitFromQuery(ctx);
+	}
+
+	@Override
+	public Void visitUpdate_statement(EqlParser.Update_statementContext ctx) {
+		statementType = QueryInformation.StatementType.UPDATE;
+		return super.visitUpdate_statement(ctx);
+	}
+
+	@Override
+	public Void visitDelete_statement(EqlParser.Delete_statementContext ctx) {
+		statementType = QueryInformation.StatementType.DELETE;
+		return super.visitDelete_statement(ctx);
 	}
 
 	@Override

--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/HibernateQueryInformation.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/HibernateQueryInformation.java
@@ -24,18 +24,25 @@ import org.jspecify.annotations.Nullable;
  *
  * @author Mark Paluch
  * @author Oscar Fanchin
+ * @author kssumin
  * @since 3.5
  */
 class HibernateQueryInformation extends QueryInformation {
 
 	private final boolean hasCte;
-	
+
 	private final boolean hasFromFunction;
-	
 
 	public HibernateQueryInformation(@Nullable String alias, List<QueryToken> projection,
-			boolean hasConstructorExpression, boolean hasCte,boolean hasFromFunction) {
+			boolean hasConstructorExpression, boolean hasCte, boolean hasFromFunction) {
 		super(alias, projection, hasConstructorExpression);
+		this.hasCte = hasCte;
+		this.hasFromFunction = hasFromFunction;
+	}
+
+	public HibernateQueryInformation(@Nullable String alias, List<QueryToken> projection,
+			boolean hasConstructorExpression, StatementType statementType, boolean hasCte, boolean hasFromFunction) {
+		super(alias, projection, hasConstructorExpression, statementType);
 		this.hasCte = hasCte;
 		this.hasFromFunction = hasFromFunction;
 	}
@@ -43,9 +50,9 @@ class HibernateQueryInformation extends QueryInformation {
 	public boolean hasCte() {
 		return hasCte;
 	}
-	
+
 	public boolean hasFromFunction() {
 		return hasFromFunction;
 	}
-	
+
 }

--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/HqlQueryIntrospector.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/HqlQueryIntrospector.java
@@ -30,6 +30,7 @@ import org.springframework.data.jpa.repository.query.HqlParser.VariableContext;
  *
  * @author Mark Paluch
  * @author Oscar Fanchin
+ * @author kssumin
  */
 @SuppressWarnings({ "UnreachableCode", "ConstantValue" })
 class HqlQueryIntrospector extends HqlBaseVisitor<Void> implements ParsedQueryIntrospector<HibernateQueryInformation> {
@@ -42,11 +43,36 @@ class HqlQueryIntrospector extends HqlBaseVisitor<Void> implements ParsedQueryIn
 	private boolean hasConstructorExpression = false;
 	private boolean hasCte = false;
 	private boolean hasFromFunction = false;
+	private QueryInformation.StatementType statementType = QueryInformation.StatementType.SELECT;
 
 	@Override
 	public HibernateQueryInformation getParsedQueryInformation() {
 		return new HibernateQueryInformation(primaryFromAlias, projection == null ? Collections.emptyList() : projection,
-				hasConstructorExpression, hasCte, hasFromFunction);
+				hasConstructorExpression, statementType, hasCte, hasFromFunction);
+	}
+
+	@Override
+	public Void visitSelectStatement(HqlParser.SelectStatementContext ctx) {
+		statementType = QueryInformation.StatementType.SELECT;
+		return super.visitSelectStatement(ctx);
+	}
+
+	@Override
+	public Void visitInsertStatement(HqlParser.InsertStatementContext ctx) {
+		statementType = QueryInformation.StatementType.INSERT;
+		return super.visitInsertStatement(ctx);
+	}
+
+	@Override
+	public Void visitUpdateStatement(HqlParser.UpdateStatementContext ctx) {
+		statementType = QueryInformation.StatementType.UPDATE;
+		return super.visitUpdateStatement(ctx);
+	}
+
+	@Override
+	public Void visitDeleteStatement(HqlParser.DeleteStatementContext ctx) {
+		statementType = QueryInformation.StatementType.DELETE;
+		return super.visitDeleteStatement(ctx);
 	}
 
 	@Override

--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/JSqlParserQueryEnhancer.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/JSqlParserQueryEnhancer.java
@@ -69,6 +69,7 @@ import org.springframework.util.StringUtils;
  * @author Yanming Zhou
  * @author Christoph Strobl
  * @author Diego Pedregal
+ * @author kssumin
  * @since 2.7.0
  */
 public class JSqlParserQueryEnhancer implements QueryEnhancer {
@@ -343,7 +344,16 @@ public class JSqlParserQueryEnhancer implements QueryEnhancer {
 		String queryString = query.getQueryString();
 		Assert.hasText(queryString, "Query must not be null or empty");
 
-		if (this.parsedType != ParsedType.SELECT || sort.isUnsorted()) {
+		if (this.parsedType != ParsedType.SELECT) {
+			if (!sort.isUnsorted()) {
+				throw new IllegalStateException(String.format(
+						"Cannot apply sorting to %s statement. Sorting is only supported for SELECT statements.",
+						this.parsedType));
+			}
+			return queryString;
+		}
+
+		if (sort.isUnsorted()) {
 			return queryString;
 		}
 
@@ -383,7 +393,9 @@ public class JSqlParserQueryEnhancer implements QueryEnhancer {
 	public String createCountQueryFor(@Nullable String countProjection) {
 
 		if (this.parsedType != ParsedType.SELECT) {
-			return this.query.getQueryString();
+			throw new IllegalStateException(String.format(
+					"Cannot derive count query for %s statement. Count queries are only supported for SELECT statements.",
+					this.parsedType));
 		}
 
 		Assert.hasText(this.query.getQueryString(), "OriginalQuery must not be null or empty");

--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/JpaQueryEnhancer.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/JpaQueryEnhancer.java
@@ -41,6 +41,7 @@ import org.springframework.data.repository.query.ReturnedType;
  *
  * @author Greg Turnquist
  * @author Mark Paluch
+ * @author kssumin
  * @since 3.1
  * @see JpqlQueryParser
  * @see HqlQueryParser
@@ -220,6 +221,13 @@ class JpaQueryEnhancer<Q extends QueryInformation> implements QueryEnhancer {
 
 	@Override
 	public String rewrite(QueryRewriteInformation rewriteInformation) {
+
+		if (!queryInformation.isSelectStatement() && !rewriteInformation.getSort().isUnsorted()) {
+			throw new IllegalStateException(String.format(
+					"Cannot apply sorting to %s statement. Sorting is only supported for SELECT statements.",
+					queryInformation.getStatementType()));
+		}
+
 		return QueryRenderer.TokenRenderer.render(
 				sortFunction.apply(rewriteInformation.getSort(), this.queryInformation, rewriteInformation.getReturnedType())
 						.visit(context));
@@ -232,6 +240,13 @@ class JpaQueryEnhancer<Q extends QueryInformation> implements QueryEnhancer {
 	 */
 	@Override
 	public String createCountQueryFor(@Nullable String countProjection) {
+
+		if (!queryInformation.isSelectStatement()) {
+			throw new IllegalStateException(String.format(
+					"Cannot derive count query for %s statement. Count queries are only supported for SELECT statements.",
+					queryInformation.getStatementType()));
+		}
+
 		return QueryRenderer.TokenRenderer
 				.render(countQueryFunction.apply(countProjection, this.queryInformation).visit(context));
 	}

--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/JpqlQueryIntrospector.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/JpqlQueryIntrospector.java
@@ -28,6 +28,7 @@ import org.jspecify.annotations.Nullable;
  *
  * @author Mark Paluch
  * @author Christoph Strobl
+ * @author kssumin
  */
 @SuppressWarnings({ "UnreachableCode", "ConstantValue" })
 class JpqlQueryIntrospector extends JpqlBaseVisitor<Void> implements ParsedQueryIntrospector<QueryInformation> {
@@ -38,11 +39,36 @@ class JpqlQueryIntrospector extends JpqlBaseVisitor<Void> implements ParsedQuery
 	private @Nullable List<QueryToken> projection;
 	private boolean projectionProcessed;
 	private boolean hasConstructorExpression = false;
+	private QueryInformation.StatementType statementType = QueryInformation.StatementType.SELECT;
 
 	@Override
 	public QueryInformation getParsedQueryInformation() {
 		return new QueryInformation(primaryFromAlias, projection == null ? Collections.emptyList() : projection,
-				hasConstructorExpression);
+				hasConstructorExpression, statementType);
+	}
+
+	@Override
+	public Void visitSelectQuery(JpqlParser.SelectQueryContext ctx) {
+		statementType = QueryInformation.StatementType.SELECT;
+		return super.visitSelectQuery(ctx);
+	}
+
+	@Override
+	public Void visitFromQuery(JpqlParser.FromQueryContext ctx) {
+		statementType = QueryInformation.StatementType.SELECT;
+		return super.visitFromQuery(ctx);
+	}
+
+	@Override
+	public Void visitUpdate_statement(JpqlParser.Update_statementContext ctx) {
+		statementType = QueryInformation.StatementType.UPDATE;
+		return super.visitUpdate_statement(ctx);
+	}
+
+	@Override
+	public Void visitDelete_statement(JpqlParser.Delete_statementContext ctx) {
+		statementType = QueryInformation.StatementType.DELETE;
+		return super.visitDelete_statement(ctx);
 	}
 
 	@Override

--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/QueryInformation.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/QueryInformation.java
@@ -23,6 +23,7 @@ import org.jspecify.annotations.Nullable;
  * Value object capturing introspection details of a parsed query.
  *
  * @author Mark Paluch
+ * @author kssumin
  * @since 3.5
  */
 class QueryInformation {
@@ -33,10 +34,18 @@ class QueryInformation {
 
 	private final boolean hasConstructorExpression;
 
+	private final StatementType statementType;
+
 	QueryInformation(@Nullable String alias, List<QueryToken> projection, boolean hasConstructorExpression) {
+		this(alias, projection, hasConstructorExpression, StatementType.SELECT);
+	}
+
+	QueryInformation(@Nullable String alias, List<QueryToken> projection, boolean hasConstructorExpression,
+			StatementType statementType) {
 		this.alias = alias;
 		this.projection = projection;
 		this.hasConstructorExpression = hasConstructorExpression;
+		this.statementType = statementType;
 	}
 
 	/**
@@ -61,4 +70,59 @@ class QueryInformation {
 	public boolean hasConstructorExpression() {
 		return hasConstructorExpression;
 	}
+
+	/**
+	 * @return the statement type of the query.
+	 * @since 4.0
+	 */
+	public StatementType getStatementType() {
+		return statementType;
+	}
+
+	/**
+	 * @return {@code true} if the query is a SELECT statement.
+	 * @since 4.0
+	 */
+	public boolean isSelectStatement() {
+		return statementType == StatementType.SELECT;
+	}
+
+	/**
+	 * Enum representing the type of SQL/JPQL statement.
+	 *
+	 * @since 4.0
+	 */
+	enum StatementType {
+
+		/**
+		 * SELECT statement.
+		 */
+		SELECT,
+
+		/**
+		 * INSERT statement.
+		 */
+		INSERT,
+
+		/**
+		 * UPDATE statement.
+		 */
+		UPDATE,
+
+		/**
+		 * DELETE statement.
+		 */
+		DELETE,
+
+		/**
+		 * MERGE statement.
+		 */
+		MERGE,
+
+		/**
+		 * Other statement types.
+		 */
+		OTHER
+	}
+
 }


### PR DESCRIPTION
## Changes

This PR addresses issue #2856 by adding proper validation to `QueryEnhancer` implementations to prevent invalid operations on non-SELECT statements.

### Summary

Previously, `QueryEnhancer` would silently return default values or apply inappropriate operations when attempting to:
- Create count queries for INSERT/UPDATE/DELETE/MERGE statements
- Apply sorting to INSERT/UPDATE/DELETE/MERGE statements

This behavior was problematic as it could lead to unexpected results or silent failures.

### What Changed

1. **Statement Type Detection**
   - Added `StatementType` enum to `QueryInformation` class
   - Implemented statement type detection using regex pattern matching in `DefaultQueryEnhancer`
   - Extended introspector classes (`JpqlQueryIntrospector`, `HqlQueryIntrospector`, `EqlQueryIntrospector`) to detect and propagate statement types

2. **Validation Logic**
   - `QueryEnhancer.rewrite()`: Now throws `IllegalStateException` when attempting to apply sorting to non-SELECT statements
   - `QueryEnhancer.createCountQueryFor()`: Now throws `IllegalStateException` when attempting to create count queries for non-SELECT statements
   - Unsorted rewriting is still allowed for all statement types (no-op behavior)

3. **Affected Classes**
   - `DefaultQueryEnhancer`: Added statement type detection and validation
   - `JpaQueryEnhancer`: Added validation for sorting and count queries
   - `JSqlParserQueryEnhancer`: Changed from returning original query to throwing exceptions
   - `QueryInformation`: Added `StatementType` enum and helper methods
   - `HibernateQueryInformation`: Extended to support statement type

4. **Test Coverage**
   - Added test cases to `QueryEnhancerUnitTests` for JPQL queries:
     - INSERT/UPDATE/DELETE statements throwing exceptions for count queries
     - INSERT/UPDATE/DELETE statements throwing exceptions for sorting
     - Unsorted operations working for all statement types
   - Added test cases to `JSqlParserQueryEnhancerUnitTests` for native queries:
     - INSERT/UPDATE statements throwing exceptions for count queries and sorting
     - Unsorted operations working for all statement types

Closes: #2856

<!--

Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
Make sure that:

-->

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
