### PR TITLE
Add QueryRewriter bean support to AOT repositories

### DIFF
--- a/spring-data-jpa/src/jmh/java/org/springframework/data/jpa/benchmark/AotRepositoryQueryMethodBenchmarks.java
+++ b/spring-data-jpa/src/jmh/java/org/springframework/data/jpa/benchmark/AotRepositoryQueryMethodBenchmarks.java
@@ -38,6 +38,7 @@ import org.openjdk.jmh.annotations.Timeout;
 import org.openjdk.jmh.annotations.Warmup;
 
 import org.springframework.aot.test.generate.TestGenerationContext;
+import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.support.BeanDefinitionRegistry;
 import org.springframework.beans.factory.support.DefaultBeanNameGenerator;
 import org.springframework.beans.factory.support.DefaultListableBeanFactory;
@@ -49,6 +50,7 @@ import org.springframework.data.domain.Sort;
 import org.springframework.data.jpa.benchmark.model.Person;
 import org.springframework.data.jpa.benchmark.model.Profile;
 import org.springframework.data.jpa.benchmark.repository.PersonRepository;
+import org.springframework.data.jpa.repository.aot.AotRepositoryFragmentSupport;
 import org.springframework.data.jpa.repository.aot.JpaRepositoryContributor;
 import org.springframework.data.jpa.repository.aot.TestJpaAotRepositoryContext;
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
@@ -69,6 +71,7 @@ import org.springframework.util.ObjectUtils;
 /**
  * @author Christoph Strobl
  * @author Mark Paluch
+ * @author YeongJae Min
  */
 @Testable
 @Fork(1)
@@ -92,7 +95,7 @@ public class AotRepositoryQueryMethodBenchmarks {
 					new StandardEnvironment(), Mockito.mock(BeanDefinitionRegistry.class), DefaultBeanNameGenerator.INSTANCE);
 
 			repositoryContext = new TestJpaAotRepositoryContext<>(new DefaultListableBeanFactory(), PersonRepository.class,
-					null, configurationSource);
+					RepositoryComposition.empty(), configurationSource);
 		}
 
 		EntityManager entityManager;
