### PR TITLE
Detect `COUNT(*)` function alias in `QueryUtils`

### DIFF
--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/QueryUtils.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/QueryUtils.java
@@ -90,6 +90,7 @@ import org.springframework.util.StringUtils;
  * @author Yanming Zhou
  * @author Alim Naizabek
  * @author Jakub Soltys
+ * @author Young-ho Kim
  */
 public abstract class QueryUtils {
 
@@ -184,7 +185,7 @@ public abstract class QueryUtils {
 
 		builder = new StringBuilder();
 		// any function call including parameters within the brackets
-		builder.append("\\w+\\s*\\([\\w\\.,\\s'=:;\\\\?]+\\)");
+		builder.append("\\w+\\s*\\([\\w\\.,\\s'=:;\\\\?\\*]+\\)");
 		// the potential alias
 		builder.append("\\s+(?:as)+\\s+([\\w\\.]+)");
 

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/QueryUtilsUnitTests.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/QueryUtilsUnitTests.java
@@ -52,6 +52,7 @@ import org.springframework.data.jpa.domain.JpaSort;
  * @author Pranav HS
  * @author Eduard Dudar
  * @author Mark Paluch
+ * @author Young-ho Kim
  */
 class QueryUtilsUnitTests {
 
@@ -558,6 +559,13 @@ class QueryUtilsUnitTests {
 		assertThat(getFunctionAliases("1 as alias1, COUNT(2) as alias2")).containsExactly("alias2");
 		assertThat(getFunctionAliases("COUNT(1) as alias1,2 as alias2")).containsExactly("alias1");
 		assertThat(getFunctionAliases("COUNT(1) as alias1, 2 as alias2")).containsExactly("alias1");
+	}
+
+	@Test // GH-4242
+	void discoversCountStarFunctionAlias() {
+
+		assertThat(getFunctionAliases("SELECT COUNT(*) as total FROM User u")).containsExactly("total");
+		assertThat(getFunctionAliases("SELECT u, COUNT(*) as cnt FROM User u GROUP BY u")).containsExactly("cnt");
 	}
 
 	@Test // GH-3911


### PR DESCRIPTION
Include the asterisk character in the `FUNCTION_PATTERN` argument
  character class so that the `COUNT(*) AS <alias>` form is detected by
  `QueryUtils.getFunctionAliases`.

  Without this, `DefaultQueryEnhancer.applySorting` prefixes the alias
  with the root entity alias and produces invalid SQL such as
  `ORDER BY u.cnt` instead of `ORDER BY cnt`.

  Adds a regression test (`discoversCountStarFunctionAlias`) covering the
  issue's reproducer and the GROUP BY example from the issue body.

  Closes #4242