### PR TITLE
Generate smart-OR predicates for keyset scrolling

### DIFF
--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/KeysetScrollDelegate.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/KeysetScrollDelegate.java
@@ -257,12 +257,15 @@ public class KeysetScrollDelegate {
 
 		/**
 		 * Create an inclusive comparison object according to the {@link Order}.
+		 * <p>
+		 * Query strategies should override this method with a native inclusive comparison if available so that keyset
+		 * predicates can promote the leading sort property into an indexable range condition.
 		 *
 		 * @param order must not be {@literal null}.
 		 * @param propertyExpression must not be {@literal null}.
 		 * @param value the value to compare with. Can be {@literal null}.
 		 * @return an object representing the inclusive comparison predicate.
-		 * @since 4.1
+		 * @since 4.2
 		 */
 		default P compareInclusive(Order order, E propertyExpression, @Nullable Object value) {
 			P predicate = or(List.of(compare(order, propertyExpression, value),
@@ -275,7 +278,7 @@ public class KeysetScrollDelegate {
 		 *
 		 * @param predicate must not be {@literal null}.
 		 * @return the nested predicate.
-		 * @since 4.1
+		 * @since 4.2
 		 */
 		default P nest(P predicate) {
 			return predicate;

--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/KeysetScrollDelegate.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/KeysetScrollDelegate.java
@@ -34,6 +34,7 @@ import org.springframework.data.jpa.repository.support.JpaEntityInformation;
  * Delegate for keyset scrolling.
  *
  * @author Mark Paluch
+ * @author YeongJae Min
  * @since 3.1
  */
 public class KeysetScrollDelegate {
@@ -123,7 +124,26 @@ public class KeysetScrollDelegate {
 			return null;
 		}
 
-		return strategy.or(or);
+		P predicate = strategy.or(or);
+
+		if (predicate == null || or.size() == 1) {
+			return predicate;
+		}
+
+		Order firstOrder = sort.iterator().next();
+		Object firstValue = keysetValues.get(firstOrder.getProperty());
+
+		if (firstValue == null) {
+			return predicate;
+		}
+
+		P inclusiveBound = strategy.compareInclusive(firstOrder, strategy.createExpression(firstOrder.getProperty()),
+				firstValue);
+		if (inclusiveBound == null) {
+			return predicate;
+		}
+
+		return strategy.and(List.of(inclusiveBound, strategy.nest(predicate)));
 	}
 
 	protected Sort getSortOrders(Sort sort) {
@@ -234,6 +254,32 @@ public class KeysetScrollDelegate {
 		 * @return an object representing the comparison predicate.
 		 */
 		P compare(String property, E propertyExpression, @Nullable Object value);
+
+		/**
+		 * Create an inclusive comparison object according to the {@link Order}.
+		 *
+		 * @param order must not be {@literal null}.
+		 * @param propertyExpression must not be {@literal null}.
+		 * @param value the value to compare with. Can be {@literal null}.
+		 * @return an object representing the inclusive comparison predicate.
+		 * @since 4.1
+		 */
+		default P compareInclusive(Order order, E propertyExpression, @Nullable Object value) {
+			P predicate = or(List.of(compare(order, propertyExpression, value),
+					compare(order.getProperty(), propertyExpression, value)));
+			return predicate == null ? predicate : nest(predicate);
+		}
+
+		/**
+		 * Nest the {@code predicate} if the underlying representation requires explicit grouping.
+		 *
+		 * @param predicate must not be {@literal null}.
+		 * @return the nested predicate.
+		 * @since 4.1
+		 */
+		default P nest(P predicate) {
+			return predicate;
+		}
 
 		/**
 		 * AND-combine the {@code intermediate} predicates.

--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/KeysetScrollSpecification.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/KeysetScrollSpecification.java
@@ -41,6 +41,7 @@ import org.springframework.data.jpa.repository.support.JpaEntityInformation;
  *
  * @author Mark Paluch
  * @author Christoph Strobl
+ * @author YeongJae Min
  * @since 3.1
  */
 public record KeysetScrollSpecification<T>(KeysetScrollPosition position, Sort sort,
@@ -126,6 +127,18 @@ public record KeysetScrollSpecification<T>(KeysetScrollPosition position, Sort s
 		}
 
 		@Override
+		public Predicate compareInclusive(Order order, Expression<Comparable> propertyExpression, @Nullable Object value) {
+
+			if (value != null) {
+				Predicate inclusive = order.isAscending() ? cb.greaterThanOrEqualTo(propertyExpression, (Comparable) value)
+						: cb.lessThanOrEqualTo(propertyExpression, (Comparable) value);
+				return isNullsLast(order) ? cb.or(inclusive, cb.isNull(propertyExpression)) : inclusive;
+			}
+
+			return compare(order, propertyExpression, value);
+		}
+
+		@Override
 		public Predicate compare(String property, Expression<Comparable> propertyExpression, @Nullable Object value) {
 			return value == null ? cb.isNull(propertyExpression) : cb.equal(propertyExpression, value);
 		}
@@ -173,12 +186,35 @@ public record KeysetScrollSpecification<T>(KeysetScrollPosition position, Sort s
 		}
 
 		@Override
+		public JpqlQueryBuilder.Predicate compareInclusive(Order order, JpqlQueryBuilder.Expression propertyExpression,
+				@Nullable Object value) {
+
+			JpqlQueryBuilder.WhereStep where = JpqlQueryBuilder.where(propertyExpression);
+
+			QueryUtils.checkSortExpression(order);
+
+			if (value != null) {
+				JpqlQueryBuilder.Predicate inclusive = order.isAscending()
+						? where.gte(factory.capture(order.getProperty(), value))
+						: where.lte(factory.capture(order.getProperty(), value));
+				return isNullsLast(order) ? inclusive.or(where.isNull()).nest() : inclusive;
+			}
+
+			return compare(order, propertyExpression, value);
+		}
+
+		@Override
 		public JpqlQueryBuilder.Predicate compare(String property, JpqlQueryBuilder.Expression propertyExpression,
 				@Nullable Object value) {
 
 			JpqlQueryBuilder.WhereStep where = JpqlQueryBuilder.where(propertyExpression);
 
 			return value == null ? where.isNull() : where.eq(factory.capture(property, value));
+		}
+
+		@Override
+		public JpqlQueryBuilder.Predicate nest(JpqlQueryBuilder.Predicate predicate) {
+			return predicate.nest();
 		}
 
 		@Override

--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/support/QuerydslJpaPredicateExecutor.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/support/QuerydslJpaPredicateExecutor.java
@@ -52,7 +52,6 @@ import com.querydsl.core.NonUniqueResultException;
 import com.querydsl.core.types.ConstantImpl;
 import com.querydsl.core.types.EntityPath;
 import com.querydsl.core.types.Expression;
-import com.querydsl.core.types.NullExpression;
 import com.querydsl.core.types.Ops;
 import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.Predicate;
@@ -443,8 +442,8 @@ public class QuerydslJpaPredicateExecutor<T> implements QuerydslPredicateExecuto
 
 		@Override
 		public BooleanExpression compare(String property, Expression<?> propertyExpression, @Nullable Object value) {
-			return Expressions.booleanOperation(Ops.EQ, propertyExpression,
-					value == null ? NullExpression.DEFAULT : ConstantImpl.create(value));
+			return value == null ? Expressions.predicate(Ops.IS_NULL, propertyExpression)
+					: Expressions.booleanOperation(Ops.EQ, propertyExpression, ConstantImpl.create(value));
 		}
 
 		@Override

--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/support/QuerydslJpaPredicateExecutor.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/support/QuerydslJpaPredicateExecutor.java
@@ -74,6 +74,7 @@ import com.querydsl.jpa.impl.AbstractJPAQuery;
  * @author Jens Schauder
  * @author Greg Turnquist
  * @author Yanming Zhou
+ * @author YeongJae Min
  */
 public class QuerydslJpaPredicateExecutor<T> implements QuerydslPredicateExecutor<T>, JpaRepositoryConfigurationAware {
 
@@ -420,6 +421,24 @@ public class QuerydslJpaPredicateExecutor<T> implements QuerydslPredicateExecuto
 			return KeysetScrollSpecification.requiresNonNullTail(order)
 					? Expressions.predicate(Ops.IS_NOT_NULL, propertyExpression)
 					: Expressions.FALSE;
+		}
+
+		@Override
+		public BooleanExpression compareInclusive(Order order, Expression<?> propertyExpression, @Nullable Object value) {
+
+			if (value != null) {
+
+				BooleanExpression inclusive = Expressions.booleanOperation(order.isAscending() ? Ops.GOE : Ops.LOE,
+						propertyExpression, ConstantImpl.create(value));
+
+				if (KeysetScrollSpecification.isNullsLast(order)) {
+					return inclusive.or(Expressions.predicate(Ops.IS_NULL, propertyExpression));
+				}
+
+				return inclusive;
+			}
+
+			return compare(order, propertyExpression, value);
 		}
 
 		@Override

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/UserRepositoryTests.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/UserRepositoryTests.java
@@ -104,6 +104,7 @@ import org.springframework.transaction.annotation.Transactional;
  * @author Geoffrey Deremetz
  * @author Krzysztof Krason
  * @author Yanming Zhou
+ * @author YeongJae Min
  */
 @ExtendWith(SpringExtension.class)
 @ContextConfiguration("classpath:application-context.xml")
@@ -1348,6 +1349,50 @@ class UserRepositoryTests {
 		assertThat(previousWindow.hasNext()).isTrue();
 	}
 
+	@Test // GH-4250
+	void scrollByKeysetReturnsSameSequenceWithDuplicateLeadingSortValues() {
+
+		saveKeysetScrollUsersWithDuplicateFirstnames();
+
+		Sort sort = Sort.by(Order.asc("firstname"), Order.asc("emailAddress"), Order.asc("id"));
+
+		assertThat(emailAddressesOf(scrollForward(sort, 2)))
+				.containsExactlyElementsOf(emailAddressesOf(repository.findAll(sort)));
+	}
+
+	@Test // GH-4250
+	void scrollBackwardByKeysetReturnsSameSequenceWithDuplicateLeadingSortValues() {
+
+		saveKeysetScrollUsersWithDuplicateFirstnames();
+
+		Sort sort = Sort.by(Order.asc("firstname"), Order.asc("emailAddress"), Order.asc("id"));
+
+		assertThat(emailAddressesOf(scrollBackward(sort, 2)))
+				.containsExactlyElementsOf(emailAddressesOf(repository.findAll(sort)));
+	}
+
+	@Test // GH-4250
+	void scrollByKeysetReturnsSameSequenceWithNullsLastAndMixedDirections() {
+
+		saveKeysetScrollUsersWithDuplicateFirstnamesAndNulls();
+
+		Sort sort = Sort.by(Order.asc("firstname").nullsLast(), Order.desc("emailAddress"), Order.asc("id"));
+
+		assertThat(emailAddressesOf(scrollForward(sort, 2)))
+				.containsExactlyElementsOf(emailAddressesOf(repository.findAll(sort)));
+	}
+
+	@Test // GH-4250
+	void scrollByPredicateKeysetReturnsSameSequenceWithNullsLastAndMixedDirections() {
+
+		saveKeysetScrollUsersWithDuplicateFirstnamesAndNulls();
+
+		Sort sort = Sort.by(Order.asc("firstname").nullsLast(), Order.desc("emailAddress"), Order.asc("id"));
+
+		assertThat(emailAddressesOf(scrollForward(QUser.user.emailAddress.contains("@example.com"), sort, 2)))
+				.containsExactlyElementsOf(emailAddressesOf(repository.findAll(sort)));
+	}
+
 	@Test // GH-2999
 	void scrollInitiallyByExampleKeysetBackward() {
 
@@ -1371,6 +1416,101 @@ class UserRepositoryTests {
 				q -> q.limit(2).sortBy(Sort.by("firstname", "emailAddress")).scroll(firstWindow.positionAt(0)));
 
 		assertThat(previousWindow).containsExactly(jane1, jane2);
+	}
+
+	private List<User> scrollForward(Sort sort, int pageSize) {
+
+		List<User> result = new ArrayList<>();
+		ScrollPosition position = ScrollPosition.keyset();
+
+		while (true) {
+
+			Window<User> window = scroll(sort, position, pageSize);
+			result.addAll(window.getContent());
+
+			if (!window.hasNext() || window.isEmpty()) {
+				return result;
+			}
+
+			position = window.positionAt(window.size() - 1);
+		}
+	}
+
+	private List<User> scrollForward(com.querydsl.core.types.Predicate predicate, Sort sort, int pageSize) {
+
+		List<User> result = new ArrayList<>();
+		ScrollPosition position = ScrollPosition.keyset();
+
+		while (true) {
+
+			Window<User> window = scroll(predicate, sort, position, pageSize);
+			result.addAll(window.getContent());
+
+			if (!window.hasNext() || window.isEmpty()) {
+				return result;
+			}
+
+			position = window.positionAt(window.size() - 1);
+		}
+	}
+
+	private List<User> scrollBackward(Sort sort, int pageSize) {
+
+		List<User> result = new ArrayList<>();
+		ScrollPosition position = ScrollPosition.keyset().backward();
+
+		while (true) {
+
+			Window<User> window = scroll(sort, position, pageSize);
+			result.addAll(0, window.getContent());
+
+			if (!window.hasNext() || window.isEmpty()) {
+				return result;
+			}
+
+			position = window.positionAt(0);
+		}
+	}
+
+	private Window<User> scroll(Sort sort, ScrollPosition position, int pageSize) {
+		return repository.findBy(Specification.unrestricted(), q -> q.limit(pageSize).sortBy(sort).scroll(position));
+	}
+
+	private Window<User> scroll(com.querydsl.core.types.Predicate predicate, Sort sort, ScrollPosition position,
+			int pageSize) {
+		return repository.findBy(predicate, q -> q.limit(pageSize).sortBy(sort).scroll(position));
+	}
+
+	private void saveKeysetScrollUsersWithDuplicateFirstnames() {
+
+		repository.saveAllAndFlush(Arrays.asList(//
+				new User("Ada", "Lovelace", "ada-3@example.com"), //
+				new User("Ada", "Lovelace", "ada-2@example.com"), //
+				new User("Ada", "Lovelace", "ada-1@example.com"), //
+				new User("Beth", "Johnson", "beth-2@example.com"), //
+				new User("Beth", "Johnson", "beth-1@example.com"), //
+				new User("Cora", "Smith", "cora-1@example.com")));
+	}
+
+	private void saveKeysetScrollUsersWithDuplicateFirstnamesAndNulls() {
+
+		repository.saveAllAndFlush(Arrays.asList(//
+				new User("Ada", "Lovelace", "ada-3@example.com"), //
+				new User("Ada", "Lovelace", "ada-2@example.com"), //
+				new User("Beth", "Johnson", "beth-2@example.com"), //
+				new User("Beth", "Johnson", "beth-1@example.com"), //
+				new User("Cora", "Smith", "cora-1@example.com"), //
+				new User(null, "Unknown", "unknown-2@example.com"), //
+				new User(null, "Unknown", "unknown-1@example.com")));
+	}
+
+	private static List<String> emailAddressesOf(List<User> users) {
+
+		List<String> result = new ArrayList<>(users.size());
+		for (User user : users) {
+			result.add(user.getEmailAddress());
+		}
+		return result;
 	}
 
 	@Test // GH-2878

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/JpaKeysetScrollQueryCreatorTests.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/JpaKeysetScrollQueryCreatorTests.java
@@ -45,6 +45,7 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
  * Unit tests for {@link JpaKeysetScrollQueryCreator}.
  *
  * @author Mark Paluch
+ * @author YeongJae Min
  */
 @ExtendWith(SpringExtension.class)
 @ContextConfiguration("classpath:hibernate-infrastructure.xml")
@@ -52,7 +53,7 @@ class JpaKeysetScrollQueryCreatorTests {
 
 	@PersistenceContext EntityManager entityManager;
 
-	@Test // GH-3588
+	@Test // GH-3588, GH-4250
 	void shouldCreateContinuationQuery() throws Exception {
 
 		Map<String, Object> keys = Map.of("id", "10", "firstname", "John", "emailAddress", "john@example.com");
@@ -66,10 +67,33 @@ class JpaKeysetScrollQueryCreatorTests {
 
 		assertThat(query).containsIgnoringWhitespaces("""
 				SELECT u FROM User u WHERE (u.firstname LIKE :firstname ESCAPE '\\')
+				AND (u.firstname <= :keyset_firstname
 				AND (u.firstname < :keyset_firstname
 				OR u.firstname = :keyset_firstname AND u.emailAddress < :keyset_emailAddress
-				OR u.firstname = :keyset_firstname AND u.emailAddress = :keyset_emailAddress AND u.id < :keyset_id)
+				OR u.firstname = :keyset_firstname AND u.emailAddress = :keyset_emailAddress AND u.id < :keyset_id))
 				ORDER BY u.firstname desc, u.emailAddress desc, u.id desc
+				""");
+	}
+
+	@Test // GH-4250
+	void shouldCreateForwardContinuationQueryUsingSmartOr() throws Exception {
+
+		Map<String, Object> keys = Map.of("id", "10", "firstname", "John", "emailAddress", "john@example.com");
+		KeysetScrollPosition position = ScrollPosition.of(keys, ScrollPosition.Direction.FORWARD);
+
+		Method method = MyRepo.class.getMethod("findTop3ByFirstnameStartingWithOrderByFirstnameAscEmailAddressAsc",
+				String.class, ScrollPosition.class);
+		JpaKeysetScrollQueryCreator creator = getJpaKeysetScrollQueryCreator(position, method);
+
+		String query = creator.createQuery();
+
+		assertThat(query).containsIgnoringWhitespaces("""
+				SELECT u FROM User u WHERE (u.firstname LIKE :firstname ESCAPE '\\')
+				AND (u.firstname >= :keyset_firstname
+				AND (u.firstname > :keyset_firstname
+				OR u.firstname = :keyset_firstname AND u.emailAddress > :keyset_emailAddress
+				OR u.firstname = :keyset_firstname AND u.emailAddress = :keyset_emailAddress AND u.id > :keyset_id))
+				ORDER BY u.firstname asc, u.emailAddress asc, u.id asc
 				""");
 	}
 


### PR DESCRIPTION
<!--

Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
Make sure that:

-->

This is a follow-up to #4254. The original PR contained the smart-OR keyset predicate implementation, but it was closed after the fork branch no longer carried the diff. This PR resubmits the change from a dedicated branch and adds the missing edge-case coverage discussed in #4250.

This change optimizes keyset continuation predicates by adding an inclusive bound for the leading sort property and grouping the existing disjunction behind it.

For multi-property keysets, the generated predicate can now use a shape such as:

`firstname <= ? AND (firstname < ? OR firstname = ? AND emailAddress < ?)`

The fallback path keeps the existing predicate shape when the leading keyset value is `null`, preserving the current null-handling behavior.

Additional integration coverage walks keyset pages over datasets with duplicate leading sort values and compares the resulting sequence against regular sorted queries. The added tests cover forward scrolling, backward scrolling, nulls-last with mixed sort directions, and Querydsl predicate scrolling.

While adding the Querydsl nulls-last coverage, the null keyset equality branch was corrected to use `IS NULL`.

Closes #4250
Supersedes #4254

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header.