### PR TITLE
Fix typos in test Javadoc

### DIFF
--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/UserRepositoryTests.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/UserRepositoryTests.java
@@ -404,7 +404,7 @@ class UserRepositoryTests {
 	}
 
 	/**
-	 * Tests, that persisting a relationsship without cascade attributes throws a {@code DataAccessException}.
+	 * Tests, that persisting a relationship without cascade attributes throws a {@code DataAccessException}.
 	 */
 	@Test
 	void testPreventsCascadingRolePersisting() {

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/support/JpaRepositoryFactoryUnitTests.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/support/JpaRepositoryFactoryUnitTests.java
@@ -113,8 +113,8 @@ class JpaRepositoryFactoryUnitTests {
 
 	/**
 	 * Asserts that the factory recognized configured predicateExecutor classes that contain custom method but no custom
-	 * implementation could be found. Furthremore the exception has to contain the name of the predicateExecutor interface
-	 * as for a large predicateExecutor configuration it's hard to find out where this error occured.
+	 * implementation could be found. Furthermore, the exception has to contain the name of the predicateExecutor interface
+	 * as for a large predicateExecutor configuration it's hard to find out where this error occurred.
 	 */
 	@Test
 	void capturesMissingCustomImplementationAndProvidesInterfacename() {


### PR DESCRIPTION
Fix two typos in test Javadoc:

- relationsship → relationship
- Furthremore -> Furthermore,
- occured → occurred

Comment-only change. No functional impact.