### PR TITLE
Resolve IdClass exception for mapped superclasses with mixed access types.

### DIFF
--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/support/JpaMetamodelEntityInformation.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/support/JpaMetamodelEntityInformation.java
@@ -57,6 +57,7 @@ import org.springframework.util.Assert;
  * @author Mark Paluch
  * @author Jens Schauder
  * @author Greg Turnquist
+ * @author Myles Fang
  */
 public class JpaMetamodelEntityInformation<T, ID> extends JpaEntityInformationSupport<T, ID> {
 
@@ -327,6 +328,11 @@ public class JpaMetamodelEntityInformation<T, ID> extends JpaEntityInformationSu
 						return Collections.singleton(attribute);
 					}
 				}
+				// SingularAttributes may not include the @Id when it's
+				// inherited from a @MappedSuperclass with a different
+				// @Access type. Fall back to getId() which resolves the
+				// attribute through the type hierarchy.
+				return Collections.singleton(source.getId(source.getIdType().getJavaType()));
 			}
 			return source.getIdClassAttributes();
 		}

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/support/JpaMetamodelEntityInformationIntegrationTests.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/support/JpaMetamodelEntityInformationIntegrationTests.java
@@ -40,6 +40,7 @@ import org.springframework.test.util.ReflectionTestUtils;
  * @author Christoph Strobl
  * @author Jens Schauder
  * @author Greg Turnquist
