### PR TITLE
Add PredicateSpecification findAll overloads

### DIFF
--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/JpaSpecificationExecutor.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/JpaSpecificationExecutor.java
@@ -102,6 +102,18 @@ public interface JpaSpecificationExecutor<T> {
 	Page<T> findAll(Specification<T> spec, Pageable pageable);
 
 	/**
+	 * Returns a {@link Page} of entities matching the given {@link PredicateSpecification}.
+	 *
+	 * @param spec must not be {@literal null}.
+	 * @param pageable must not be {@literal null}.
+	 * @return never {@literal null}.
+	 * @see Specification#unrestricted()
+	 */
+	default Page<T> findAll(PredicateSpecification<T> spec, Pageable pageable) {
+		return findAll(Specification.where(spec), pageable);
+	}
+
+	/**
 	 * Returns a {@link Page} of entities matching the given {@link Specification}.
 	 * <p>
 	 * Supports counting the total number of entities matching the {@link Specification}.
@@ -115,6 +127,21 @@ public interface JpaSpecificationExecutor<T> {
 	Page<T> findAll(Specification<T> spec, Specification<T> countSpec, Pageable pageable);
 
 	/**
+	 * Returns a {@link Page} of entities matching the given {@link PredicateSpecification}.
+	 * <p>
+	 * Supports counting the total number of entities matching the {@link PredicateSpecification}.
+	 *
+	 * @param spec must not be {@literal null}.
+	 * @param countSpec must not be {@literal null}.
+	 * @param pageable must not be {@literal null}.
+	 * @return never {@literal null}.
+	 * @since 3.5
+	 */
+	default Page<T> findAll(PredicateSpecification<T> spec, PredicateSpecification<T> countSpec, Pageable pageable) {
+		return findAll(Specification.where(spec), Specification.where(countSpec), pageable);
+	}
+
+	/**
 	 * Returns all entities matching the given {@link Specification} and {@link Sort}.
 	 *
 	 * @param spec must not be {@literal null}.
@@ -123,6 +150,18 @@ public interface JpaSpecificationExecutor<T> {
 	 * @see Specification#unrestricted()
 	 */
 	List<T> findAll(Specification<T> spec, Sort sort);
+
+	/**
+	 * Returns all entities matching the given {@link PredicateSpecification} and {@link Sort}.
+	 *
+	 * @param spec must not be {@literal null}.
+	 * @param sort must not be {@literal null}.
+	 * @return never {@literal null}.
+	 * @see Specification#unrestricted()
+	 */
+	default List<T> findAll(PredicateSpecification<T> spec, Sort sort) {
+		return findAll(Specification.where(spec), sort);
+	}
 
 	/**
 	 * Returns the number of instances that the given {@link PredicateSpecification} will return.

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/UserRepositoryTests.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/UserRepositoryTests.java
@@ -531,7 +531,7 @@ class UserRepositoryTests {
 		flushTestUsers();
 		PredicateSpecification<User> spec1 = userHasFirstname("Oliver").or(userHasLastname("Arrasz"));
 
-		Page<User> users1 = repository.findAll(Specification.where(spec1), PageRequest.of(0, 1));
+		Page<User> users1 = repository.findAll(spec1, PageRequest.of(0, 1));
 		assertThat(users1.getSize()).isOne();
 		assertThat(users1.hasPrevious()).isFalse();
 		assertThat(users1.getTotalElements()).isEqualTo(2L);
@@ -540,12 +540,43 @@ class UserRepositoryTests {
 				userHasFirstname("Oliver"), //
 				userHasLastname("Arrasz"));
 
-		Page<User> users2 = repository.findAll(Specification.where(spec2), PageRequest.of(0, 1));
+		Page<User> users2 = repository.findAll(spec2, PageRequest.of(0, 1));
 		assertThat(users2.getSize()).isOne();
 		assertThat(users2.hasPrevious()).isFalse();
 		assertThat(users2.getTotalElements()).isEqualTo(2L);
 
 		assertThat(users1).containsExactlyInAnyOrderElementsOf(users2);
+	}
+
+	@Test // GH-4198
+	void executesCombinedSpecificationsWithCountSpecCorrectly() {
+
+		flushTestUsers();
+
+		PredicateSpecification<User> spec = userHasFirstname("Oliver").or(userHasLastname("Matthews"));
+		PredicateSpecification<User> countSpec = userHasFirstname("Oliver");
+
+		Page<User> users = repository.findAll(spec, countSpec, PageRequest.of(0, 1, Sort.by("id")));
+
+		assertThat(users.getSize()).isOne();
+		assertThat(users.hasPrevious()).isFalse();
+		assertThat(users.getTotalElements()).isOne();
+	}
+
+	@Test // GH-4198
+	void executesCombinedSpecificationsWithSortCorrectly() {
+
+		flushTestUsers();
+
+		PredicateSpecification<User> spec1 = userHasFirstname("Oliver").or(userHasLastname("Matthews"));
+		List<User> users1 = repository.findAll(spec1, Sort.by("id"));
+
+		PredicateSpecification<User> spec2 = PredicateSpecification.anyOf( //
+				userHasFirstname("Oliver"), //
+				userHasLastname("Matthews"));
+		List<User> users2 = repository.findAll(spec2, Sort.by("id"));
+
+		assertThat(users1).containsExactlyElementsOf(users2);
 	}
 
 	@Test


### PR DESCRIPTION
Closes #4198

Add missing `PredicateSpecification` overloads to `JpaSpecificationExecutor` for `findAll` with `Pageable` and `Sort`.

Changes include:
- adding default `findAll(PredicateSpecification<T> spec, Pageable pageable)`
- adding default `findAll(PredicateSpecification<T> spec, PredicateSpecification<T> countSpec, Pageable pageable)`
- adding default `findAll(PredicateSpecification<T> spec, Sort sort)`
- extending `UserRepositoryTests` to cover pageable/countSpec/sort paths for `PredicateSpecification`
