### PR TITLE
Fix grammar in projections documentation.

### DIFF
--- a/src/main/antora/modules/ROOT/pages/repositories/projections.adoc
+++ b/src/main/antora/modules/ROOT/pages/repositories/projections.adoc
@@ -28,7 +28,7 @@ Any nested properties resolving to joins select the entire nested property causi
 
 === String-based queries
 
-Support for string-based queries covers both, JPQL queries(`@Query`) and native queries (`@NativeQuery`).
+Support for string-based queries covers both JPQL queries (`@Query`) and native queries (`@NativeQuery`).
 
 ==== JPQL Queries
 


### PR DESCRIPTION
 Remove unnecessary comma after 'both' in the sentence structure 'both A and B'. The comma between 'both' and the first item is grammatically incorrect.

  **Before:**
  Support for string-based queries covers both, JPQL queries(@Query) and native queries (@NativeQuery).

  **After:**
  Support for string-based queries covers both JPQL queries (@Query) and native queries (@NativeQuery).
