### PR TITLE
Fix JPQL, EQL, and HQL query rendering round-trips

### DIFF
--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/EqlQueryRenderer.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/EqlQueryRenderer.java
@@ -554,8 +554,15 @@ class EqlQueryRenderer extends EqlBaseVisitor<QueryTokenStream> {
 		QueryRendererBuilder builder = QueryRenderer.builder();
 
 		builder.append(QueryTokens.expression(ctx.FROM()));
-		builder.appendExpression(
-				QueryTokenStream.concat(ctx.subselect_identification_variable_declaration(), this::visit, TOKEN_COMMA));
+
+		List<ParseTree> declarations = new ArrayList<>();
+		for (ParseTree child : ctx.children) {
+			if (child instanceof EqlParser.Subselect_identification_variable_declarationContext
+					|| child instanceof EqlParser.Collection_member_declarationContext) {
+				declarations.add(child);
+			}
+		}
+		builder.appendExpression(QueryTokenStream.concat(declarations, this::visit, TOKEN_COMMA));
 
 		return builder;
 	}

--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/EqlQueryRenderer.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/EqlQueryRenderer.java
@@ -730,7 +730,7 @@ class EqlQueryRenderer extends EqlBaseVisitor<QueryTokenStream> {
 			builder.append(TOKEN_COMMA);
 			builder.appendInline(visit(ctx.string_expression(1)));
 
-			if (ctx.arithmetic_expression() != null) {
+			if (!ctx.arithmetic_expression().isEmpty()) {
 				builder.append(TOKEN_COMMA);
 				builder.appendInline(visit(ctx.arithmetic_expression(0)));
 			}

--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/EqlQueryRenderer.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/EqlQueryRenderer.java
@@ -36,6 +36,7 @@ import org.springframework.util.CollectionUtils;
  * @author Christoph Strobl
  * @author Mark Paluch
  * @author TaeHyun Kang
+ * @author Jewoo Shin
  * @since 3.2
  */
 @SuppressWarnings({ "ConstantConditions", "DuplicatedCode" })
@@ -273,9 +274,7 @@ class EqlQueryRenderer extends EqlBaseVisitor<QueryTokenStream> {
 
 		QueryRendererBuilder builder = QueryRenderer.builder();
 
-		if (ctx.qualified_identification_variable() != null) {
-			builder.append(visit(ctx.qualified_identification_variable()));
-		} else if (ctx.qualified_identification_variable() != null) {
+		if (ctx.TREAT() != null) {
 
 			builder.append(QueryTokens.token(ctx.TREAT()));
 			builder.append(TOKEN_OPEN_PAREN);
@@ -283,6 +282,8 @@ class EqlQueryRenderer extends EqlBaseVisitor<QueryTokenStream> {
 			builder.append(QueryTokens.expression(ctx.AS()));
 			builder.appendInline(visit(ctx.subtype()));
 			builder.append(TOKEN_CLOSE_PAREN);
+		} else if (ctx.qualified_identification_variable() != null) {
+			builder.append(visit(ctx.qualified_identification_variable()));
 		} else if (ctx.state_field_path_expression() != null) {
 			builder.append(visit(ctx.state_field_path_expression()));
 		} else if (ctx.single_valued_object_path_expression() != null) {

--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/HqlQueryRenderer.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/HqlQueryRenderer.java
@@ -37,6 +37,7 @@ import org.springframework.util.CollectionUtils;
  * @author Oscar Fanchin
  * @author Mark Paluch
  * @author TaeHyun Kang
+ * @author Jewoo Shin
  * @since 3.1
  */
 @SuppressWarnings({ "ConstantConditions", "DuplicatedCode", "UnreachableCode" })
@@ -1116,11 +1117,11 @@ class HqlQueryRenderer extends HqlBaseVisitor<QueryTokenStream> {
 		QueryRendererBuilder nested = QueryRenderer.builder();
 		nested.appendInline(visit(ctx.path()));
 		nested.append(TOKEN_DOT);
-		nested.appendExpression(visit(ctx.jpaNonstandardFunctionName()));
+		nested.append(visit(ctx.jpaNonstandardFunctionName()));
 
 		if (ctx.castTarget() != null) {
 			nested.append(QueryTokens.expression(ctx.AS()));
-			nested.appendExpression(visit(ctx.jpaNonstandardFunctionName()));
+			nested.append(visit(ctx.castTarget()));
 		}
 
 		builder.appendInline(nested);

--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/JpqlQueryRenderer.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/JpqlQueryRenderer.java
@@ -556,8 +556,15 @@ class JpqlQueryRenderer extends JpqlBaseVisitor<QueryTokenStream> {
 		QueryRendererBuilder builder = QueryRenderer.builder();
 
 		builder.append(QueryTokens.expression(ctx.FROM()));
-		builder.appendExpression(
-				QueryTokenStream.concat(ctx.subselect_identification_variable_declaration(), this::visit, TOKEN_COMMA));
+
+		List<ParseTree> declarations = new ArrayList<>();
+		for (ParseTree child : ctx.children) {
+			if (child instanceof JpqlParser.Subselect_identification_variable_declarationContext
+					|| child instanceof JpqlParser.Collection_member_declarationContext) {
+				declarations.add(child);
+			}
+		}
+		builder.appendExpression(QueryTokenStream.concat(declarations, this::visit, TOKEN_COMMA));
 
 		return builder;
 	}

--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/JpqlQueryRenderer.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/JpqlQueryRenderer.java
@@ -36,6 +36,7 @@ import org.springframework.util.CollectionUtils;
  * @author Christoph Strobl
  * @author Mark Paluch
  * @author TaeHyun Kang
+ * @author Jewoo Shin
  * @since 3.1
  */
 @SuppressWarnings({ "ConstantConditions", "DuplicatedCode" })
@@ -274,9 +275,7 @@ class JpqlQueryRenderer extends JpqlBaseVisitor<QueryTokenStream> {
 
 		QueryRendererBuilder builder = QueryRenderer.builder();
 
-		if (ctx.qualified_identification_variable() != null) {
-			builder.append(visit(ctx.qualified_identification_variable()));
-		} else if (ctx.qualified_identification_variable() != null) {
+		if (ctx.TREAT() != null) {
 
 			builder.append(QueryTokens.token(ctx.TREAT()));
 			builder.append(TOKEN_OPEN_PAREN);
@@ -284,6 +283,8 @@ class JpqlQueryRenderer extends JpqlBaseVisitor<QueryTokenStream> {
 			builder.append(QueryTokens.expression(ctx.AS()));
 			builder.appendInline(visit(ctx.subtype()));
 			builder.append(TOKEN_CLOSE_PAREN);
+		} else if (ctx.qualified_identification_variable() != null) {
+			builder.append(visit(ctx.qualified_identification_variable()));
 		} else if (ctx.state_field_path_expression() != null) {
 			builder.append(visit(ctx.state_field_path_expression()));
 		} else if (ctx.single_valued_object_path_expression() != null) {

--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/JpqlQueryRenderer.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/JpqlQueryRenderer.java
@@ -734,7 +734,7 @@ class JpqlQueryRenderer extends JpqlBaseVisitor<QueryTokenStream> {
 			builder.append(TOKEN_COMMA);
 			builder.appendInline(visit(ctx.string_expression(1)));
 
-			if (ctx.arithmetic_expression() != null) {
+			if (!ctx.arithmetic_expression().isEmpty()) {
 				builder.append(TOKEN_COMMA);
 				builder.appendInline(visit(ctx.arithmetic_expression(0)));
 			}

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/HqlQueryRendererTests.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/HqlQueryRendererTests.java
@@ -35,6 +35,7 @@ import org.junit.jupiter.params.provider.ValueSource;
  * @author Mark Paluch
  * @author Yannick Brandt
  * @author Oscar Fanchin
+ * @author Jewoo Shin
  * @since 3.1
  */
 class HqlQueryRendererTests extends JpqlQueryRendererTckTests {
@@ -1812,6 +1813,14 @@ class HqlQueryRendererTests extends JpqlQueryRendererTckTests {
 						nonExisting String,
 						nonExistingWithDefault String default 'none') t
 				""");
+	}
+
+	@Test // GH-4272
+	void columnFunctionWithCastTarget() {
+
+		assertQuery("select column(tbl.foo as int) from Entity tbl");
+		assertQuery("select column(tbl.foo as varchar(255)) from Entity tbl");
+		assertQuery("select column(tbl.foo) from Entity tbl");
 	}
 
 }

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/JpqlQueryRendererTckTests.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/JpqlQueryRendererTckTests.java
@@ -27,6 +27,7 @@ import org.junit.jupiter.params.provider.ValueSource;
  * Abstract TCK Tests for JPQL query rendering.
  *
  * @author Mark Paluch
+ * @author Jewoo Shin
  */
 abstract class JpqlQueryRendererTckTests {
 
@@ -565,6 +566,13 @@ abstract class JpqlQueryRendererTckTests {
 				SELECT TREAT(e as Integer).foo
 				FROM Employee e
 				""");
+	}
+
+	@Test // GH-4272
+	void treatQualifiedIdentificationVariableDowncast() {
+
+		assertQuery("SELECT TREAT(VALUE(m) AS Employee) FROM Department d JOIN d.employees m");
+		assertQuery("SELECT d FROM Department d JOIN d.employees m WHERE TREAT(VALUE(m) AS Employee) IS NOT NULL");
 	}
 
 	@Test

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/JpqlQueryRendererTckTests.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/JpqlQueryRendererTckTests.java
@@ -582,6 +582,14 @@ abstract class JpqlQueryRendererTckTests {
 		assertQuery("SELECT d FROM Department d JOIN d.employees m WHERE TREAT(VALUE(m) AS Employee) IS NOT NULL");
 	}
 
+	@Test // GH-4272
+	void subqueryFromWithCollectionMemberDeclaration() {
+
+		assertQuery("SELECT o FROM Order o WHERE EXISTS (SELECT l FROM Order o2, IN(o2.lineItems) l WHERE l.quantity > 5)");
+		assertQuery(
+				"SELECT o FROM Order o WHERE EXISTS (SELECT l FROM Order o2, IN(o2.lineItems) l, Order o3, IN(o3.lineItems) s WHERE l.quantity > 5)");
+	}
+
 	@Test
 	void fromClauseDowncastingExample1() {
 

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/JpqlQueryRendererTckTests.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/JpqlQueryRendererTckTests.java
@@ -344,6 +344,13 @@ abstract class JpqlQueryRendererTckTests {
 		assertQuery("SELECT e.firstname || e.lastname AS name FROM Employee e");
 	}
 
+	@Test // GH-4272
+	void locateWithOptionalThirdArgument() {
+
+		assertQuery("SELECT LOCATE('a', e.name) FROM Employee e");
+		assertQuery("SELECT LOCATE('a', e.name, 2) FROM Employee e");
+	}
+
 	/**
 	 * @see https://github.com/jakartaee/persistence/blob/master/spec/src/main/asciidoc/ch04-query-language.adoc#example
 	 */


### PR DESCRIPTION
These four focused commits fix renderer-only defects where the JPQL, EQL, and HQL renderers fail to preserve parsed query constructs during rendering. The first three affect `JpqlQueryRenderer` and `EqlQueryRenderer` (HQL already round-trips these correctly); the fourth fixes the HQL-only `column(...)` function in `HqlQueryRenderer`. All four are confined to visitor methods, add round-trip tests, and leave the grammars untouched.

| Fix | Root cause | Change |
|---|---|---|
| `TREAT(…)` downcast | `TREAT` branch guarded by a condition duplicated from the preceding branch → unreachable, cast silently dropped | check `TREAT()` first |
| Two-argument `LOCATE(…)` | third-argument guard used `!= null` on a never-null list accessor → `visit(null)`, throwing `NullPointerException` | check the list is non-empty |
| Subquery `FROM` collection member | `visitSubquery_from_clause` rendered only the identification variable, dropping a trailing `collection_member_declaration` and leaving its alias undefined | iterate child nodes in source order |
| HQL `column(…)` cast target | `visitColumnFunction` appended the function name as an expression after the `.` (stray space) and, for the optional cast, visited `jpaNonstandardFunctionName()` instead of `castTarget()` → `column(tbl.foo as int)` rendered as `column(tbl. foo as foo)` | append without expression spacing and render `castTarget()`, matching `visitJpaNonstandardFunction` |

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).

Closes #4272
