### PR TITLE
Add regression test for `existsBy` on `@IdClass` for entity with `@Id @ManyToOne` identifier

### DIFF
--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/RepositoryWithCompositeKeyTests.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/RepositoryWithCompositeKeyTests.java
@@ -370,6 +370,26 @@ class RepositoryWithCompositeKeyTests {
 		assertThat(employeeRepositoryWithIdClass.existsByName("Walter")).isFalse();
 	}
 
+	@Test // GH-1616
+	void shouldExecuteExistsQueryByIdClassRelationshipAttribute() {
+
+		IdClassExampleDepartment dep = new IdClassExampleDepartment();
+		dep.setDepartmentId(2L);
+		dep.setName("Dep2");
+
+		IdClassExampleEmployee emp = new IdClassExampleEmployee();
+		emp.setEmpId(3L);
+		emp.setDepartment(dep);
+
+		employeeRepositoryWithIdClass.save(emp);
+
+		IdClassExampleDepartment unknown = new IdClassExampleDepartment();
+		unknown.setDepartmentId(99L);
+
+		assertThat(employeeRepositoryWithIdClass.existsByDepartment(dep)).isTrue();
+		assertThat(employeeRepositoryWithIdClass.existsByDepartment(unknown)).isFalse();
+	}
+
 	@Test // GH-3349
 	void findByRelationshipPartialEmbeddedId() {
 

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/sample/EmployeeRepositoryWithIdClass.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/sample/EmployeeRepositoryWithIdClass.java
@@ -18,6 +18,7 @@ package org.springframework.data.jpa.repository.sample;
 import java.util.List;
 
 import org.springframework.context.annotation.Lazy;
+import org.springframework.data.jpa.domain.sample.IdClassExampleDepartment;
 import org.springframework.data.jpa.domain.sample.IdClassExampleEmployee;
 import org.springframework.data.jpa.domain.sample.IdClassExampleEmployeePK;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -41,6 +42,9 @@ public interface EmployeeRepositoryWithIdClass extends JpaRepository<IdClassExam
 
 	// DATAJPA-920
 	boolean existsByName(String name);
+
+	// GH-1616
+	boolean existsByDepartment(IdClassExampleDepartment department);
 
 	List<IdClassExampleEmployee> findAllByDepartment_DepartmentId(long departmentId);
 	List<IdClassExampleEmployee> findAllByEmpId(long empId);


### PR DESCRIPTION
The NPE reported in #1616 is not reproducible on `main` with the current `JpaQueryCreator` exists-projection path — the rewrite on top of the JPQL builder routes `@IdClass` entities through `entityType.getIdClassAttributes()` (`JpaQueryCreator#doSelect`), sidestepping the original `root.get((SingularAttribute) id)` path that triggered the NPE.

This PR adds a regression test mirroring the reported reproducer — a derived `existsBy<RelationProperty>` method on an `@IdClass`-mapped entity whose id includes an `@Id @ManyToOne` association. The new `shouldExecuteExistsQueryByIdClassRelationshipAttribute` sits next to the existing DATAJPA-920 exists-with-IdClass coverage. `RepositoryWithCompositeKeyTests` passes locally.

Closes #1616
