### PR TITLE
Remove unused QueryRendererBuilder locals in JPQL and HQL query renderers

### DIFF
--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/HqlQueryRenderer.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/HqlQueryRenderer.java
@@ -1258,8 +1258,6 @@ class HqlQueryRenderer extends HqlBaseVisitor<QueryTokenStream> {
 		builder.append(QueryTokens.token(ctx.LISTAGG()));
 		builder.append(TOKEN_OPEN_PAREN);
 
-		QueryRendererBuilder nested = QueryRenderer.builder();
-
 		if (ctx.DISTINCT() != null) {
 			builder.append(QueryTokens.expression(ctx.DISTINCT()));
 		}
@@ -1272,7 +1270,6 @@ class HqlQueryRenderer extends HqlBaseVisitor<QueryTokenStream> {
 			builder.appendExpression(visit(ctx.onOverflowClause()));
 		}
 
-		builder.appendInline(nested);
 		builder.append(TOKEN_CLOSE_PAREN);
 
 		if (ctx.withinGroupClause() != null) {

--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/JpqlQueryRenderer.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/JpqlQueryRenderer.java
@@ -673,8 +673,6 @@ class JpqlQueryRenderer extends JpqlBaseVisitor<QueryTokenStream> {
 	@Override
 	public QueryTokenStream visitString_expression(JpqlParser.String_expressionContext ctx) {
 
-		QueryRendererBuilder builder = QueryRenderer.builder();
-
 		if (ctx.subquery() != null) {
 			return QueryTokenStream.group(visit(ctx.subquery()));
 		}


### PR DESCRIPTION
While following up on #4273, I found two leftover `QueryRendererBuilder` locals that are never used.

This removes the unused builder in `JpqlQueryRenderer#visitString_expression` and the empty `nested` builder plus no-op `appendInline(nested)` in `HqlQueryRenderer#visitListaggFunction`. Rendering behavior is unchanged.

Verified with the JPQL/HQL/EQL renderer round-trip suites.

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [ ] You submit test cases (unit or integration tests) that back your changes. — N/A for this behavior-preserving dead-code removal; the existing renderer round-trip suites noted above already exercise both methods and pass unchanged.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
