### PR TITLE
Document Docker dependency on README

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -148,7 +148,7 @@ https://github.com/spring-projects/spring-data-jpa/issues[issue tracker] to see 
 == Building from Source
 
 You don’t need to build from source to use Spring Data (binaries in https://repo.spring.io[repo.spring.io]), but if you want to try out the latest and greatest, Spring Data can be easily built with the https://github.com/takari/maven-wrapper[maven wrapper].
-You also need JDK 17 or above.
+You also need JDK 17 or above and Docker for integration tests.
 
 [source,bash]
 ----


### PR DESCRIPTION
I wanted to build the project from source and ran into some errors during integration tests. It took a while to figure out that a Docker environment is needed to run them properly, so I've added a mention of this requirement to the README so others don't run into the same problem.