### PR TITLE
Refactor entity metadata resolution to use JpaPersistentEntity.

### DIFF
--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/mapping/JpaMetamodelMappingContext.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/mapping/JpaMetamodelMappingContext.java
@@ -63,8 +63,7 @@ public class JpaMetamodelMappingContext
 
 	@Override
 	protected <T> JpaPersistentEntityImpl<?> createPersistentEntity(TypeInformation<T> typeInformation) {
-		return new JpaPersistentEntityImpl<>(typeInformation, persistenceProvider,
-				models.getRequiredMetamodel(typeInformation));
+		return new JpaPersistentEntityImpl<>(typeInformation, models.getRequiredMetamodel(typeInformation));
 	}
 
 	@Override

--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/mapping/JpaPersistentEntityImpl.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/mapping/JpaPersistentEntityImpl.java
@@ -21,6 +21,7 @@ import org.jspecify.annotations.Nullable;
 
 import org.springframework.data.annotation.Version;
 import org.springframework.data.core.TypeInformation;
+import org.springframework.data.jpa.provider.PersistenceProvider;
 import org.springframework.data.jpa.provider.ProxyIdAccessor;
 import org.springframework.data.jpa.util.JpaMetamodel;
 import org.springframework.data.mapping.IdentifierAccessor;
@@ -36,6 +37,7 @@ import org.springframework.util.Assert;
  * @author Christoph Strobl
  * @author Mark Paluch
  * @author Michael J. Simons
+ * @author Gieun Nam
  * @since 1.3
  */
 class JpaPersistentEntityImpl<T> extends BasicPersistentEntity<T, JpaPersistentProperty>
@@ -45,23 +47,21 @@ class JpaPersistentEntityImpl<T> extends BasicPersistentEntity<T, JpaPersistentP
 			+ org.springframework.data.annotation.Version.class.getName() + " but needs to use "
 			+ jakarta.persistence.Version.class.getName() + " to trigger optimistic locking correctly";
 
-	private final ProxyIdAccessor proxyIdAccessor;
+	private final PersistenceProvider persistenceProvider;
+
 	private final JpaMetamodel metamodel;
 
 	/**
 	 * Creates a new {@link JpaPersistentEntityImpl} using the given {@link TypeInformation} and {@link Comparator}.
 	 *
 	 * @param information must not be {@literal null}.
-	 * @param proxyIdAccessor must not be {@literal null}.
 	 * @param metamodel must not be {@literal null}.
 	 */