@@ -132,21 +135,20 @@ public class AotRepositoryQueryMethodBenchmarks {
 				new JpaRepositoryContributor(repositoryContext, entityManager.getEntityManagerFactory())
 						.contribute(generationContext);
 
-				TestCompiler.forSystem().withCompilerOptions("-parameters").with(generationContext).compile(compiled -> {
+				generationContext.writeGeneratedContent();
 
-					try {
-						this.aot = compiled.getClassLoader().loadClass(PersonRepository.class.getName() + "Impl__Aot");
-					} catch (Exception e) {
-						throw new RuntimeException(e);
-					}
+				TestCompiler.forSystem().withCompilerOptions("-parameters").with(generationContext).compile(compiled -> {
+					this.aot = compiled.getAllCompiledClasses().stream()
+							.filter(AotRepositoryFragmentSupport.class::isAssignableFrom).findFirst()
+							.orElseThrow(() -> new IllegalStateException("No generated AOT repository fragment found"));
 				});
 			}
 
 			try {
 				RepositoryFactoryBeanSupport.FragmentCreationContext creationContext = getCreationContext(repositoryContext);
 				fragments = RepositoryComposition.RepositoryFragments
-						.just(aot.getConstructor(EntityManager.class, RepositoryFactoryBeanSupport.FragmentCreationContext.class)
-								.newInstance(entityManager, creationContext));
+						.just(aot.getConstructor(EntityManager.class, RepositoryFactoryBeanSupport.FragmentCreationContext.class,
+								BeanFactory.class).newInstance(entityManager, creationContext, new DefaultListableBeanFactory()));
 
 				this.repositoryProxy = createRepository(fragments);
 			} catch (Exception e) {

--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/aot/AotRepositoryFragmentSupport.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/aot/AotRepositoryFragmentSupport.java
@@ -24,11 +24,13 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
+import java.util.function.Supplier;
 import java.util.function.UnaryOperator;
 import java.util.stream.Stream;
 
 import org.jspecify.annotations.Nullable;
 
+import org.springframework.beans.factory.BeanFactory;
 import org.springframework.core.CollectionFactory;
 import org.springframework.core.convert.ConversionService;
 import org.springframework.core.convert.support.ConfigurableConversionService;
@@ -37,11 +39,14 @@ import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.expression.ValueEvaluationContextProvider;
 import org.springframework.data.expression.ValueExpression;
+import org.springframework.data.jpa.repository.QueryRewriter;
+import org.springframework.data.jpa.repository.query.BeanFactoryQueryRewriterProvider;
 import org.springframework.data.jpa.repository.query.DeclaredQuery;
 import org.springframework.data.jpa.repository.query.JpaParameters;
 import org.springframework.data.jpa.repository.query.JpaResultConverters;
 import org.springframework.data.jpa.repository.query.QueryEnhancer;
 import org.springframework.data.jpa.repository.query.QueryEnhancerSelector;
+import org.springframework.data.jpa.repository.query.QueryRewriterProvider;
 import org.springframework.data.jpa.util.TupleBackedMap;
 import org.springframework.data.projection.ProjectionFactory;
 import org.springframework.data.repository.core.RepositoryMetadata;
@@ -56,6 +61,7 @@ import org.springframework.util.ConcurrentLruCache;
  * Support class for JPA AOT repository fragments.
  *
  * @author Mark Paluch
+ * @author YeongJae Min
  * @since 4.0
  */
 public class AotRepositoryFragmentSupport {
@@ -85,18 +91,33 @@ public class AotRepositoryFragmentSupport {
 
 	private final Lazy<ConcurrentLruCache<Method, ValueEvaluationContextProvider>> contextProviders;
 
+	private final QueryRewriterProvider queryRewriterProvider;
+
 	protected AotRepositoryFragmentSupport(QueryEnhancerSelector selector,
 			RepositoryFactoryBeanSupport.FragmentCreationContext context) {
 		this(selector, context.getRepositoryMetadata(), context.getValueExpressionDelegate(),
 				context.getProjectionFactory());
 	}
 
+	protected AotRepositoryFragmentSupport(QueryEnhancerSelector selector,
+			RepositoryFactoryBeanSupport.FragmentCreationContext context, BeanFactory beanFactory) {
+		this(selector, context.getRepositoryMetadata(), context.getValueExpressionDelegate(), context.getProjectionFactory(),
+				new BeanFactoryQueryRewriterProvider(beanFactory));
+	}
+
 	protected AotRepositoryFragmentSupport(QueryEnhancerSelector selector, RepositoryMetadata repositoryMetadata,
 			ValueExpressionDelegate valueExpressions, ProjectionFactory projectionFactory) {
+		this(selector, repositoryMetadata, valueExpressions, projectionFactory, QueryRewriterProvider.simple());
+	}
+
+	private AotRepositoryFragmentSupport(QueryEnhancerSelector selector, RepositoryMetadata repositoryMetadata,
+			ValueExpressionDelegate valueExpressions, ProjectionFactory projectionFactory,
+			QueryRewriterProvider queryRewriterProvider) {
 
 		this.repositoryMetadata = repositoryMetadata;
 		this.valueExpressions = valueExpressions;
 		this.projectionFactory = projectionFactory;
+		this.queryRewriterProvider = queryRewriterProvider;
 		this.enhancers = Lazy.of(() -> new ConcurrentLruCache<>(32, query -> selector.select(query).create(query)));
 		this.expressions = Lazy.of(() -> new ConcurrentLruCache<>(32, valueExpressions::parse));
 		this.contextProviders = Lazy.of(() -> new ConcurrentLruCache<>(32, it -> valueExpressions
@@ -116,6 +137,15 @@ public class AotRepositoryFragmentSupport {
 		QueryEnhancer queryStringEnhancer = this.enhancers.get().get(query);
 		return queryStringEnhancer.rewrite(new DefaultQueryRewriteInformation(sort,
 				ReturnedType.of(returnedType, repositoryMetadata.getDomainType(), projectionFactory)));
+	}
+
+	protected QueryRewriter getQueryRewriter(Class<? extends QueryRewriter> queryRewriter) {
+		return this.queryRewriterProvider.getQueryRewriter(queryRewriter);
+	}
+
+	protected QueryRewriter getQueryRewriter(Class<? extends QueryRewriter> queryRewriter,
+			Supplier<QueryRewriter> fallback) {
+		return this.queryRewriterProvider.getQueryRewriter(queryRewriter, fallback);
 	}
 
 	/**

--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/aot/JpaCodeBlocks.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/aot/JpaCodeBlocks.java
@@ -21,6 +21,8 @@ import jakarta.persistence.Query;
 import jakarta.persistence.QueryHint;
 import jakarta.persistence.Tuple;
 
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Modifier;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
@@ -66,6 +68,7 @@ import org.springframework.util.StringUtils;
  *
  * @author Christoph Strobl
  * @author Mark Paluch
+ * @author YeongJae Min
  * @since 4.0
  */
 class JpaCodeBlocks {
@@ -181,7 +184,13 @@ class JpaCodeBlocks {
 			if (queries.result() instanceof StringAotQuery && queryRewriter != QueryRewriter.IdentityQueryRewriter.class) {
 
 				queryRewriterName = context.localVariable("queryRewriter");
-				builder.addStatement("$T $L = new $T()", queryRewriter, queryRewriterName, queryRewriter);
+				if (hasAccessibleNoArgsConstructor(queryRewriter)) {
+					builder.addStatement("$T $L = getQueryRewriter($T.class, () -> new $T())", QueryRewriter.class,
+							queryRewriterName, queryRewriter, queryRewriter);
+				} else {
+					builder.addStatement("$T $L = getQueryRewriter($T.class)", QueryRewriter.class, queryRewriterName,
+							queryRewriter);
+				}
 			}
 
 			if (queries.result() instanceof StringAotQuery sq) {
@@ -248,6 +257,35 @@ class JpaCodeBlocks {
 			CodeBlock.Builder builder = CodeBlock.builder();
 			builder.addStatement("$T $L = $S", String.class, queryStringVariableName, sq.getQueryString());
 			return builder.build();
+		}
+
+		private boolean hasAccessibleNoArgsConstructor(Class<?> type) {
+
+			try {
+				Constructor<?> constructor = type.getDeclaredConstructor();
+				boolean samePackage = type.getPackageName()
+						.equals(context.getRepositoryInformation().getRepositoryInterface().getPackageName());
+
+				return isAccessible(type, samePackage) && isAccessible(constructor, samePackage);
+			} catch (NoSuchMethodException e) {
+				return false;
+			}
+		}
+
+		private static boolean isAccessible(Class<?> type, boolean samePackage) {
+
+			if (Modifier.isPrivate(type.getModifiers()) || (!Modifier.isPublic(type.getModifiers()) && !samePackage)) {
+				return false;
+			}
+
+			Class<?> enclosingClass = type.getEnclosingClass();
+			return enclosingClass == null || isAccessible(enclosingClass, samePackage);
+		}
+
+		private static boolean isAccessible(Constructor<?> constructor, boolean samePackage) {
+
+			return Modifier.isPublic(constructor.getModifiers())
+					|| (!Modifier.isPrivate(constructor.getModifiers()) && samePackage);
 		}
 
 		private CodeBlock applyRewrite(@Nullable String sort, @Nullable String dynamicReturnType, boolean isProjecting,

--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/aot/JpaRepositoryContributor.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/aot/JpaRepositoryContributor.java
@@ -29,6 +29,7 @@ import java.util.function.Function;
 import org.jspecify.annotations.Nullable;
 
 import org.springframework.beans.BeanUtils;
+import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.config.RuntimeBeanReference;
 import org.springframework.core.annotation.AnnotatedElementUtils;
 import org.springframework.core.annotation.MergedAnnotation;
@@ -73,6 +74,7 @@ import org.springframework.util.StringUtils;
  *
  * @author Christoph Strobl
  * @author Mark Paluch
+ * @author YeongJae Min
  * @since 4.0
  */
 public class JpaRepositoryContributor extends RepositoryContributor {
@@ -126,15 +128,17 @@ public class JpaRepositoryContributor extends RepositoryContributor {
 		});
 
 		constructorBuilder.addParameter("context", RepositoryFactoryBeanSupport.FragmentCreationContext.class);
+		constructorBuilder.addParameter("beanFactory", BeanFactory.class,
+				customizer -> customizer.origin(context -> context.getBeanFactory()));
 
 		Optional<Class<QueryEnhancerSelector>> queryEnhancerSelector = getQueryEnhancerSelectorClass();
 
 		constructorBuilder.customize(builder -> {
 
 			if (queryEnhancerSelector.isPresent()) {
-				builder.addStatement("super(new T$(), context)", queryEnhancerSelector.get());
+				builder.addStatement("super(new T$(), context, beanFactory)", queryEnhancerSelector.get());
 			} else {
-				builder.addStatement("super($T.DEFAULT_SELECTOR, context)", QueryEnhancerSelector.class);
+				builder.addStatement("super($T.DEFAULT_SELECTOR, context, beanFactory)", QueryEnhancerSelector.class);
 			}
 		});
 	}

--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/cdi/BeanManagerQueryRewriterProvider.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/cdi/BeanManagerQueryRewriterProvider.java
@@ -20,6 +20,7 @@ import jakarta.enterprise.inject.spi.Bean;
 import jakarta.enterprise.inject.spi.BeanManager;
 
 import java.util.Iterator;
+import java.util.function.Supplier;
 
 import org.springframework.beans.BeanUtils;
 import org.springframework.data.jpa.repository.QueryRewriter;
@@ -33,6 +34,7 @@ import org.springframework.data.util.Lazy;
  *
  * @author Greg Turnquist
  * @author Mark Paluch
+ * @author YeongJae Min
  * @since 3.0
  */
 public class BeanManagerQueryRewriterProvider implements QueryRewriterProvider {
@@ -44,10 +46,20 @@ public class BeanManagerQueryRewriterProvider implements QueryRewriterProvider {
 	}
 
 	@Override
-	@SuppressWarnings("unchecked")
 	public QueryRewriter getQueryRewriter(JpaQueryMethod method) {
+		return getQueryRewriter(method.getQueryRewriter());
+	}
 
-		Class<? extends QueryRewriter> queryRewriter = method.getQueryRewriter();
+	@Override
+	public QueryRewriter getQueryRewriter(Class<? extends QueryRewriter> queryRewriter) {
+		return getQueryRewriter(queryRewriter, () -> BeanUtils.instantiateClass(queryRewriter));
+	}
+
+	@Override
+	@SuppressWarnings("unchecked")
+	public QueryRewriter getQueryRewriter(Class<? extends QueryRewriter> queryRewriter,
+			Supplier<QueryRewriter> fallback) {
+
 		if (queryRewriter == QueryRewriter.IdentityQueryRewriter.class) {
 			return QueryRewriter.IdentityQueryRewriter.INSTANCE;
 		}
@@ -64,7 +76,7 @@ public class BeanManagerQueryRewriterProvider implements QueryRewriterProvider {
 			return new DelegatingQueryRewriter(rewriter);
 		}
 
-		return BeanUtils.instantiateClass(queryRewriter);
+		return fallback.get();
 	}
 
 }

--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/BeanFactoryQueryRewriterProvider.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/BeanFactoryQueryRewriterProvider.java
@@ -15,6 +15,8 @@
  */
 package org.springframework.data.jpa.repository.query;
 
+import java.util.function.Supplier;
+
 import org.springframework.beans.BeanUtils;
 import org.springframework.beans.factory.BeanFactory;
 import org.springframework.data.jpa.repository.QueryRewriter;
@@ -25,6 +27,7 @@ import org.springframework.data.util.Lazy;
  *
  * @author Greg Turnquist
  * @author Mark Paluch
+ * @author YeongJae Min
  * @since 3.0
  */
 public class BeanFactoryQueryRewriterProvider implements QueryRewriterProvider {
@@ -36,16 +39,26 @@ public class BeanFactoryQueryRewriterProvider implements QueryRewriterProvider {
 	}
 
 	@Override
-	@SuppressWarnings("unchecked")
 	public QueryRewriter getQueryRewriter(JpaQueryMethod method) {
+		return getQueryRewriter(method.getQueryRewriter());
+	}
 
-		Class<? extends QueryRewriter> queryRewriter = method.getQueryRewriter();
+	@Override
+	public QueryRewriter getQueryRewriter(Class<? extends QueryRewriter> queryRewriter) {
+		return getQueryRewriter(queryRewriter, () -> BeanUtils.instantiateClass(queryRewriter));
+	}
+
+	@Override
+	@SuppressWarnings("unchecked")
+	public QueryRewriter getQueryRewriter(Class<? extends QueryRewriter> queryRewriter,
+			Supplier<QueryRewriter> fallback) {
+
 		if (queryRewriter == QueryRewriter.IdentityQueryRewriter.class) {
 			return QueryRewriter.IdentityQueryRewriter.INSTANCE;
 		}
 
 		Lazy<QueryRewriter> rewriter = Lazy.of(() -> beanFactory.getBeanProvider((Class<QueryRewriter>) queryRewriter)
-				.getIfAvailable(() -> BeanUtils.instantiateClass(queryRewriter)));
+				.getIfAvailable(fallback));
 
 		return new DelegatingQueryRewriter(rewriter);
 	}

--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/QueryRewriterProvider.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/QueryRewriterProvider.java
@@ -15,6 +15,8 @@
  */
 package org.springframework.data.jpa.repository.query;
 
+import java.util.function.Supplier;
+
 import org.springframework.beans.BeanUtils;
 import org.springframework.data.jpa.repository.QueryRewriter;
 
@@ -24,6 +26,7 @@ import org.springframework.data.jpa.repository.QueryRewriter;
  *
  * @author Greg Turnquist
  * @author Mark Paluch
+ * @author YeongJae Min
  * @since 3.0
  * @see QueryRewriter
  */
@@ -37,16 +40,42 @@ public interface QueryRewriterProvider {
 	 */
 	static QueryRewriterProvider simple() {
 
-		return method -> {
+		return new QueryRewriterProvider() {
 
-			Class<? extends QueryRewriter> queryRewriter = method.getQueryRewriter();
-
-			if (queryRewriter == QueryRewriter.IdentityQueryRewriter.class) {
-				return QueryRewriter.IdentityQueryRewriter.INSTANCE;
+			@Override
+			public QueryRewriter getQueryRewriter(JpaQueryMethod method) {
+				return getQueryRewriter(method.getQueryRewriter());
 			}
-
-			return BeanUtils.instantiateClass(queryRewriter);
 		};
+	}
+
+	/**
+	 * Obtain an instance of {@link QueryRewriter} for the given type.
+	 *
+	 * @param queryRewriter the {@link QueryRewriter} type.
+	 * @return a Java bean that implements {@link QueryRewriter}.
+	 * @since 4.1
+	 */
+	default QueryRewriter getQueryRewriter(Class<? extends QueryRewriter> queryRewriter) {
+		return getQueryRewriter(queryRewriter, () -> BeanUtils.instantiateClass(queryRewriter));
+	}
+
+	/**
+	 * Obtain an instance of {@link QueryRewriter} for the given type.
+	 *
+	 * @param queryRewriter the {@link QueryRewriter} type.
+	 * @param fallback fallback to obtain an instance if no contextual instance is available.
+	 * @return a Java bean that implements {@link QueryRewriter}.
+	 * @since 4.1
+	 */
+	default QueryRewriter getQueryRewriter(Class<? extends QueryRewriter> queryRewriter,
+			Supplier<QueryRewriter> fallback) {
+
+		if (queryRewriter == QueryRewriter.IdentityQueryRewriter.class) {
+			return QueryRewriter.IdentityQueryRewriter.INSTANCE;
+		}
+
+		return fallback.get();
 	}
 
 	/**

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/aot/AotFragmentTestConfigurationSupport.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/aot/AotFragmentTestConfigurationSupport.java
@@ -64,6 +64,7 @@ import org.springframework.util.ReflectionUtils;
  * invocations to the backing AOT fragment. Note that {@code repositoryInterface} is not a repository proxy.
  *
  * @author Mark Paluch
+ * @author YeongJae Min
  */
 @ImportResource("classpath:hibernate-infrastructure.xml")
 public class AotFragmentTestConfigurationSupport implements BeanFactoryPostProcessor {
@@ -108,6 +109,7 @@ public class AotFragmentTestConfigurationSupport implements BeanFactoryPostProce
 				.addConstructorArgValue(new RuntimeBeanReference(EntityManager.class))
 				.addConstructorArgValue(
 						getCreationContext(repositoryContext, beanFactory.getBean(Environment.class), beanFactory))
+				.addConstructorArgValue(beanFactory)
 				.getBeanDefinition();
 
 		generationContext.writeGeneratedContent();

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/aot/JpaCodeBlocksUnitTests.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/aot/JpaCodeBlocksUnitTests.java
@@ -31,7 +31,9 @@ import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.data.domain.Limit;
+import org.springframework.data.domain.Sort;
 import org.springframework.data.jpa.provider.PersistenceProvider;
+import org.springframework.data.jpa.repository.QueryRewriter;
 import org.springframework.data.jpa.repository.aot.JpaCodeBlocks.QueryBlockBuilder;
 import org.springframework.data.jpa.repository.query.JpaQueryMethod;
 import org.springframework.data.projection.SpelAwareProxyProjectionFactory;
@@ -47,6 +49,7 @@ import org.springframework.javapoet.CodeBlock;
  * Unit tests for {@link JpaCodeBlocks}.
  *
  * @author Christoph Strobl
+ * @author YeongJae Min
  */
 class JpaCodeBlocksUnitTests {
 
@@ -58,6 +61,29 @@ class JpaCodeBlocksUnitTests {
 				.lockMode(LockModeType.PESSIMISTIC_READ).build();
 
 		assertThat(codeBlock.toString()).containsSubsequence(".setLockMode(", "LockModeType.PESSIMISTIC_READ)");
+	}
+
+	@Test // GH-3839, GH-3984
+	void obtainsQueryRewriterFromFragmentSupport() throws NoSuchMethodException {
+
+		CodeBlock codeBlock = initQueryBuilder()
+				.filter(new AotQueries(jpqlQuery("SELECT d FROM DummyEntity d", List.of(), Limit.unlimited(), false, false))) //
+				.queryRewriter(MyQueryRewriter.class).build();
+
+		assertThat(codeBlock.toString()).containsSubsequence("QueryRewriter queryRewriter = getQueryRewriter(",
+				"MyQueryRewriter.class)");
+		assertThat(codeBlock.toString()).doesNotContain("new MyQueryRewriter()");
+	}
+
+	@Test // GH-3839, GH-3984
+	void usesNoArgsConstructorAsFallbackIfAvailable() throws NoSuchMethodException {
+
+		CodeBlock codeBlock = initQueryBuilder()
+				.filter(new AotQueries(jpqlQuery("SELECT d FROM DummyEntity d", List.of(), Limit.unlimited(), false, false))) //
+				.queryRewriter(NoArgsQueryRewriter.class).build();
+
+		assertThat(codeBlock.toString()).containsSubsequence("QueryRewriter queryRewriter = getQueryRewriter(",
+				"NoArgsQueryRewriter.class, () -> new", "NoArgsQueryRewriter())");
 	}
 
 	QueryBlockBuilder initQueryBuilder() throws NoSuchMethodException {
@@ -98,6 +124,24 @@ class JpaCodeBlocksUnitTests {
 	@Entity
 	static class DummyEntity {
 		@Id Long id;
+	}
+
+	static class MyQueryRewriter implements QueryRewriter {
+
+		private MyQueryRewriter(String value) {}
+
+		@Override
+		public String rewrite(String query, Sort sort) {
+			return query;
+		}
+	}
+
+	static class NoArgsQueryRewriter implements QueryRewriter {
+
+		@Override
+		public String rewrite(String query, Sort sort) {
+			return query;
+		}
 	}
 
 }

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/aot/JpaRepositoryContributorIntegrationTests.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/aot/JpaRepositoryContributorIntegrationTests.java
@@ -30,6 +30,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.domain.Limit;
 import org.springframework.data.domain.Page;
@@ -49,6 +50,7 @@ import org.springframework.transaction.annotation.Transactional;
  *
  * @author Christoph Strobl
  * @author Mark Paluch
+ * @author YeongJae Min
  */
 @SpringJUnitConfig(classes = JpaRepositoryContributorIntegrationTests.JpaRepositoryContributorConfiguration.class)
 @Transactional
@@ -61,8 +63,14 @@ class JpaRepositoryContributorIntegrationTests {
 
 	@Configuration
 	static class JpaRepositoryContributorConfiguration extends AotFragmentTestConfigurationSupport {
+
 		public JpaRepositoryContributorConfiguration() {
 			super(UserRepository.class);
+		}
+
+		@Bean
+		UserRepository.BeanBackedQueryRewriter beanBackedQueryRewriter() {
+			return new UserRepository.BeanBackedQueryRewriter("User");
 		}
 	}
 
@@ -707,6 +715,14 @@ class JpaRepositoryContributorIntegrationTests {
 		Page<User> page = fragment.findAndApplyQueryRewriter(kylo.getEmailAddress(), Pageable.unpaged());
 
 		assertThat(page).isNotEmpty();
+	}
+
+	@Test // GH-3839, GH-3984
+	void shouldApplyBeanBackedQueryRewriter() {
+
+		User result = fragment.findAndApplyBeanBackedQueryRewriter(kylo.getEmailAddress());
+
+		assertThat(result).isNotNull();
 	}
 
 	void todo() {

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/aot/UserRepository.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/aot/UserRepository.java
@@ -42,6 +42,7 @@ import org.springframework.data.util.Streamable;
 /**
  * @author Christoph Strobl
  * @author Mark Paluch
+ * @author YeongJae Min
  */
 interface UserRepository extends CrudRepository<User, Integer> {
 
@@ -266,6 +267,9 @@ interface UserRepository extends CrudRepository<User, Integer> {
 	@Query(value = "select u from OTHER u where u.emailAddress = ?1", queryRewriter = MyQueryRewriter.class)
 	Page<User> findAndApplyQueryRewriter(String emailAddress, Pageable pageable);
 
+	@Query(value = "select u from BEAN_BACKED u where u.emailAddress = ?1", queryRewriter = BeanBackedQueryRewriter.class)
+	User findAndApplyBeanBackedQueryRewriter(String emailAddress);
+
 	// -------------------------------------------------------------------------
 	// Unsupported: Procedures
 	// -------------------------------------------------------------------------
@@ -292,6 +296,20 @@ interface UserRepository extends CrudRepository<User, Integer> {
 		@Override
 		public String rewrite(String query, Pageable pageRequest) {
 			return query.replaceAll("OTHER", "User");
+		}
+	}
+
+	static class BeanBackedQueryRewriter implements QueryRewriter {
+
+		private final String entityName;
+
+		BeanBackedQueryRewriter(String entityName) {
+			this.entityName = entityName;
+		}
+
+		@Override
+		public String rewrite(String query, Sort sort) {
+			return query.replaceAll("BEAN_BACKED", entityName);
 		}
 	}
 }

--- a/src/main/antora/modules/ROOT/pages/jpa/aot.adoc
+++ b/src/main/antora/modules/ROOT/pages/jpa/aot.adoc
@@ -30,7 +30,8 @@ Mind that using Value Expressions requires expression parsing and contextual inf
 **Limitations**
 
 * Requires Hibernate for AOT processing.
-* `QueryRewriter` must be a no-args class. `QueryRewriter` beans are not yet supported.
+* `QueryRewriter` types declared on query methods are resolved from the application context.
+If no bean is available, AOT repositories fall back to no-args class instantiation.
 * Methods accepting `ScrollPosition` (e.g. `Keyset` pagination) are not yet supported.
 * Custom Collection return types (e.g. `io.vavr.collection`, `"org.eclipse.collections`) are not yet supported.
 


### PR DESCRIPTION
<!--

Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
Make sure that:

-->

This PR adds BeanFactory-backed `QueryRewriter` resolution for AOT-generated JPA repository fragments.

AOT repositories now obtain `QueryRewriter` instances from the application context when a bean is available and fall back to no-args instantiation otherwise. This keeps the existing generated-fragment behavior while allowing `QueryRewriter` implementations that need bean dependencies.

Closes #3839
Closes #3984

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