+ * @author Myles Fang
  */
 public abstract class JpaMetamodelEntityInformationIntegrationTests {
 
@@ -315,6 +316,65 @@ public abstract class JpaMetamodelEntityInformationIntegrationTests {
 		Object id = information.getId(entity);
 
 		assertThat(id).isEqualTo(42L);
+	}
+
+	/**
+	 * GH-4246: Current Hibernate already includes inherited {@code @Id} in
+	 * {@code getSingularAttributes()}, so this test passes without the
+	 * {@code findAttributes()} fallback (see UnitTests for the mocked
+	 * fallback path). The real bug surfaces on other JPA providers that miss
+	 * the {@code @Id} when {@code @Access} types differ between
+	 * {@code @Entity} and {@code @MappedSuperclass}.
+	 */
+	@Test // GH-4246
+	void resolvesIdFromMappedSuperclassWithDifferentAccessType() {
+
+		JpaMetamodelEntityInformation<EntityWithFieldAccessAndMappedSuperclassPropertyId, Long> information = new JpaMetamodelEntityInformation<>(
+				EntityWithFieldAccessAndMappedSuperclassPropertyId.class, em.getMetamodel(),
+				em.getEntityManagerFactory().getPersistenceUnitUtil());
+
+		assertThat(information.getIdType()).isEqualTo(Long.class);
+		assertThat(information.hasCompositeId()).isFalse();
+		assertThat(information.getId(new EntityWithFieldAccessAndMappedSuperclassPropertyId())).isNull();
+	}
+
+	/**
+	 * GH-4246: Companion to
+	 * {@link #resolvesIdFromMappedSuperclassWithDifferentAccessType()}.
+	 * See that method for context.
+	 */
+	@Test // GH-4246
+	void resolvesIdAttributePathsFromMappedSuperclassWithDifferentAccessType() {
+
+		JpaMetamodelEntityInformation<EntityWithFieldAccessAndMappedSuperclassPropertyId, Long> information = new JpaMetamodelEntityInformation<>(
+				EntityWithFieldAccessAndMappedSuperclassPropertyId.class, em.getMetamodel(),
+				em.getEntityManagerFactory().getPersistenceUnitUtil());
+
+		assertThat(information.getIdAttributeNames()).containsExactly("id");
+	}
+
+	@MappedSuperclass
+	@Access(AccessType.PROPERTY)
+	public static abstract class PropertyAccessMappedSuperclass {
+
+		private Long id;
+
+		@Id
+		@GeneratedValue
+		public Long getId() {
+			return this.id;
+		}
+
+		public void setId(Long id) {
+			this.id = id;
+		}
+	}
+
+	@Entity
+	@Access(AccessType.FIELD)
+	public static class EntityWithFieldAccessAndMappedSuperclassPropertyId extends PropertyAccessMappedSuperclass {
+
+		private String name;
 	}
 
 	@SuppressWarnings("serial")

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/support/JpaMetamodelEntityInformationUnitTests.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/support/JpaMetamodelEntityInformationUnitTests.java
@@ -46,6 +46,7 @@ import org.springframework.data.jpa.domain.sample.PersistableWithIdClassPK;
  *
  * @author Oliver Gierke
  * @author Jens Schauder
+ * @author Myles Fang
  */
 @ExtendWith(MockitoExtension.class)
 @MockitoSettings(strictness = Strictness.LENIENT)
@@ -61,6 +62,10 @@ class JpaMetamodelEntityInformationUnitTests {
 
 	@Mock
 	@SuppressWarnings("rawtypes") Type idType;
+
+	@Mock IdentifiableType<PersistableWithIdClass> singleIdType;
+	@Mock Type<String> singleIdTypeMock;
+	@Mock SingularAttribute<PersistableWithIdClass, String> singleIdAttribute;
 
 	@BeforeEach
 	@SuppressWarnings("unchecked")
@@ -95,5 +100,28 @@ class JpaMetamodelEntityInformationUnitTests {
 		entity = new PersistableWithIdClass(2L, null);
 		when(persistenceUnit.getIdentifier(entity)).thenReturn(2L);
 		assertThat(information.getId(entity)).isNotNull();
+	}
+
+	@Test // GH-4246
+	void fallsBackToGetIdWhenSingularAttributesMissesInheritedId() {
+
+		when(singleIdType.hasSingleIdAttribute()).thenReturn(true);
+		when(singleIdType.getSingularAttributes()).thenReturn(java.util.Collections.emptySet());
+		doReturn(singleIdTypeMock).when(singleIdType).getIdType();
+		when(singleIdTypeMock.getJavaType()).thenReturn(String.class);
+
+		when(singleIdAttribute.getName()).thenReturn("id");
+		when(singleIdAttribute.isId()).thenReturn(true);
+		when(singleIdAttribute.isAssociation()).thenReturn(false);
+		when(singleIdAttribute.getJavaType()).thenReturn(String.class);
+		doReturn(singleIdAttribute).when(singleIdType).getId(String.class);
+
+		when(metamodel.managedType(PersistableWithIdClass.class)).thenReturn(singleIdType);
+
+		JpaMetamodelEntityInformation<PersistableWithIdClass, Serializable> information = new JpaMetamodelEntityInformation<>(
+				PersistableWithIdClass.class, metamodel, persistenceUnit);
+
+		assertThat(information.hasCompositeId()).isFalse();
+		assertThat(information.getIdAttribute().getName()).isEqualTo("id");
 	}
 }

--- a/spring-data-jpa/src/test/resources/META-INF/persistence.xml
+++ b/spring-data-jpa/src/test/resources/META-INF/persistence.xml
@@ -67,6 +67,8 @@
 		<class>org.springframework.data.jpa.repository.support.JpaMetamodelEntityInformationIntegrationTests$EntityWithNestedIdClass</class>
 		<class>org.springframework.data.jpa.repository.support.JpaMetamodelEntityInformationIntegrationTests$EntityWithIdClass</class>
 		<class>org.springframework.data.jpa.repository.support.JpaMetamodelEntityInformationIntegrationTests$EntityWithPrivateIdGetter</class>
+		<class>org.springframework.data.jpa.repository.support.JpaMetamodelEntityInformationIntegrationTests$PropertyAccessMappedSuperclass</class>
+		<class>org.springframework.data.jpa.repository.support.JpaMetamodelEntityInformationIntegrationTests$EntityWithFieldAccessAndMappedSuperclassPropertyId</class>
 		<class>org.springframework.data.jpa.domain.sample.Trade</class>
 		<class>org.springframework.data.jpa.domain.sample.TradeOrder</class>
 		<class>org.springframework.data.jpa.domain.sample.TradeItem</class>
@@ -140,6 +142,8 @@
 		<class>org.springframework.data.jpa.repository.support.JpaMetamodelEntityInformationIntegrationTests$EntityWithPrivateIdGetter</class>
 		<class>org.springframework.data.jpa.repository.support.JpaMetamodelEntityInformationIntegrationTests$ExampleEntityWithStringId</class>
 		<class>org.springframework.data.jpa.repository.support.JpaMetamodelEntityInformationIntegrationTests$ExampleEntityWithUUIDId</class>
+		<class>org.springframework.data.jpa.repository.support.JpaMetamodelEntityInformationIntegrationTests$PropertyAccessMappedSuperclass</class>
+		<class>org.springframework.data.jpa.repository.support.JpaMetamodelEntityInformationIntegrationTests$EntityWithFieldAccessAndMappedSuperclassPropertyId</class>
 		<exclude-unlisted-classes>true</exclude-unlisted-classes>
 		<properties>
 			<property name="hibernate.dialect" value="org.hibernate.dialect.HSQLDialect" />
@@ -159,6 +163,8 @@
 		<class>org.springframework.data.jpa.repository.support.JpaMetamodelEntityInformationIntegrationTests$EntityWithPrivateIdGetter</class>
 		<class>org.springframework.data.jpa.repository.support.JpaMetamodelEntityInformationIntegrationTests$ExampleEntityWithStringId</class>
 		<class>org.springframework.data.jpa.repository.support.JpaMetamodelEntityInformationIntegrationTests$ExampleEntityWithUUIDId</class>
+		<class>org.springframework.data.jpa.repository.support.JpaMetamodelEntityInformationIntegrationTests$PropertyAccessMappedSuperclass</class>
+		<class>org.springframework.data.jpa.repository.support.JpaMetamodelEntityInformationIntegrationTests$EntityWithFieldAccessAndMappedSuperclassPropertyId</class>
 		<class>org.springframework.data.jpa.domain.sample.Dummy</class>
 		<exclude-unlisted-classes>true</exclude-unlisted-classes>
 		<properties>
@@ -184,6 +190,8 @@
 		<class>org.springframework.data.jpa.repository.support.JpaMetamodelEntityInformationIntegrationTests$EntityWithPrivateIdGetter</class>
 		<class>org.springframework.data.jpa.repository.support.JpaMetamodelEntityInformationIntegrationTests$ExampleEntityWithStringId</class>
 		<class>org.springframework.data.jpa.repository.support.JpaMetamodelEntityInformationIntegrationTests$ExampleEntityWithUUIDId</class>
+		<class>org.springframework.data.jpa.repository.support.JpaMetamodelEntityInformationIntegrationTests$PropertyAccessMappedSuperclass</class>
+		<class>org.springframework.data.jpa.repository.support.JpaMetamodelEntityInformationIntegrationTests$EntityWithFieldAccessAndMappedSuperclassPropertyId</class>
 		<exclude-unlisted-classes>true</exclude-unlisted-classes>
 		<properties>
 			<property name="hibernate.dialect" value="org.hibernate.dialect.PostgreSQLDialect" />
@@ -203,6 +211,8 @@
 		<class>org.springframework.data.jpa.repository.support.JpaMetamodelEntityInformationIntegrationTests$EntityWithPrivateIdGetter</class>
 		<class>org.springframework.data.jpa.repository.support.JpaMetamodelEntityInformationIntegrationTests$ExampleEntityWithStringId</class>
 		<class>org.springframework.data.jpa.repository.support.JpaMetamodelEntityInformationIntegrationTests$ExampleEntityWithUUIDId</class>
+		<class>org.springframework.data.jpa.repository.support.JpaMetamodelEntityInformationIntegrationTests$PropertyAccessMappedSuperclass</class>
+		<class>org.springframework.data.jpa.repository.support.JpaMetamodelEntityInformationIntegrationTests$EntityWithFieldAccessAndMappedSuperclassPropertyId</class>
 		<exclude-unlisted-classes>true</exclude-unlisted-classes>
 		<properties>
 			<property name="hibernate.dialect" value="org.hibernate.dialect.PostgreSQLDialect" />


### PR DESCRIPTION
When an @Entity uses @Access(FIELD) and extends a @MappedSuperclass that uses @Access(PROPERTY) with @Id on a getter, getSingularAttributes() may not include the inherited @Id attribute.

Added a fallback in findAttributes() that calls source.getId() to resolve the attribute through the type hierarchy when the for-loop over getSingularAttributes() doesn't find the @Id.

Closes #4246