### PR TITLE
Remove duplicate Query by Example collection-property note

### DIFF
--- a/src/main/antora/modules/ROOT/pages/repositories/query-by-example.adoc
+++ b/src/main/antora/modules/ROOT/pages/repositories/query-by-example.adoc
@@ -21,8 +21,6 @@ public class PersonService {
 ----
 ====
 
-NOTE: Currently, only `SingularAttribute` properties can be used for property matching.
-
 The property specifier accepts property names (such as `firstname` and `lastname`). You can navigate by chaining properties together with dots (`address.city`). You can also tune it with matching options and case sensitivity.
 
 The following table shows the various `StringMatcher` options that you can use and the result of using them on a field named `firstname`:


### PR DESCRIPTION
Spring Data JPA already renders the shared Query by Example limitations section with `:support-qbe-collection: false`, which includes "No support for matching collections or maps."

This removes the JPA-specific `SingularAttribute` NOTE because it describes the same limitation in a duplicate location and with less user-facing terminology. Runtime behavior matches the shared wording: `QueryByExamplePredicateBuilder` iterates over `type.getSingularAttributes()`, so plural attributes are not matched.

No production code changes.

Closes #1472