### PR TITLE
Fix `IS NULL` rendering of keyset queries using Querydsl

### DIFF
--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/support/QuerydslJpaPredicateExecutor.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/support/QuerydslJpaPredicateExecutor.java
@@ -52,7 +52,6 @@ import com.querydsl.core.NonUniqueResultException;
 import com.querydsl.core.types.ConstantImpl;
 import com.querydsl.core.types.EntityPath;
 import com.querydsl.core.types.Expression;
-import com.querydsl.core.types.NullExpression;
 import com.querydsl.core.types.Ops;
 import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.Predicate;
@@ -74,6 +73,7 @@ import com.querydsl.jpa.impl.AbstractJPAQuery;
  * @author Jens Schauder
  * @author Greg Turnquist
  * @author Yanming Zhou
+ * @author Ilya Bakaev
  */
 public class QuerydslJpaPredicateExecutor<T> implements QuerydslPredicateExecutor<T>, JpaRepositoryConfigurationAware {
 
@@ -424,8 +424,9 @@ public class QuerydslJpaPredicateExecutor<T> implements QuerydslPredicateExecuto
 
 		@Override
 		public BooleanExpression compare(String property, Expression<?> propertyExpression, @Nullable Object value) {
-			return Expressions.booleanOperation(Ops.EQ, propertyExpression,
-					value == null ? NullExpression.DEFAULT : ConstantImpl.create(value));
+			return value == null
+					? Expressions.booleanOperation(Ops.IS_NULL, propertyExpression)
+					: Expressions.booleanOperation(Ops.EQ, propertyExpression, ConstantImpl.create(value));
 		}
 
 		@Override

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/UserRepositoryTests.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/UserRepositoryTests.java
@@ -104,6 +104,7 @@ import org.springframework.transaction.annotation.Transactional;
  * @author Geoffrey Deremetz
  * @author Krzysztof Krason
  * @author Yanming Zhou
+ * @author Ilya Bakaev
  */
 @ExtendWith(SpringExtension.class)
 @ContextConfiguration("classpath:application-context.xml")
@@ -1520,6 +1521,130 @@ class UserRepositoryTests {
 
 		// no more items before this window
 		assertThat(previousWindow.hasNext()).isFalse();
+	}
+
+	@Test
+	void scrollByPredicateKeysetWithAscNullsFirst() {
+
+		User jane1 = new User("Jane", "Doe", "jane@doe1.com");
+		User jane2 = new User("Jane", null, "jane@doe2.com");
+		User jane3 = new User("Jane", null, "jane@doe3.com");
+		User john1 = new User("John", "Doe", "john@doe1.com");
+		User john2 = new User("John", null, "john@doe2.com");
+		User john3 = new User("John", null, "john@doe3.com");
+
+		repository.saveAllAndFlush(Arrays.asList(john1, john2, john3, jane1, jane2, jane3));
+
+		Sort sort = Sort.by(
+				Order.asc("firstname"),
+				Order.asc("lastname").nullsFirst(),
+				Order.asc("emailAddress")
+		);
+
+		Window<User> firstWindow = repository.findBy(QUser.user.firstname.startsWith("J"),
+				q -> q.limit(1).sortBy(sort).scroll(ScrollPosition.keyset()));
+
+		assertThat(firstWindow).containsOnly(jane2);
+		assertThat(firstWindow.hasNext()).isTrue();
+
+		Window<User> nextWindow = repository.findBy(QUser.user.firstname.startsWith("J"),
+				q -> q.limit(3).sortBy(sort).scroll(firstWindow.positionAt(0)));
+
+		assertThat(nextWindow).containsExactly(jane3, jane1, john2);
+		assertThat(nextWindow.hasNext()).isTrue();
+	}
+
+	@Test // GH-2878
+	void scrollByPredicateKeysetWithDescNullsFirst() {
+
+		User jane1 = new User("Jane", "Doe", "jane@doe1.com");
+		User jane2 = new User("Jane", null, "jane@doe2.com");
+		User jane3 = new User("Jane", null, "jane@doe3.com");
+		User john1 = new User("John", "Doe", "john@doe1.com");
+		User john2 = new User("John", null, "john@doe2.com");
+		User john3 = new User("John", null, "john@doe3.com");
+
+		repository.saveAllAndFlush(Arrays.asList(john1, john2, john3, jane1, jane2, jane3));
+
+		Sort sort = Sort.by(
+				Order.asc("firstname"),
+				Order.desc("lastname").nullsFirst(),
+				Order.asc("emailAddress")
+		);
+
+		Window<User> firstWindow = repository.findBy(QUser.user.firstname.startsWith("J"),
+				q -> q.limit(1).sortBy(sort).scroll(ScrollPosition.keyset()));
+
+		assertThat(firstWindow).containsOnly(jane2);
+		assertThat(firstWindow.hasNext()).isTrue();
+
+		Window<User> nextWindow = repository.findBy(QUser.user.firstname.startsWith("J"),
+				q -> q.limit(3).sortBy(sort).scroll(firstWindow.positionAt(0)));
+
+		assertThat(nextWindow).containsExactly(jane3, jane1, john2);
+		assertThat(nextWindow.hasNext()).isTrue();
+	}
+
+	@Test // GH-2878
+	void scrollByPredicateKeysetWithAscNullsLast() {
+
+		User jane1 = new User("Jane", "Doe", "jane@doe1.com");
+		User jane2 = new User("Jane", null, "jane@doe2.com");
+		User jane3 = new User("Jane", null, "jane@doe3.com");
+		User john1 = new User("John", "Doe", "john@doe1.com");
+		User john2 = new User("John", null, "john@doe2.com");
+		User john3 = new User("John", null, "john@doe3.com");
+
+		repository.saveAllAndFlush(Arrays.asList(john1, john2, john3, jane1, jane2, jane3));
+
+		Sort sort = Sort.by(
+				Order.asc("firstname"),
+				Order.asc("lastname").nullsLast(),
+				Order.asc("emailAddress")
+		);
+
+		Window<User> firstWindow = repository.findBy(QUser.user.firstname.startsWith("J"),
+				q -> q.limit(1).sortBy(sort).scroll(ScrollPosition.keyset()));
+
+		assertThat(firstWindow).containsOnly(jane1);
+		assertThat(firstWindow.hasNext()).isTrue();
+
+		Window<User> nextWindow = repository.findBy(QUser.user.firstname.startsWith("J"),
+				q -> q.limit(3).sortBy(sort).scroll(firstWindow.positionAt(0)));
+
+		assertThat(nextWindow).containsExactly(jane2, jane3, john1);
+		assertThat(nextWindow.hasNext()).isTrue();
+	}
+
+	@Test // GH-2878
+	void scrollByPredicateKeysetWithDescNullsLast() {
+
+		User jane1 = new User("Jane", "Doe", "jane@doe1.com");
+		User jane2 = new User("Jane", null, "jane@doe2.com");
+		User jane3 = new User("Jane", null, "jane@doe3.com");
+		User john1 = new User("John", "Doe", "john@doe1.com");
+		User john2 = new User("John", null, "john@doe2.com");
+		User john3 = new User("John", null, "john@doe3.com");
+
+		repository.saveAllAndFlush(Arrays.asList(john1, john2, john3, jane1, jane2, jane3));
+
+		Sort sort = Sort.by(
+				Order.asc("firstname"),
+				Order.desc("lastname").nullsLast(),
+				Order.asc("emailAddress")
+		);
+
+		Window<User> firstWindow = repository.findBy(QUser.user.firstname.startsWith("J"),
+				q -> q.limit(1).sortBy(sort).scroll(ScrollPosition.keyset()));
+
+		assertThat(firstWindow).containsOnly(jane1);
+		assertThat(firstWindow.hasNext()).isTrue();
+
+		Window<User> nextWindow = repository.findBy(QUser.user.firstname.startsWith("J"),
+				q -> q.limit(3).sortBy(sort).scroll(firstWindow.positionAt(0)));
+
+		assertThat(nextWindow).containsExactly(jane2, jane3, john1);
+		assertThat(nextWindow.hasNext()).isTrue();
 	}
 
 	@Test // GH-3015, GH-3407


### PR DESCRIPTION
<!--

Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
Make sure that:

-->

This PR fixes the issue for querydsl scroll where one of keyset position values is null.
Before fix querydsl generates query with `column = null` and after fix it will be `column is null`.

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).