### PR TITLE
Add private constructor and null validation to CollectionUtils.

### DIFF
--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/CollectionUtils.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/CollectionUtils.java
@@ -17,12 +17,19 @@ package org.springframework.data.jpa.repository.query;
 
 import java.util.List;
 
+import org.springframework.util.Assert;
+
 /**
  * Utility methods to obtain sublists.
  *
  * @author Mark Paluch
+ * @author qkrtkdwns3410
  */
 class CollectionUtils {
+
+	private CollectionUtils() {
+		// prevent instantiation
+	}
 
 	/**
 	 * Return the first {@code count} items from the list.
@@ -33,6 +40,7 @@ class CollectionUtils {
 	 * @param <T> the element type of the lists.
 	 */
 	public static <T> List<T> getFirst(int count, List<T> list) {
+		Assert.notNull(list, "List must not be null");
 
 		if (count > 0 && list.size() > count) {
 			return list.subList(0, count);
@@ -50,9 +58,10 @@ class CollectionUtils {
 	 * @param <T> the element type of the lists.
 	 */
 	public static <T> List<T> getLast(int count, List<T> list) {
+		Assert.notNull(list, "List must not be null");
 
 		if (count > 0 && list.size() > count) {
-			return list.subList(list.size() - (count), list.size());
+			return list.subList(list.size() - count, list.size());
 		}
 
 		return list;

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/CollectionUtilsUnitTests.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/CollectionUtilsUnitTests.java
@@ -25,6 +25,7 @@ import org.junit.jupiter.api.Test;
  * Unit tests for {@link CollectionUtils}.
  *
  * @author Mark Paluch
+ * @author qkrtkdwns3410
  */
 class CollectionUtilsUnitTests {
 
@@ -42,5 +43,15 @@ class CollectionUtilsUnitTests {
 		assertThat(CollectionUtils.getLast(2, List.of(1, 2, 3))).containsExactly(2, 3);
 		assertThat(CollectionUtils.getLast(2, List.of(1, 2))).containsExactly(1, 2);
 		assertThat(CollectionUtils.getLast(2, List.of(1))).containsExactly(1);
+	}
+
+	@Test // GH-4108
+	void getFirstShouldRejectNullList() {
+		assertThatIllegalArgumentException().isThrownBy(() -> CollectionUtils.getFirst(2, null));
+	}
+
+	@Test // GH-4108
+	void getLastShouldRejectNullList() {
+		assertThatIllegalArgumentException().isThrownBy(() -> CollectionUtils.getLast(2, null));
 	}
 }


### PR DESCRIPTION
## Summary

Improve `CollectionUtils` utility class with defensive programming practices.

## Changes

### 1. Add private constructor
- Prevent instantiation of utility class
- Follow Java best practices for utility classes

### 2. Add null validation with `Assert.notNull()`
- Enforce the contract documented in Javadoc (`@param list must not be null`)
- Fail fast with clear error message instead of `NullPointerException`

### 3. Add unit tests for null validation
- `getFirstShouldRejectNullList()` 
- `getLastShouldRejectNullList()`

## Why these changes?

| Before | After |
|--------|-------|
| No instantiation prevention | Private constructor |
| Silent NPE on null input | Clear `IllegalArgumentException` |
| No test for null case | Test coverage added |