### PR TITLE
Do not use tuple-typed queries for derived count queries. 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-jpa-parent</artifactId>
-	<version>4.1.0-SNAPSHOT</version>
+	<version>4.1.x-GH-4230-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data JPA Parent</name>

--- a/spring-data-envers/pom.xml
+++ b/spring-data-envers/pom.xml
@@ -5,12 +5,12 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-envers</artifactId>
-	<version>4.1.0-SNAPSHOT</version>
+	<version>4.1.x-GH-4230-SNAPSHOT</version>
 
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-jpa-parent</artifactId>
-		<version>4.1.0-SNAPSHOT</version>
+		<version>4.1.x-GH-4230-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-jpa-distribution/pom.xml
+++ b/spring-data-jpa-distribution/pom.xml
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-jpa-parent</artifactId>
-		<version>4.1.0-SNAPSHOT</version>
+		<version>4.1.x-GH-4230-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-jpa/pom.xml
+++ b/spring-data-jpa/pom.xml
@@ -7,7 +7,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-jpa</artifactId>
-	<version>4.1.0-SNAPSHOT</version>
+	<version>4.1.x-GH-4230-SNAPSHOT</version>
 
 	<name>Spring Data JPA</name>
 	<description>Spring Data module for JPA repositories.</description>
@@ -16,7 +16,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-jpa-parent</artifactId>
-		<version>4.1.0-SNAPSHOT</version>
+		<version>4.1.x-GH-4230-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/JpaCountQueryCreator.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/JpaCountQueryCreator.java
@@ -78,6 +78,11 @@ public class JpaCountQueryCreator extends JpaQueryCreator {
 	}
 
 	@Override
+	public boolean useTupleQuery() {
+		return false;
+	}
+
+	@Override
 	protected JpqlQueryBuilder.Select buildQuery(Sort sort) {
 
 		JpqlQueryBuilder.SelectStep selectStep = JpqlQueryBuilder.selectFrom(getEntity());

--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/PartTreeJpaQuery.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/PartTreeJpaQuery.java
@@ -68,7 +68,7 @@ public class PartTreeJpaQuery extends AbstractJpaQuery {
 	private final JpaParameters parameters;
 
 	private final QueryPreparer queryPreparer;
-	private final QueryPreparer countQuery;
+	private final CountQueryPreparer countQuery;
 	private final EntityManager em;
 	private final EscapeCharacter escape;
 	private final Lazy<JpaEntityInformation<?, ?>> entityInformation;

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/PartTreeJpaQueryIntegrationTests.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/PartTreeJpaQueryIntegrationTests.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2011-present the original author or authors.
  *
- * Licensed under the Apache License, Version 2.0 (the "License
-import org.springframework.aop.framework.Advised;
-");
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
@@ -22,6 +20,7 @@ import static org.assertj.core.api.Assertions.*;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
 import jakarta.persistence.Query;
+import jakarta.persistence.Tuple;
 import jakarta.persistence.TemporalType;
 
 import java.lang.reflect.Method;
@@ -247,6 +246,20 @@ class PartTreeJpaQueryIntegrationTests {
 		new PartTreeJpaQuery(getQueryMethod("findByAttributes", String[].class), entityManager);
 	}
 
+	@Test // GH-4230
+	void countQueryForPagedInterfaceProjectionReturnsScalarAggregate() throws Exception {
+
+		JpaQueryMethod queryMethod = getQueryMethod(ProjectionPagingRepository.class, "findByFirstname", String.class,
+				Pageable.class);
+		PartTreeJpaQuery jpaQuery = new PartTreeJpaQuery(queryMethod, entityManager);
+
+		Query countQuery = jpaQuery
+				.createCountQuery(getAccessor(queryMethod, new Object[] { "Matthews", PageRequest.of(0, 2) }));
+
+		Object total = countQuery.getSingleResult();
+		assertThat(total).isInstanceOf(Number.class).isNotInstanceOf(Tuple.class);
+	}
+
 	private void testIgnoreCase(String methodName, Object... values) throws Exception {
 
 		Class<?>[] parameterTypes = new Class[values.length];
@@ -262,8 +275,14 @@ class PartTreeJpaQueryIntegrationTests {
 
 	private JpaQueryMethod getQueryMethod(String methodName, Class<?>... parameterTypes) throws Exception {
 
-		Method method = UserRepository.class.getMethod(methodName, parameterTypes);
-		return new JpaQueryMethod(method, new DefaultRepositoryMetadata(UserRepository.class),
+		return getQueryMethod(UserRepository.class, methodName, parameterTypes);
+	}
+
+	private JpaQueryMethod getQueryMethod(Class<?> repositoryType, String methodName, Class<?>... parameterTypes)
+			throws Exception {
+
+		Method method = repositoryType.getMethod(methodName, parameterTypes);
+		return new JpaQueryMethod(method, new DefaultRepositoryMetadata(repositoryType),
 				new SpelAwareProxyProjectionFactory(), PersistenceProvider.fromEntityManager(entityManager));
 	}
 
@@ -324,6 +343,14 @@ class PartTreeJpaQueryIntegrationTests {
 		List<User> findByAttributes(Set<String> attributes);
 
 		List<User> findByAttributes(String... attributes);
+	}
+
+	interface UserNameProjection {
+		String getLastname();
+	}
+
+	interface ProjectionPagingRepository extends Repository<User, Integer> {
+		Page<UserNameProjection> findByFirstname(String firstname, Pageable pageable);
 	}
 
 }


### PR DESCRIPTION
This PR fixes a problem where interface projections used to set `useTupleQuery` to `true` on `JpaQueryCreator`, which was later also reused to build the count query. This caused trouble when reading results expecting a numeric value.

Closes: #4230 