### PR TITLE
Fix EclipseLink 5 derived query compatibility

### DIFF
--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/JpaQueryCreator.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/JpaQueryCreator.java
@@ -345,14 +345,16 @@ public class JpaQueryCreator extends AbstractQueryCreator<String, JpqlQueryBuild
 			if (entityType.hasSingleIdAttribute()) {
 
 				SingularAttribute<?, ?> id = entityType.getId(entityType.getIdType().getJavaType());
-				return selectStep.select(JpqlUtils.toExpressionRecursively(metamodel, entity, entityType,
-						PropertyPath.from(id.getName(), returnedType.getDomainType()), true));
+				JpqlQueryBuilder.PathExpression path = JpqlUtils.toExpressionRecursively(metamodel, entity, entityType,
+						PropertyPath.from(id.getName(), returnedType.getDomainType()), true);
+				return selectStep.select(List.of(JpqlQueryBuilder.unaliased(path)));
 
 			} else {
 
-				List<JpqlQueryBuilder.PathExpression> paths = entityType.getIdClassAttributes().stream()//
+				List<JpqlQueryBuilder.Expression> paths = entityType.getIdClassAttributes().stream()//
 						.map(it -> JpqlUtils.toExpressionRecursively(metamodel, entity, entityType,
 								PropertyPath.from(it.getName(), returnedType.getDomainType()), true))
+						.map(JpqlQueryBuilder::unaliased)
 						.toList();
 				return selectStep.select(paths);
 			}

--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/JpqlQueryBuilder.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/JpqlQueryBuilder.java
@@ -236,6 +236,13 @@ public final class JpqlQueryBuilder {
 		return new StringLiteralExpression(literal);
 	}
 
+	static Expression unaliased(Expression expression) {
+
+		Assert.notNull(expression, "Expression must not be null");
+
+		return expression instanceof AliasedExpression ? new UnaliasedExpression(expression) : expression;
+	}
+
 	/**
 	 * A parameter placeholder.
 	 *
@@ -783,6 +790,19 @@ public final class JpqlQueryBuilder {
 			return render(RenderContext.EMPTY);
 		}
 
+	}
+
+	record UnaliasedExpression(Expression delegate) implements Expression {
+
+		@Override
+		public String render(RenderContext context) {
+			return delegate.render(context);
+		}
+
+		@Override
+		public String toString() {
+			return render(RenderContext.EMPTY);
+		}
 	}
 
 	/**

--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/QueryParameterSetter.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/QueryParameterSetter.java
@@ -214,14 +214,10 @@ interface QueryParameterSetter {
 			this.parameters = query.getParameters();
 
 			// DATAJPA-1172
-			// Since EclipseLink doesn't reliably report whether a query has parameters
-			// we simply try to set the parameters and ignore possible failures.
-			// this is relevant for native queries with SpEL expressions, where the method parameters don't have to match the
-			// parameters in the query.
+			// EclipseLink can under-report query parameters (Hermes parser); allow binding by index regardless.
 			// https://bugs.eclipse.org/bugs/show_bug.cgi?id=521915
 
-			this.registerExcessParameters = query.getParameters().size() == 0
-					&& unwrapClass(query).getName().startsWith("org.eclipse");
+			this.registerExcessParameters = unwrapClass(query).getName().startsWith("org.eclipse");
 		}
 
 		/**

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/domain/sample/SoftDeleteUser.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/domain/sample/SoftDeleteUser.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2024-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.jpa.domain.sample;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+/**
+ * Simple entity to exercise derived queries on EclipseLink.
+ *
+ * @author Spring Data Team
+ */
+@Entity
+@Table(name = "SD_SOFT_DELETE_USER")
+public class SoftDeleteUser {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.AUTO)
+	private Long id;
+
+	@Column(nullable = false)
+	private String email;
+
+	@Column(nullable = false)
+	private Integer isDeleted;
+
+	protected SoftDeleteUser() {}
+
+	public SoftDeleteUser(String email, Integer isDeleted) {
+		this.email = email;
+		this.isDeleted = isDeleted;
+	}
+
+	public Long getId() {
+		return id;
+	}
+
+	public String getEmail() {
+		return email;
+	}
+
+	public void setEmail(String email) {
+		this.email = email;
+	}
+
+	public Integer getIsDeleted() {
+		return isDeleted;
+	}
+
+	public void setIsDeleted(Integer isDeleted) {
+		this.isDeleted = isDeleted;
+	}
+}

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/EclipseLinkDerivedQueryCompatibilityTests.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/EclipseLinkDerivedQueryCompatibilityTests.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2024-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.jpa.repository;
+
+import static org.assertj.core.api.Assertions.*;
+
+import jakarta.persistence.EntityManager;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.jpa.domain.sample.SoftDeleteUser;
+import org.springframework.data.jpa.repository.sample.SoftDeleteUserRepository;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * EclipseLink integration tests for derived query compatibility.
+ *
+ * @author Spring Data Team
+ */
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(locations = { "classpath:config/namespace-application-context-h2.xml", "classpath:eclipselink-h2.xml" })
+@Transactional
+class EclipseLinkDerivedQueryCompatibilityTests {
+
+	@Autowired SoftDeleteUserRepository repository;
+	@Autowired EntityManager em;
+
+	private Long activeId;
+	private Long otherId;
+
+	@BeforeEach
+	void setUp() {
+
+		SoftDeleteUser active = repository.save(new SoftDeleteUser("user@example.com", 0));
+		SoftDeleteUser other = repository.save(new SoftDeleteUser("other@example.com", 0));
+
+		this.activeId = active.getId();
+		this.otherId = other.getId();
+
+		em.flush();
+		em.clear();
+	}
+
+	@AfterEach
+	void tearDown() {
+		repository.deleteAll();
+	}
+
+	@Test
+	void existsProjectionShouldWorkWithEclipseLinkHermes() {
+
+		boolean exists = repository.existsByEmailIgnoreCaseAndIdNotAndIsDeletedNot("USER@EXAMPLE.COM", otherId, 1);
+
+		assertThat(exists).isTrue();
+	}
+
+	@Test
+	void bindsParametersForIsDeletedDerivedQuery() {
+
+		Optional<SoftDeleteUser> found = repository.findByIdAndIsDeleted(activeId, 0);
+
+		assertThat(found).isPresent();
+		assertThat(found.get().getId()).isEqualTo(activeId);
+	}
+}

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/JpaQueryCreatorTests.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/JpaQueryCreatorTests.java
@@ -747,7 +747,7 @@ class JpaQueryCreatorTests {
 				.forTree(Person.class, "existsPersonByFirstname") //
 				.returning(Long.class).withParameters("chris") //
 				.as(QueryCreatorTester::create) //
-				.expectJpql("SELECT p.id id FROM %s p WHERE p.firstname = ?1", DefaultJpaEntityMetadata.unqualify(Person.class)) //
+				.expectJpql("SELECT p.id FROM %s p WHERE p.firstname = ?1", DefaultJpaEntityMetadata.unqualify(Person.class)) //
 				.validateQuery();
 	}
 

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/sample/SoftDeleteUserRepository.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/sample/SoftDeleteUserRepository.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2024-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.jpa.repository.sample;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.domain.sample.SoftDeleteUser;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+/**
+ * Repository for {@link SoftDeleteUser} used in EclipseLink integration tests.
+ *
+ * @author Spring Data Team
+ */
+public interface SoftDeleteUserRepository extends JpaRepository<SoftDeleteUser, Long> {
+
+	boolean existsByEmailIgnoreCaseAndIdNotAndIsDeletedNot(String email, Long id, Integer isDeleted);
+
+	Optional<SoftDeleteUser> findByIdAndIsDeleted(Long id, Integer isDeleted);
+}

