### PR TITLE
Fix parsing of single-character string literals in JPQL and EQL collection member expressions.

### DIFF
--- a/spring-data-jpa/src/main/antlr4/org/springframework/data/jpa/repository/query/Eql.g4
+++ b/spring-data-jpa/src/main/antlr4/org/springframework/data/jpa/repository/query/Eql.g4
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 the original author or authors.
+ * Copyright 2023-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,6 +23,7 @@ grammar Eql;
  * @see https://eclipse.dev/eclipselink/documentation/3.0/jpa/extensions/jpql.htm
  * @author Greg Turnquist
  * @author Christoph Strobl
+ * @author Jewoo Shin
  * @since 3.2
  */
 }
@@ -677,6 +678,7 @@ constructor_name
 
 literal
     : STRINGLITERAL
+    | CHARACTER
     | JAVASTRINGLITERAL
     | INTLITERAL
     | FLOATLITERAL

--- a/spring-data-jpa/src/main/antlr4/org/springframework/data/jpa/repository/query/Jpql.g4
+++ b/spring-data-jpa/src/main/antlr4/org/springframework/data/jpa/repository/query/Jpql.g4
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2023 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,6 +24,7 @@ grammar Jpql;
  * @see https://github.com/jakartaee/persistence/blob/master/spec/src/main/asciidoc/ch04-query-language.adoc#bnf
  * @author Greg Turnquist
  * @author Christoph Strobl
+ * @author Jewoo Shin
  * @since 3.1
  */
 }
@@ -670,6 +671,7 @@ constructor_name
 
 literal
     : STRINGLITERAL
+    | CHARACTER
     | JAVASTRINGLITERAL
     | INTLITERAL
     | FLOATLITERAL

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/JpqlQueryRendererTckTests.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/JpqlQueryRendererTckTests.java
@@ -250,6 +250,12 @@ abstract class JpqlQueryRendererTckTests {
 		assertQuery("SELECT p FROM Phone p WHERE FUNCTION('TO_NUMBER', p.areaCode) > 613");
 	}
 
+	@Test // GH-4278
+	void singleCharacterLiteralAsCollectionMemberExpression() {
+
+		assertQuery("SELECT e FROM Employee e WHERE 'c' MEMBER OF e.responsibilities");
+	}
+
 	@Test // GH-3314
 	void isNullAndIsNotNull() {
 

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/JpqlQueryRendererTckTests.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/JpqlQueryRendererTckTests.java
@@ -254,6 +254,16 @@ abstract class JpqlQueryRendererTckTests {
 	void singleCharacterLiteralAsCollectionMemberExpression() {
 
 		assertQuery("SELECT e FROM Employee e WHERE 'c' MEMBER OF e.responsibilities");
+		assertQuery("SELECT e FROM Employee e WHERE 'c' NOT MEMBER OF e.responsibilities");
+
+		assertQuery("""
+				SELECT e
+				FROM Employee e
+				WHERE EXISTS (SELECT p FROM Person p WHERE 'c' MEMBER OF p.nicknames)
+				""");
+
+		assertQuery("UPDATE Employee e SET e.name = 'x' WHERE 'c' MEMBER OF e.responsibilities");
+		assertQuery("DELETE FROM Employee e WHERE 'c' MEMBER OF e.responsibilities");
 	}
 
 	@Test // GH-3314


### PR DESCRIPTION
JPQL and EQL currently tokenize a single-character quoted string such as `'c'` as `CHARACTER`, while other quoted strings are tokenized as `STRINGLITERAL`. The `literal` parser rule accepted `STRINGLITERAL` but not `CHARACTER`, causing a single-character string literal to fail when used as the left operand of `MEMBER OF`.

This change adds `CHARACTER` to the JPQL and EQL `literal` rules and covers the collection-member case with a shared query renderer round-trip test.

Jakarta Persistence allows a `literal` as the left operand of `MEMBER OF`, defines string literals as single-quoted strings without distinguishing single-character strings from longer strings, and itself uses `'Joe' MEMBER OF p.nicknames` as an example.

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).

See #4278
