### PR TITLE
Consider unsafe `JpaSort` in Querydsl sorting

### DIFF
--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/support/Querydsl.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/support/Querydsl.java
@@ -236,8 +236,6 @@ public class Querydsl {
             return Expressions.template(Object.class, order.getProperty());
         }
 
-        Assert.notNull(order, "Order must not be null");
-
         QueryUtils.checkSortExpression(order);
         PropertyPath path = PropertyPath.from(order.getProperty(), builder.getType());
         Expression<?> sortPropertyExpression = builder;

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/support/QuerydslIntegrationTests.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/support/QuerydslIntegrationTests.java
@@ -21,12 +21,9 @@ import java.util.stream.Stream;
 
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-
-import org.springframework.data.core.PropertyReferenceException;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.jpa.domain.sample.User;
 import org.springframework.test.context.ContextConfiguration;
@@ -84,28 +81,6 @@ class QuerydslIntegrationTests {
 		assertThat(result.toString()) //
 				.startsWith("select user") //
 				.endsWith("order by lower(user.firstname) asc, user.id asc, user.dateOfBirth asc");
-	}
-
-	@Test // GH-4209
-	void shouldApplySortingByProjectionAlias() {
-
-		JPQLQuery<?> projectedQuery = querydsl.createQuery()
-				.select(userPath.getString("firstname").as("firstnameAlias"), userPath.getNumber("id", Integer.class));
-
-		JPQLQuery<?> result = querydsl.applySorting(Sort.by("firstnameAlias"), projectedQuery);
-
-		assertThat(result).isNotNull();
-		assertThat(result.toString()).contains("order by");
-	}
-
-	@Test // GH-4209
-	void shouldThrowPropertyReferenceExceptionForUnknownProjectionAlias() {
-
-		JPQLQuery<?> projectedQuery = querydsl.createQuery()
-				.select(userPath.getString("firstname").as("firstnameAlias"), userPath.getNumber("id", Integer.class));
-
-		assertThatExceptionOfType(PropertyReferenceException.class)
-				.isThrownBy(() -> querydsl.applySorting(Sort.by("doesNotExistAlias"), projectedQuery));
 	}
 
 }

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/support/QuerydslRepositorySupportTests.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/support/QuerydslRepositorySupportTests.java
@@ -125,7 +125,6 @@ class QuerydslRepositorySupportTests {
 
 	@Test
 	void findAll() {
-
 		Page<User> page = repository.findAllByFilter(null,
 				PageRequest.of(0, 10, Sort.by("firstname").ascending()));
 
@@ -137,16 +136,6 @@ class QuerydslRepositorySupportTests {
         Page<User> page = repository.findAllByFilter(null,
                 PageRequest.of(0, 10, JpaSort.unsafe("lower(firstname)").ascending()));
         assertThat(page).hasSize(2);
-    }
-
-    @Test
-    void findAllWithAlias() {
-        Page<User> page = repository.findAllByFilter(null,
-                PageRequest.of(0, 10, Sort.by("firstNameAlias").ascending()));
-
-        assertThat(page).hasSize(2);
-        assertThat(page.getContent().stream().map(User::getFirstname).collect(Collectors.toList()))
-                .containsExactly("Carter", "Dave");
     }
 
 	interface UserRepository {


### PR DESCRIPTION
Fixes #4209 