### PR TITLE
Document fetch behavior for streaming query results

### DIFF
--- a/src/main/antora/modules/ROOT/pages/jpa/query-methods.adoc
+++ b/src/main/antora/modules/ROOT/pages/jpa/query-methods.adoc
@@ -684,6 +684,9 @@ public interface UserRepository extends Repository<User, Long> {
 ====
 The preceding declaration would apply the configured `@QueryHint` for that actually query but omit applying it to the count query triggered to calculate the total number of pages.
 
+NOTE: Returning a `Stream<T>` does not guarantee that the JPA provider or JDBC driver fetches database rows incrementally.
+For memory-efficient processing of large result sets, use query hints to apply provider-specific fetch-size settings and check your JPA provider and JDBC driver documentation for supported values.
+
 [[jpa.query-hints.comments]]
 === Adding Comments to Queries
 Sometimes, you need to debug a query based upon database performance.


### PR DESCRIPTION
Adds a JPA-specific note to the Query Hints section for repository methods returning `Stream<T>`.

A `Stream<T>` return type can suggest lazy result processing, but the actual row fetching behavior still depends on the JPA provider and JDBC driver. The note clarifies that returning a `Stream<T>` does not guarantee incremental row fetching. It places the guidance alongside `@QueryHints`, since query hints are the JPA mechanism for applying provider-specific fetch-size settings.

Testing: `./mvnw -pl spring-data-jpa-distribution -am -Pantora install -DskipTests`

Closes #1346
