### PR TITLE
Fix `EXTRACT(TIME FROM ...)` in `JpaSort` order expressions

### DIFF
--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/HqlOrderExpressionVisitor.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/HqlOrderExpressionVisitor.java
@@ -60,6 +60,7 @@ import org.springframework.util.StringUtils;
  *
  * @author Greg Turnquist
  * @author Mark Paluch
+ * @author oniwon
  * @since 4.0
  */
 @SuppressWarnings({ "unchecked", "rawtypes", "ConstantValue", "NullAway" })
@@ -387,7 +388,7 @@ class HqlOrderExpressionVisitor extends HqlBaseVisitor<Expression<?>> {
 			}
 
 			if (ctx.dateOrTimeField().TIME() != null) {
-				return LocalDateTimeField.DATE;
+				return LocalDateTimeField.TIME;
 			}
 		} else if (ctx.datetimeField() != null) {
 

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/HqlOrderExpressionVisitorUnitTests.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/HqlOrderExpressionVisitorUnitTests.java
@@ -44,6 +44,7 @@ import org.springframework.transaction.annotation.Transactional;
  *
  * @author Greg Turnquist
  * @author Mark Paluch
+ * @author oniwon
  */
 @ExtendWith(SpringExtension.class)
 @ContextConfiguration("classpath:application-context.xml")
@@ -76,6 +77,12 @@ class HqlOrderExpressionVisitorUnitTests {
 
 		assertThat(renderOrderBy(JpaSort.unsafe("EXTRACT(DAY FROM createdAt)"), "var_1"))
 				.startsWithIgnoringCase("order by extract(day from var_1.createdAt)");
+
+		assertThat(renderOrderBy(JpaSort.unsafe("EXTRACT(DATE FROM createdAt)"), "var_1"))
+				.startsWithIgnoringCase("order by cast(var_1.createdAt as java.time.LocalDate)");
+
+		assertThat(renderOrderBy(JpaSort.unsafe("EXTRACT(TIME FROM createdAt)"), "var_1"))
+				.startsWithIgnoringCase("order by cast(var_1.createdAt as java.time.LocalTime)");
 
 		assertThat(renderOrderBy(JpaSort.unsafe("WEEK(createdAt)"), "var_1"))
 				.startsWithIgnoringCase("order by extract(week from var_1.createdAt)");


### PR DESCRIPTION
`HqlOrderExpressionVisitor#getTemporalField(ExtractFieldContext)` returned `LocalDateTimeField.DATE` for the `TIME` field — a copy-paste from the `DATE` branch just above. As a result, sorting via `JpaSort.unsafe("extract(time from …)")` silently extracted the **date** portion instead of the **time** portion (wrong ordering, no exception). Introduced in b61c51d8c.

This PR returns `LocalDateTimeField.TIME` and adds regression coverage in `HqlOrderExpressionVisitorUnitTests#extract` for both the DATE and TIME extract fields (`extract(date …)` → `cast(… as LocalDate)`, `extract(time …)` → `cast(… as LocalTime)`).

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/main/CONTRIBUTING.adoc).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/main/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
