### PR TITLE
Improve clarity and accuracy of Example 7 and 11 titles.

### DIFF
--- a/src/main/antora/modules/ROOT/pages/jpa/query-methods.adoc
+++ b/src/main/antora/modules/ROOT/pages/jpa/query-methods.adoc
@@ -194,7 +194,7 @@ In the preceding example, the `LIKE` delimiter character (`%`) is recognized, an
 
 Using the `@NativeQuery` annotation allows running native queries, as shown in the following example:
 
-.Declare a native query at the query method using @Query
+.Declare a native query at the query method using `@NativeQuery`
 ====
 [source, java]
 ----
@@ -296,7 +296,7 @@ That is, you can make any alterations at the last moment.
 Query rewriting applies to the actual query and, when applicable, to count queries.
 Count queries are optimized and therefore, either not necessary or a count is obtained through other means, such as derived from a Hibernate `SelectionQuery` if there is an enclosing transaction.
 
-.Declare a QueryRewriter using `@Query`
+.Declare a QueryRewriter using `@Query` and `@NativeQuery`
 ====
 [source,java]
 ----


### PR DESCRIPTION
### Description

This Pull Request addresses issues with the titles of Example 7 and Example 11 in the Spring Data JPA reference documentation (`jpa/query-methods.adoc`). This is a documentation fix for clarity and accuracy.

<br>

### Changes Made

**1. Example 7 Title Update**
- **Original:** `Example 7. Declare a native query at the query method using @Query`
- **Updated:** `Example 7. Declare a native query at the query method using @NativeQuery`
- **Reason:** The original title was inaccurate as the code snippet explicitly uses the dedicated `@NativeQuery` annotation.

**2. Example 11 Title Update**
- **Original:** `Example 11. Declare a QueryRewriter using @Query`
- **Updated:** `Example 11. Declare a QueryRewriter using @Query and @NativeQuery`
- **Reason:** Example 11 demonstrates the use of `QueryRewriter` with both `@Query` (JPQL) and `@NativeQuery` (Native SQL), but the original title only mentioned `@Query`. This update ensures the title accurately reflects the content.