### PR TITLE
Fix positional binding when only later positions are reported

### DIFF
--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/QueryParameterSetter.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/QueryParameterSetter.java
@@ -109,10 +109,12 @@ interface QueryParameterSetter {
 			} else {
 
 				Integer position = parameter.getPosition();
+				boolean canBindByPosition = query.hasPositionParameters()
+						? query.hasParameterPosition(position) || errorHandler == LENIENT || errorHandler == STRICT
+						: query.getParameters().size() >= position || errorHandler == LENIENT;
 
 				if (position != null //
-						&& (query.getParameters().size() >= position //
-								|| errorHandler == LENIENT //
+						&& (canBindByPosition //
 								|| query.registerExcessParameters())) {
 					query.setParameter(position, value);
 				}
@@ -163,11 +165,13 @@ interface QueryParameterSetter {
 			} else {
 
 				Integer position = parameter.getPosition();
+				boolean canBindByPosition = query.hasPositionParameters()
+						? query.hasParameterPosition(position) || errorHandler == LENIENT || errorHandler == STRICT
+						: query.getParameters().size() >= position || errorHandler == LENIENT;
 
 				if (position != null //
-						&& (query.getParameters().size() >= parameter.getPosition() //
-								|| query.registerExcessParameters() //
-								|| errorHandler == LENIENT)) {
+						&& (canBindByPosition //
+								|| query.registerExcessParameters())) {
 
 					query.setParameter(parameter.getPosition(), date, temporalType);
 				}
@@ -240,6 +244,25 @@ interface QueryParameterSetter {
 
 		public boolean registerExcessParameters() {
 			return this.registerExcessParameters;
+		}
+
+		boolean hasPositionParameters() {
+			for (Parameter<?> candidate : parameters) {
+				if (candidate.getPosition() != null) {
+					return true;
+				}
+			}
+			return false;
+		}
+
+		boolean hasParameterPosition(int position) {
+			for (Parameter<?> candidate : parameters) {
+				Integer candidatePosition = candidate.getPosition();
+				if (candidatePosition != null && candidatePosition == position) {
+					return true;
+				}
+			}
+			return false;
 		}
 
 		/**

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/NamedOrIndexedQueryParameterSetterUnitTests.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/NamedOrIndexedQueryParameterSetterUnitTests.java
@@ -162,6 +162,30 @@ class NamedOrIndexedQueryParameterSetterUnitTests {
 
 	}
 
+	@Test // DATAJPA-4167
+	void setsParameterWhenQueryExposesOnlySecondPosition() {
+
+		Query query = mock(Query.class);
+		doReturn(Collections.singleton(new ParameterImpl(null, 2))).when(query).getParameters();
+
+		for (TemporalType temporalType : temporalTypes) {
+
+			QueryParameterSetter setter = QueryParameterSetter.create( //
+					firstValueExtractor, //
+					new ParameterImpl(null, 2), //
+					temporalType //
+			);
+
+			setter.setParameter(QueryParameterSetter.BindableQuery.from(query), methodArguments, STRICT);
+
+			if (temporalType == null) {
+				verify(query).setParameter(eq(2), any(Date.class));
+			} else {
+				verify(query).setParameter(eq(2), any(Date.class), eq(temporalType));
+			}
+		}
+	}
+
 	/**
 	 * This scenario happens when the only (name) parameter is part of an ORDER BY clause and gets stripped of for the
 	 * count query. Then the count query has no named parameter but the parameter provided has a {@literal null} position.


### PR DESCRIPTION
Fix binding for EclipseLink when a derived query collapses to `... IS NULL AND ... = ?2` and the provider reports only position 2. We now bind positional parameters based on the reported positions (falling back to the previous size heuristic when no positional metadata is available).

This prevents `Query argument 2 not found` seen in #4167. Reproducer and logs: https://github.com/spring-projects/spring-data-jpa/issues/4167#issuecomment-3783485530.

Tests: ./mvnw -pl spring-data-jpa -Dtest=NamedOrIndexedQueryParameterSetterUnitTests test (local `eclipselink-test` fork still fails due to the existing EclipseLink javaagent ASM error).
