### PR TITLE
test: Use ARM64-compatible MySQL image in stored procedure integration tests

### DIFF
--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/procedures/MySqlStoredProcedureIntegrationTests.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/procedures/MySqlStoredProcedureIntegrationTests.java
@@ -258,7 +258,7 @@ class MySqlStoredProcedureIntegrationTests {
 		@Bean(initMethod = "start", destroyMethod = "stop")
 		public MySQLContainer container() {
 
-			return new MySQLContainer("mysql:8.0.24") //
+			return new MySQLContainer("mysql:8.0.43") //
 					.withUsername("test") //
 					.withPassword("test") //
 					.withConfigurationOverride("");


### PR DESCRIPTION
## Summary

This PR updates the MySQL Testcontainers image used by
`MySqlStoredProcedureIntegrationTests` from `mysql:8.0.24` to `mysql:8.0.43`.

## Motivation

`mysql:8.0.24` does not provide a `linux/arm64/v8` manifest, which can break
test execution on Apple Silicon machines when the image is not already cached.
That makes contributor experience inconsistent across architectures.

## Changes

- Updated:
  - `spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/procedures/MySqlStoredProcedureIntegrationTests.java`
- Image tag:
  - `mysql:8.0.24` -> `mysql:8.0.43`

## Verification

Executed:

`./mvnw -pl spring-data-jpa -Dtest=org.springframework.data.jpa.repository.procedures.MySqlStoredProcedureIntegrationTests test -DfailIfNoTests=false`

Result:

- BUILD SUCCESS
- Tests run: 8, Failures: 0, Errors: 0, Skipped: 0

## Impact

- Test-only change (no production/runtime code path changes).
- Improves cross-platform reliability for contributors, especially on ARM64/Apple Silicon.