--- a/spring-data-jpa/src/test/resources/META-INF/persistence.xml
+++ b/spring-data-jpa/src/test/resources/META-INF/persistence.xml
@@ -57,6 +57,7 @@
 		<class>org.springframework.data.jpa.domain.sample.Site</class>
 		<class>org.springframework.data.jpa.domain.sample.SpecialUser</class>
 		<class>org.springframework.data.jpa.domain.sample.User</class>
+		<class>org.springframework.data.jpa.domain.sample.SoftDeleteUser</class>
 		<class>org.springframework.data.jpa.domain.sample.UserWithOptionalField</class>
 		<class>org.springframework.data.jpa.domain.sample.VersionedUser</class>
 		<class>org.springframework.data.jpa.domain.sample.Dummy</class>

--- a/spring-data-jpa/src/test/resources/META-INF/persistence2.xml
+++ b/spring-data-jpa/src/test/resources/META-INF/persistence2.xml
@@ -23,6 +23,7 @@
 		<class>org.springframework.data.jpa.domain.sample.Role</class>
 		<class>org.springframework.data.jpa.domain.sample.Site</class>
 		<class>org.springframework.data.jpa.domain.sample.SpecialUser</class>
+		<class>org.springframework.data.jpa.domain.sample.SoftDeleteUser</class>
 		<class>org.springframework.data.jpa.domain.sample.Owner</class>
 		<class>org.springframework.data.jpa.domain.sample.User</class>
 		<class>org.springframework.data.jpa.domain.sample.Dummy</class>
@@ -45,6 +46,7 @@
 		<class>org.springframework.data.jpa.domain.sample.Role</class>
 		<class>org.springframework.data.jpa.domain.sample.Site</class>
 		<class>org.springframework.data.jpa.domain.sample.SpecialUser</class>
+		<class>org.springframework.data.jpa.domain.sample.SoftDeleteUser</class>
 		<class>org.springframework.data.jpa.domain.sample.User</class>
 		<class>org.springframework.data.jpa.domain.sample.Dummy</class>
 		<exclude-unlisted-classes>true</exclude-unlisted-classes>


### PR DESCRIPTION
<!--

Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
Make sure that:

-->

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).

## Summary
- Avoid implicit select aliases for exists projections to satisfy EclipseLink Hermes parsing.
- Allow binding positional parameters even when EclipseLink under-reports parameters.
- Add EclipseLink regression coverage for existsBy... and findByIdAndIsDeleted with a minimal test entity.

## Testing
- ./mvnw -pl spring-data-jpa clean test

## Notes
- Targets EclipseLink 5 behavior; other providers should be unaffected.
- Separate from #4145 (IN clause list binding).

## Implementation Details
- For `exists` projections, the JPQL builder suppresses implicit select aliases so Hermes accepts the query. This changes `SELECT o.id id` to `SELECT o.id` by wrapping aliased expressions in an unaliased form.
- For EclipseLink, positional parameter binding now ignores under-reported parameter metadata, enabling derived queries to bind `?2` even when EclipseLink reports fewer parameters.
- Added EclipseLink regression tests using `SoftDeleteUser` to cover both the exists projection and `findByIdAndIsDeleted` binding.
