### PR TITLE
Make ELSE optional in CASE expressions

### DIFF
--- a/spring-data-jpa/src/main/antlr4/org/springframework/data/jpa/repository/query/Eql.g4
+++ b/spring-data-jpa/src/main/antlr4/org/springframework/data/jpa/repository/query/Eql.g4
@@ -604,7 +604,7 @@ case_expression
     ;
 
 general_case_expression
-    : CASE when_clause (when_clause)* ELSE scalar_expression END
+    : CASE when_clause (when_clause)* (ELSE scalar_expression)? END
     ;
 
 when_clause
@@ -612,7 +612,7 @@ when_clause
     ;
 
 simple_case_expression
-    : CASE case_operand simple_when_clause (simple_when_clause)* ELSE scalar_expression END
+    : CASE case_operand simple_when_clause (simple_when_clause)* (ELSE scalar_expression)? END
     ;
 
 case_operand

--- a/spring-data-jpa/src/main/antlr4/org/springframework/data/jpa/repository/query/Jpql.g4
+++ b/spring-data-jpa/src/main/antlr4/org/springframework/data/jpa/repository/query/Jpql.g4
@@ -604,7 +604,7 @@ case_expression
     ;
 
 general_case_expression
-    : CASE when_clause (when_clause)* ELSE scalar_expression END
+    : CASE when_clause (when_clause)* (ELSE scalar_expression)? END
     ;
 
 when_clause
@@ -612,7 +612,7 @@ when_clause
     ;
 
 simple_case_expression
-    : CASE case_operand simple_when_clause (simple_when_clause)* ELSE scalar_expression END
+    : CASE case_operand simple_when_clause (simple_when_clause)* (ELSE scalar_expression)? END
     ;
 
 case_operand

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/EqlQueryRendererTests.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/EqlQueryRendererTests.java
@@ -1476,4 +1476,28 @@ class EqlQueryRendererTests {
 		assertQuery("SELECT name, lastname from Person JOIN department");
 	}
 
+	@Test // GH-4142
+	void generalCaseExpressionWithoutElseShouldWork() {
+
+		assertQuery("""
+				SELECT e.name,
+				    CASE WHEN e.rating = 1 THEN e.salary * 1.1
+				         WHEN e.rating = 2 THEN e.salary * 1.05
+				    END
+				FROM Employee e
+				""");
+	}
+
+	@Test // GH-4142
+	void simpleCaseExpressionWithoutElseShouldWork() {
+
+		assertQuery("""
+				SELECT e.name,
+				    CASE e.rating WHEN 1 THEN e.salary * 1.1
+				                  WHEN 2 THEN e.salary * 1.05
+				    END
+				FROM Employee e
+				""");
+	}
+
 }

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/JpqlQueryRendererTests.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/JpqlQueryRendererTests.java
@@ -1482,4 +1482,40 @@ class JpqlQueryRendererTests {
 		assertQuery("SELECT name, lastname from Person JOIN department");
 	}
 
+	@Test // GH-4142
+	void generalCaseExpressionWithoutElseShouldWork() {
+
+		assertQuery("""
+				SELECT e.name,
+				    CASE WHEN e.rating = 1 THEN e.salary * 1.1
+				         WHEN e.rating = 2 THEN e.salary * 1.05
+				    END
+				FROM Employee e
+				""");
+	}
+
+	@Test // GH-4142
+	void simpleCaseExpressionWithoutElseShouldWork() {
+
+		assertQuery("""
+				SELECT e.name,
+				    CASE e.rating WHEN 1 THEN e.salary * 1.1
+				                  WHEN 2 THEN e.salary * 1.05
+				    END
+				FROM Employee e
+				""");
+	}
+
+	@Test // GH-4142
+	void updateCaseExpressionWithoutElseShouldWork() {
+
+		assertQuery("""
+				UPDATE Employee e
+				SET e.salary =
+				    CASE WHEN e.rating = 1 THEN e.salary * 1.1
+				         WHEN e.rating = 2 THEN e.salary * 1.05
+				    END
+				""");
+	}
+
 }


### PR DESCRIPTION
Resolves #4142

  ## Summary
  Makes the ELSE clause optional in CASE expressions

  ## Changes
  -  Updated the ANTLR grammar files for both JPQL and EQL parsers to make the ELSE clause optional by wrapping `(ELSE scalar_expression)` with `?` quantifier.
  - Added test cases for optional ELSE scenarios
  
  ## Checklist
- [X] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [X] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [X] You submit test cases (unit or integration tests) that back your changes.
- [X] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
