### PR TITLE
Add regression tests for sorting native queries with a derived table containing `ORDER BY … LIMIT`

### DIFF
--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/DefaultQueryEnhancerUnitTests.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/DefaultQueryEnhancerUnitTests.java
@@ -29,6 +29,7 @@ import org.springframework.data.repository.query.ReturnedType;
  *
  * @author Mark Paluch
  * @author Alim Naizabek
+ * @author Jewoo Shin
  */
 class DefaultQueryEnhancerUnitTests extends QueryEnhancerTckTests {
 
@@ -63,5 +64,18 @@ class DefaultQueryEnhancerUnitTests extends QueryEnhancerTckTests {
 				ReturnedType.of(Object.class, Object.class, new SpelAwareProxyProjectionFactory())));
 
 		assertThat(sql).isEqualTo("SELECT e FROM Employee e order by e.foo asc nulls first, e.bar asc nulls last");
+	}
+
+	@Test // GH-2395
+	void appliesSortingWithoutBreakingDerivedTableOrderByLimit() {
+
+		QueryEnhancer enhancer = createQueryEnhancer(DeclaredQuery.nativeQuery(
+				"SELECT n.id, n.name, n.status FROM n_entity n LEFT JOIN (SELECT s.status FROM entity_statuses s ORDER BY s.updated_at DESC LIMIT 1) st ON n.id = st.entity_id WHERE n.status = :status"));
+
+		String sql = enhancer.rewrite(new DefaultQueryRewriteInformation(Sort.by("name"),
+				ReturnedType.of(Object.class, Object.class, new SpelAwareProxyProjectionFactory())));
+
+		assertThat(sql).isEqualTo(
+				"SELECT n.id, n.name, n.status FROM n_entity n LEFT JOIN (SELECT s.status FROM entity_statuses s ORDER BY s.updated_at DESC LIMIT 1) st ON n.id = st.entity_id WHERE n.status = :status order by n.name asc");
 	}
 }

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/JSqlParserQueryEnhancerUnitTests.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/JSqlParserQueryEnhancerUnitTests.java
@@ -37,6 +37,7 @@ import org.springframework.data.repository.query.ReturnedType;
  * @author Geoffrey Deremetz
  * @author Christoph Strobl
  * @author Soomin Kim
+ * @author Jewoo Shin
  */
 class JSqlParserQueryEnhancerUnitTests extends QueryEnhancerTckTests {
 
@@ -67,6 +68,19 @@ class JSqlParserQueryEnhancerUnitTests extends QueryEnhancerTckTests {
 				ReturnedType.of(Object.class, Object.class, new SpelAwareProxyProjectionFactory())));
 
 		assertThat(sql).isEqualTo("SELECT e FROM Employee e ORDER BY e.foo ASC NULLS LAST, e.bar DESC NULLS FIRST");
+	}
+
+	@Test // GH-2395
+	void appliesSortingWithoutBreakingDerivedTableOrderByLimit() {
+
+		QueryEnhancer enhancer = createQueryEnhancer(DeclaredQuery.nativeQuery(
+				"SELECT n.id, n.name, n.status FROM n_entity n LEFT JOIN (SELECT s.status FROM entity_statuses s ORDER BY s.updated_at DESC LIMIT 1) st ON n.id = st.entity_id WHERE n.status = :status"));
+
+		String sql = enhancer.rewrite(new DefaultQueryRewriteInformation(Sort.by("name"),
+				ReturnedType.of(Object.class, Object.class, new SpelAwareProxyProjectionFactory())));
+
+		assertThat(sql).isEqualTo(
+				"SELECT n.id, n.name, n.status FROM n_entity n LEFT JOIN (SELECT s.status FROM entity_statuses s ORDER BY s.updated_at DESC LIMIT 1) st ON n.id = st.entity_id WHERE n.status = :status ORDER BY n.name ASC");
 	}
 
 	@Test // GH-3707


### PR DESCRIPTION
The broken sort fragment reported in #2395 reproduces on the version it was filed against (2.3.9): `QueryUtils.applySorting` matched the derived table's inner `ORDER BY` and appended the primary sort after the `WHERE` clause without an `order by` keyword (`… = :status, n.name asc`), which becomes invalid SQL once pagination adds its `LIMIT`. It is no longer reproducible on `main` — both native query enhancers append the primary `ORDER BY` to the outer query while preserving the derived table's inner ordering.

This PR adds a regression test for each native enhancer: the regex-based `DefaultQueryEnhancer`, where the original breakage lived, and the JSqlParser-based `JSqlParserQueryEnhancer`, the default once JSqlParser is on the classpath. Each sits next to the existing `shouldApplySorting` coverage in its test class; both classes pass locally.

Closes #2395

---

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