-	public JpaPersistentEntityImpl(TypeInformation<T> information, ProxyIdAccessor proxyIdAccessor,
-			JpaMetamodel metamodel) {
+	public JpaPersistentEntityImpl(TypeInformation<T> information, JpaMetamodel metamodel) {
 
 		super(information, null);
-
-		this.proxyIdAccessor = proxyIdAccessor;
 		this.metamodel = metamodel;
+		this.persistenceProvider = PersistenceProvider.fromMetamodel(metamodel.getMetamodel());
 	}
 
 	@Override
@@ -71,7 +71,7 @@ class JpaPersistentEntityImpl<T> extends BasicPersistentEntity<T, JpaPersistentP
 
 	@Override
 	public IdentifierAccessor getIdentifierAccessor(Object bean) {
-		return new JpaProxyAwareIdentifierAccessor(this, bean, proxyIdAccessor);
+		return new JpaProxyAwareIdentifierAccessor(this, bean, persistenceProvider);
 	}
 
 	@Override
@@ -98,7 +98,7 @@ class JpaPersistentEntityImpl<T> extends BasicPersistentEntity<T, JpaPersistentP
 	private static class JpaProxyAwareIdentifierAccessor extends IdPropertyIdentifierAccessor {
 
 		private final Object bean;
-		private final ProxyIdAccessor proxyIdAccessor;
+		private final PersistenceProvider persistenceProvider;
 
 		/**
 		 * Creates a new {@link JpaProxyAwareIdentifierAccessor} for the given {@link JpaPersistentEntity}, target bean and
@@ -106,23 +106,23 @@ class JpaPersistentEntityImpl<T> extends BasicPersistentEntity<T, JpaPersistentP
 		 *
 		 * @param entity must not be {@literal null}.
 		 * @param bean must not be {@literal null}.
-		 * @param proxyIdAccessor must not be {@literal null}.
+		 * @param persistenceProvider must not be {@literal null}.
 		 */
-		JpaProxyAwareIdentifierAccessor(JpaPersistentEntity<?> entity, Object bean, ProxyIdAccessor proxyIdAccessor) {
+		JpaProxyAwareIdentifierAccessor(JpaPersistentEntity<?> entity, Object bean, PersistenceProvider persistenceProvider) {
 
 			super(entity, bean);
 
-			Assert.notNull(proxyIdAccessor, "Proxy identifier accessor must not be null");
+			Assert.notNull(persistenceProvider, "Proxy identifier accessor must not be null");
 
-			this.proxyIdAccessor = proxyIdAccessor;
+			this.persistenceProvider = persistenceProvider;
 			this.bean = bean;
 		}
 
 		@Override
 		public @Nullable Object getIdentifier() {
 
-			return proxyIdAccessor.shouldUseAccessorFor(bean) //
-					? proxyIdAccessor.getIdentifierFrom(bean)//
+			return persistenceProvider.shouldUseAccessorFor(bean) //
+					? persistenceProvider.getIdentifierFrom(bean)//
 					: super.getIdentifier();
 		}
 	}

--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/mapping/JpaPersistentEntityInformation.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/mapping/JpaPersistentEntityInformation.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2026-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.jpa.mapping;
+
+
+import org.springframework.data.mapping.IdentifierAccessor;
+import org.springframework.util.Assert;
+
+/**
+ * Implementation of {@link JpaPersistentEntityInformation}.
+ *
+ * @author Gieun Nam
+ * @since 4.1
+ */
+public class JpaPersistentEntityInformation<T, ID> {
+    private final JpaPersistentEntity<T> entityMetadata;
+
+    public JpaPersistentEntityInformation(JpaPersistentEntity<T> entityMetadata) {
+        Assert.notNull(entityMetadata, "JpaPersistentEntity must not be null");
+        this.entityMetadata = entityMetadata;
+    }
+
+    public ID getId(T entity) {
+        Assert.notNull(entity, "Entity must not be null");
+
+        IdentifierAccessor accessor = entityMetadata.getIdentifierAccessor(entity);
+        return (ID) accessor.getIdentifier();
+    }
+
+    public Class<ID> getIdType() {
+        return (Class<ID>) entityMetadata.getRequiredIdProperty().getType();
+    }
+
+    public boolean isNew(T entity) {
+        return entityMetadata.isNew(entity);
+    }
+
+    public boolean hasCompositeId() {
+        JpaPersistentProperty idProperty = entityMetadata.getRequiredIdProperty();
+        return idProperty.isEmbeddable();
+    }
+
+    public Class<?> getIdAttribute() {
+        return entityMetadata.getRequiredIdProperty().getActualType();
+    }
+}

--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/util/JpaMetamodel.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/util/JpaMetamodel.java
@@ -154,4 +154,8 @@ public class JpaMetamodel {
 				.filter(SingularAttribute::isId) //
 				.findFirst();
 	}
+
+	public Metamodel getMetamodel() {
+		return metamodel;
+	}
 }

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/mapping/JpaPersistentEntityInformationUnitTests.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/mapping/JpaPersistentEntityInformationUnitTests.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2026-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.jpa.mapping;
+
+import jakarta.persistence.metamodel.Metamodel;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+/**
+ * Unit tests for {@link JpaPersistentEntityInformation}.
+ *
+ * @author Gieun Nam
+ */
+class JpaPersistentEntityInformationUnitTests {
+    private JpaMetamodelMappingContext mappingContext;
+    @BeforeEach
+    void setUp() {
+        Metamodel metamodel = mock(Metamodel.class);
+        this.mappingContext = new JpaMetamodelMappingContext(Collections.singleton(metamodel));
+    }
+
+    @Test // GH-4037
+    void validationScenario() {
+        JpaPersistentEntity<?> metaData = mappingContext.getRequiredPersistentEntity(User.class);
+
+        JpaPersistentEntityInformation<User, Long> entityInfo =
+                new JpaPersistentEntityInformation<>((JpaPersistentEntity<User>) metaData);
+
+        User user = new User();
+        user.id = 77L;
+
+        assertThat(entityInfo.getId(user)).isEqualTo(77L);
+
+        assertThat(entityInfo.getIdType()).isEqualTo(Long.class);
+
+        assertThat(entityInfo.isNew(user)).isFalse();
+
+        assertThat(entityInfo.hasCompositeId()).isFalse();
+
+        assertThat(entityInfo.getIdAttribute()).isEqualTo(Long.class);
+    }
+
+    @Test
+    void identifiesCompositeIdCorrectly() {
+        JpaPersistentEntity<?> metaData = mappingContext.getRequiredPersistentEntity(Order.class);
+        JpaPersistentEntityInformation<Order, OrderId> entityInfo =
+                new JpaPersistentEntityInformation<>((JpaPersistentEntity<Order>) metaData);
+
+        assertThat(entityInfo.hasCompositeId()).isTrue();
+
+        assertThat(entityInfo.getIdAttribute()).isEqualTo(OrderId.class);
+    }
+
+    // Test Entities
+    static class User {
+        @jakarta.persistence.Id Long id;
+    }
+
+    static class Order {
+        @jakarta.persistence.EmbeddedId OrderId id;
+    }
+
+    @jakarta.persistence.Embeddable
+    static class OrderId implements java.io.Serializable {
+        Long orderId;
+        Long userId;
+    }
+}


### PR DESCRIPTION
1. Refactor JpaPersistentEntityImpl.getIdentifier to use PersistenceProvider instead of ProxyIdAccessor for proxy identification checks.
2. Introduce JpaPersistentEntityInformation to decouple metadata extraction from JpaMetamodelEntityInformation. This allows metadata resolution by depending solely on JpaPersistentEntity rather than multiple instances like IdMetadata or PersistenceUnitUtil.
3. Add JpaPersistentEntityInformationUnitTests to verify identity extraction, type resolution, and composite ID detection logic.

This change aligns JPA entity information handling with the core Spring Data mapping infrastructure and reduces redundant metadata analysis. Refs #4037

<!--

Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
Make sure that:

-->

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [ ] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
