### PR TITLE
Expand glossary with core JPA and Spring Data terms.

### DIFF
--- a/src/main/antora/modules/ROOT/pages/jpa/glossary.adoc
+++ b/src/main/antora/modules/ROOT/pages/jpa/glossary.adoc
@@ -16,6 +16,16 @@ Dependency Injection :: Pattern to hand a component's dependency to the componen
 
 EclipseLink :: Object relational mapper implementing JPA - link:$$https://www.eclipse.org/eclipselink/$$[https://www.eclipse.org/eclipselink/]
 
+EntityManager :: JPA interface used to interact with the persistence context. It provides methods to perform operations such as persisting, merging, removing, and querying entities. For more information, see link:$$https://en.wikipedia.org/wiki/Jakarta_Persistence#EntityManager$$[https://en.wikipedia.org/wiki/Jakarta_Persistence#EntityManager].
+
+JPQL :: Jakarta Persistence Query Language - An object-oriented query language similar to SQL but operates on entity objects rather than database tables. For more information, see link:$$https://en.wikipedia.org/wiki/Jakarta_Persistence_Query_Language$$[https://en.wikipedia.org/wiki/Jakarta_Persistence_Query_Language].
+
+Persistence Context :: A set of entity instances managed by the EntityManager. Entities within the persistence context are automatically synchronized with the database. For more information, see link:$$https://en.wikipedia.org/wiki/Jakarta_Persistence#Persistence_context$$[https://en.wikipedia.org/wiki/Jakarta_Persistence#Persistence_context].
+
+Query Methods :: Repository methods that derive queries from their method names, eliminating the need to write explicit queries for simple cases.
+
+Repository :: Central interface in Spring Data for generic CRUD operations on a specific type. Provides methods like save, findById, findAll, and delete.
+
 Hibernate :: Object relational mapper implementing JPA - link:$$https://hibernate.org/$$[https://hibernate.org/]
 
 JPA :: Jakarta Persistence API


### PR DESCRIPTION
As a first-time contributor, I noticed the glossary section had only 9 terms. I've added 5 commonly used JPA and Spring Data terms that developers frequently encounter:

- EntityManager: JPA interface for persistence operations
- JPQL: Jakarta Persistence Query Language
- Persistence Context: Entity instances managed by EntityManager
- Query Methods: Method name-based query derivation
- Repository: Central interface for CRUD operations

I included Wikipedia links for JPA standard terms to maintain consistency with the existing style (similar to Dependency Injection).

This is my first contribution to Spring Data JPA. I hope these additions help developers better understand the terminology. Please let me know if any changes are needed.
