### PR TITLE
Refine `JpaOrder.withUnsafe(…)` documentation

### DIFF
--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/domain/JpaSort.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/domain/JpaSort.java
@@ -381,6 +381,10 @@ public class JpaSort extends Sort {
 		/**
 		 * Creates new {@link Sort} with potentially unsafe {@link Order} instances.
 		 *
+		 * <p>
+		 * The returned {@link JpaOrder} instances inherit the receiver's direction,
+		 * case-sensitivity, and null-handling settings for each provided property.
+		 *
 		 * @param properties must not be {@literal null}.
 		 * @return
 		 */

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/domain/JpaSortTests.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/domain/JpaSortTests.java
@@ -27,6 +27,7 @@ import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
+import org.springframework.data.domain.Sort;
 import org.springframework.data.jpa.domain.sample.Address_;
 import org.springframework.data.jpa.domain.sample.MailMessage_;
 import org.springframework.data.jpa.domain.sample.MailSender_;
@@ -172,6 +173,20 @@ class JpaSortTests {
 		assertThat(sort).contains(Order.desc("foo.bar"), Order.desc("spring.data"));
 		assertThat(sort.getOrderFor("foo.bar")).isInstanceOf(JpaOrder.class);
 		assertThat(sort.getOrderFor("spring.data")).isInstanceOf(JpaOrder.class);
+	}
+
+	@Test // GH-2932
+	void withUnsafeRetainsOrderConfigurationForAllProperties() {
+
+		JpaOrder order = ((JpaOrder) JpaSort.unsafe(DESC, "foo.bar").getOrderFor("foo.bar")).ignoreCase()
+				.with(Sort.NullHandling.NULLS_LAST);
+
+		Sort sort = order.withUnsafe("spring.data", "baz");
+
+		assertThat(sort).containsExactly(Order.desc("spring.data").ignoreCase().nullsLast(),
+				Order.desc("baz").ignoreCase().nullsLast());
+		assertThat(sort.getOrderFor("spring.data")).isInstanceOf(JpaOrder.class);
+		assertThat(sort.getOrderFor("baz")).isInstanceOf(JpaOrder.class);
 	}
 
 	@Test // DATAJPA-965

--- a/src/main/antora/modules/ROOT/pages/jpa/query-methods.adoc
+++ b/src/main/antora/modules/ROOT/pages/jpa/query-methods.adoc
@@ -408,6 +408,7 @@ Throws Exception.
 
 * When used with derived Queries or String-based Queries, the order string is appended to the query.
 * When used with Query by Example or Specifications (that use `CriteriaQuery`), order expressions are parsed and added to the `CriteriaQuery` as expressions.
+* `JpaSort.JpaOrder.withUnsafe(…)` keeps the source order's direction, case-sensitivity, and null-handling settings for each new property.
 Query expressions can contain function calls, various clauses (such as `CASE WHEN`, arithmetic expressions) or property paths.
 Order translation does not support subquery expressions, `TREAT` and `CAST`.
 


### PR DESCRIPTION
Closes #2932

This clarifies that `JpaOrder.withUnsafe` returns a new order instance instead of mutating the existing one.

The change adds focused tests and updates the reference documentation to make that behavior explicit.

Tests:
- `JpaSortTests`