### PR TITLE
Add `EntityGraphHint` query method parameter

### DIFF
--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/EntityGraphHint.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/EntityGraphHint.java
@@ -1,0 +1,183 @@
+/*
+ * Copyright 2026-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.jpa.repository;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+
+import org.jspecify.annotations.Nullable;
+
+import org.springframework.data.core.TypedPropertyPath;
+import org.springframework.data.jpa.repository.EntityGraph.EntityGraphType;
+import org.springframework.util.Assert;
+
+/**
+ * Query method argument to configure the JPA {@link jakarta.persistence.EntityGraph} used for a single repository
+ * invocation.
+ *
+ * @author YeongJae Min
+ * @since 4.2
+ */
+public final class EntityGraphHint<T> {
+
+	private final EntityGraphType type;
+	private final @Nullable String name;
+	private final jakarta.persistence.@Nullable EntityGraph<?> entityGraph;
+	private final List<String> attributePaths;
+
+	private EntityGraphHint(EntityGraphType type, @Nullable String name,
+			jakarta.persistence.@Nullable EntityGraph<?> entityGraph, List<String> attributePaths) {
+
+		Assert.notNull(type, "EntityGraphType must not be null");
+		Assert.notNull(attributePaths, "Attribute paths must not be null");
+
+		this.type = type;
+		this.name = name;
+		this.entityGraph = entityGraph;
+		this.attributePaths = List.copyOf(attributePaths);
+	}
+
+	/**
+	 * Create a fetch graph hint from type-safe property paths.
+	 *
+	 * @param propertyPaths must not be {@literal null} or empty.
+	 * @return a new {@link EntityGraphHint}.
+	 */
+	@SafeVarargs
+	public static <T> EntityGraphHint<T> fetch(TypedPropertyPath<T, ?>... propertyPaths) {
+		return from(EntityGraphType.FETCH, propertyPaths);
+	}
+
+	/**
+	 * Create a load graph hint from type-safe property paths.
+	 *
+	 * @param propertyPaths must not be {@literal null} or empty.
+	 * @return a new {@link EntityGraphHint}.
+	 */
+	@SafeVarargs
+	public static <T> EntityGraphHint<T> load(TypedPropertyPath<T, ?>... propertyPaths) {
+		return from(EntityGraphType.LOAD, propertyPaths);
+	}
+
+	/**
+	 * Create a fetch graph hint from a named entity graph.
+	 *
+	 * @param name must not be {@literal null} or empty.
+	 * @return a new {@link EntityGraphHint}.
+	 */
+	public static <T> EntityGraphHint<T> fetch(String name) {
+		return named(EntityGraphType.FETCH, name);
+	}
+
+	/**
+	 * Create a load graph hint from a named entity graph.
+	 *
+	 * @param name must not be {@literal null} or empty.
+	 * @return a new {@link EntityGraphHint}.
+	 */
+	public static <T> EntityGraphHint<T> load(String name) {
+		return named(EntityGraphType.LOAD, name);
+	}
+
+	/**
+	 * Create a fetch graph hint from a JPA {@link jakarta.persistence.EntityGraph}.
+	 *
+	 * @param entityGraph must not be {@literal null}.
+	 * @return a new {@link EntityGraphHint}.
+	 */
+	public static <T> EntityGraphHint<T> fetch(jakarta.persistence.EntityGraph<T> entityGraph) {
+		return from(EntityGraphType.FETCH, entityGraph);
+	}
+
+	/**
+	 * Create a load graph hint from a JPA {@link jakarta.persistence.EntityGraph}.
+	 *
+	 * @param entityGraph must not be {@literal null}.
+	 * @return a new {@link EntityGraphHint}.
+	 */
+	public static <T> EntityGraphHint<T> load(jakarta.persistence.EntityGraph<T> entityGraph) {
+		return from(EntityGraphType.LOAD, entityGraph);
+	}
+
+	private static <T> EntityGraphHint<T> named(EntityGraphType type, String name) {
+
+		Assert.hasText(name, "Entity graph name must not be null or empty");
+
+		return new EntityGraphHint<>(type, name, null, List.of());
+	}
+
+	private static <T> EntityGraphHint<T> from(EntityGraphType type, jakarta.persistence.EntityGraph<T> entityGraph) {
+
+		Assert.notNull(entityGraph, "EntityGraph must not be null");
+
+		return new EntityGraphHint<>(type, null, entityGraph, List.of());
+	}
+
+	private static <T> EntityGraphHint<T> from(EntityGraphType type, TypedPropertyPath<T, ?>[] propertyPaths) {
+
+		Assert.notEmpty(propertyPaths, "Property paths must not be null or empty");
+		Assert.noNullElements(propertyPaths, "Property paths must not contain null values");
+
+		List<String> attributePaths = Arrays.stream(propertyPaths) //
+				.map(it -> TypedPropertyPath.of(it).toDotPath()) //
+				.toList();
+
+		return new EntityGraphHint<>(type, null, null, attributePaths);
+	}
+
+	public EntityGraphType getType() {
+		return type;
+	}
+
+	public @Nullable String getName() {
+		return name;
+	}
+
+	public jakarta.persistence.@Nullable EntityGraph<?> getEntityGraph() {
+		return entityGraph;
+	}
+
+	public List<String> getAttributePaths() {
+		return attributePaths;
+	}
+
+	@Override
+	public boolean equals(@Nullable Object obj) {
+
+		if (this == obj) {
+			return true;
+		}
+
+		if (!(obj instanceof EntityGraphHint<?> that)) {
+			return false;
+		}
+
+		return type == that.type && Objects.equals(name, that.name) && Objects.equals(entityGraph, that.entityGraph)
+				&& attributePaths.equals(that.attributePaths);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(type, name, entityGraph, attributePaths);
+	}
+
+	@Override
+	public String toString() {
+		return "EntityGraphHint [type=" + type + ", name=" + name + ", entityGraph=" + entityGraph + ", attributePaths="
+				+ attributePaths + "]";
+	}
+}

--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/aot/JpaCodeBlocks.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/aot/JpaCodeBlocks.java
@@ -46,6 +46,7 @@ import org.springframework.data.jpa.repository.NativeQuery;
 import org.springframework.data.jpa.repository.QueryHints;
 import org.springframework.data.jpa.repository.QueryRewriter;
 import org.springframework.data.jpa.repository.query.DeclaredQuery;
+import org.springframework.data.jpa.repository.query.Jpa21Utils;
 import org.springframework.data.jpa.repository.query.JpaQueryMethod;
 import org.springframework.data.jpa.repository.query.ParameterBinding;
 import org.springframework.data.jpa.repository.support.JpqlQueryTemplates;
@@ -349,17 +350,17 @@ class JpaCodeBlocks {
 			builder.add(doCreateQuery(count, queryVariableName, queryStringNameVariableName, queryRewriterName, query,
 					sqlResultSetMapping, pageable, queryReturnType));
 
-			if (!count && lockModeType != null) {
-				builder.addStatement("$L.setLockMode($T.$L)", queryVariableName, LockModeType.class, lockModeType.toString());
-			}
-
-			if (entityGraph != null) {
-				builder.add(applyEntityGraph(entityGraph, queryVariableName));
-			}
-
 			if (queryHints.isPresent()) {
 				builder.add(applyHints(queryVariableName, queryHints));
 				builder.add("\n");
+			}
+
+			if (!count) {
+				builder.add(applyEntityGraph(entityGraph, queryVariableName));
+			}
+
+			if (!count && lockModeType != null) {
+				builder.addStatement("$L.setLockMode($T.$L)", queryVariableName, LockModeType.class, lockModeType.toString());
 			}
 
 			for (ParameterBinding binding : query.getParameterBindings()) {
@@ -565,7 +566,42 @@ class JpaCodeBlocks {
 			throw new UnsupportedOperationException("Not supported yet for: " + origin);
 		}
 
-		private CodeBlock applyEntityGraph(AotEntityGraph entityGraph, String queryVariableName) {
+		private CodeBlock applyEntityGraph(@Nullable AotEntityGraph entityGraph, String queryVariableName) {
+
+			CodeBlock.Builder builder = CodeBlock.builder();
+			String entityGraphHintParameter = getEntityGraphHintParameterName();
+
+			if (entityGraphHintParameter != null) {
+
+				builder.beginControlFlow("if ($L != null)", entityGraphHintParameter);
+				builder.addStatement("$T.getFetchGraphHint($L, $L, $T.class).forEach($L::setHint)", Jpa21Utils.class,
+						context.fieldNameOf(EntityManager.class), entityGraphHintParameter, context.getDomainType(),
+						queryVariableName);
+
+				if (entityGraph != null) {
+					builder.nextControlFlow("else");
+					builder.add(applyDeclaredEntityGraph(entityGraph, queryVariableName));
+				}
+
+				builder.endControlFlow();
+				return builder.build();
+			}
+
+			if (entityGraph != null) {
+				builder.add(applyDeclaredEntityGraph(entityGraph, queryVariableName));
+			}
+
+			return builder.build();
+		}
+
+		private @Nullable String getEntityGraphHintParameterName() {
+
+			return queryMethod.getParameters().hasEntityGraphHintParameter()
+					? context.getParameterName(queryMethod.getParameters().getEntityGraphHintIndex())
+					: null;
+		}
+
+		private CodeBlock applyDeclaredEntityGraph(AotEntityGraph entityGraph, String queryVariableName) {
 
 			CodeBlock.Builder builder = CodeBlock.builder();
 

--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/AbstractJpaQuery.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/AbstractJpaQuery.java
@@ -38,6 +38,7 @@ import org.springframework.core.MethodParameter;
 import org.springframework.core.convert.converter.Converter;
 import org.springframework.data.jpa.provider.PersistenceProvider;
 import org.springframework.data.jpa.repository.EntityGraph;
+import org.springframework.data.jpa.repository.EntityGraphHint;
 import org.springframework.data.jpa.repository.query.JpaQueryExecution.CollectionExecution;
 import org.springframework.data.jpa.repository.query.JpaQueryExecution.ModifyingExecution;
 import org.springframework.data.jpa.repository.query.JpaQueryExecution.PagedExecution;
@@ -263,18 +264,30 @@ public abstract class AbstractJpaQuery implements RepositoryQuery {
 	}
 
 	protected Query createQuery(JpaParametersParameterAccessor parameters) {
-		return applyLockMode(applyEntityGraphConfiguration(applyHints(doCreateQuery(parameters), method), method), method);
+		return applyLockMode(applyEntityGraphConfiguration(applyHints(doCreateQuery(parameters), method), method, parameters),
+				method);
 	}
 
 	/**
-	 * Configures the {@link jakarta.persistence.EntityGraph} to use for the given {@link JpaQueryMethod} if the
-	 * {@link EntityGraph} annotation is present.
+	 * Configures the {@link jakarta.persistence.EntityGraph} to use for the given {@link JpaQueryMethod} if an
+	 * {@link EntityGraphHint} parameter is present or the {@link EntityGraph} annotation is configured.
 	 *
 	 * @param query must not be {@literal null}.
 	 * @param method must not be {@literal null}.
+	 * @param parameters must not be {@literal null}.
 	 * @return
 	 */
-	private Query applyEntityGraphConfiguration(Query query, JpaQueryMethod method) {
+	private Query applyEntityGraphConfiguration(Query query, JpaQueryMethod method, JpaParametersParameterAccessor parameters) {
+
+		EntityGraphHint<?> entityGraphHint = parameters.getEntityGraphHint();
+
+		if (entityGraphHint != null) {
+			QueryHints hints = Jpa21Utils.getFetchGraphHint(em, entityGraphHint,
+					getQueryMethod().getEntityInformation().getJavaType());
+
+			hints.forEach(query::setHint);
+			return query;
+		}
 
 		JpaEntityGraph entityGraph = method.getEntityGraph();
 

--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/Jpa21Utils.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/Jpa21Utils.java
@@ -25,6 +25,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
+import org.springframework.data.jpa.repository.EntityGraphHint;
 import org.springframework.data.jpa.repository.support.MutableQueryHints;
 
 import org.jspecify.annotations.Nullable;
@@ -60,6 +61,17 @@ public class Jpa21Utils {
 		return result;
 	}
 
+	public static QueryHints getFetchGraphHint(EntityManager em, EntityGraphHint<?> entityGraphHint,
+			Class<?> entityType) {
+
+		MutableQueryHints result = new MutableQueryHints();
+
+		EntityGraph<?> graph = tryGetFetchGraph(em, entityGraphHint, entityType);
+
+		result.add(entityGraphHint.getType().getKey(), graph);
+		return result;
+	}
+
 	/**
 	 * Adds a JPA 2.1 fetch-graph or load-graph hint to the given {@link Query} if running under JPA 2.1.
 	 *
@@ -85,6 +97,29 @@ public class Jpa21Utils {
 		}
 
 		return createDynamicEntityGraph(em, jpaEntityGraph, entityType);
+	}
+
+	private static EntityGraph<?> tryGetFetchGraph(EntityManager em, EntityGraphHint<?> entityGraphHint,
+			Class<?> entityType) {
+
+		Assert.notNull(em, "EntityManager must not be null");
+		Assert.notNull(entityGraphHint, "EntityGraphHint must not be null");
+		Assert.notNull(entityType, "EntityType must not be null");
+
+		EntityGraph<?> entityGraph = entityGraphHint.getEntityGraph();
+
+		if (entityGraph != null) {
+			return entityGraph;
+		}
+
+		if (StringUtils.hasText(entityGraphHint.getName())) {
+			return em.getEntityGraph(entityGraphHint.getName());
+		}
+
+		return createDynamicEntityGraph(em,
+				new JpaEntityGraph(EntityGraphHint.class.getName(), entityGraphHint.getType(),
+						entityGraphHint.getAttributePaths().toArray(new String[0])),
+				entityType);
 	}
 
 	/**

--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/JpaParameters.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/JpaParameters.java
@@ -26,11 +26,13 @@ import org.jspecify.annotations.Nullable;
 
 import org.springframework.core.MethodParameter;
 import org.springframework.data.core.TypeInformation;
+import org.springframework.data.jpa.repository.EntityGraphHint;
 import org.springframework.data.jpa.repository.Temporal;
 import org.springframework.data.jpa.repository.query.JpaParameters.JpaParameter;
 import org.springframework.data.repository.query.Parameter;
 import org.springframework.data.repository.query.Parameters;
 import org.springframework.data.repository.query.ParametersSource;
+import org.springframework.util.Assert;
 
 /**
  * Custom extension of {@link Parameters} discovering additional query parameter annotations.
@@ -41,6 +43,8 @@ import org.springframework.data.repository.query.ParametersSource;
  */
 public class JpaParameters extends Parameters<JpaParameters, JpaParameter> {
 
+	private final int entityGraphHintIndex;
+
 	/**
 	 * Creates a new {@link JpaParameters} instance from the given {@link ParametersSource}.
 	 *
@@ -50,6 +54,7 @@ public class JpaParameters extends Parameters<JpaParameters, JpaParameter> {
 	public JpaParameters(ParametersSource parametersSource) {
 		super(parametersSource,
 				methodParameter -> new JpaParameter(methodParameter, parametersSource.getDomainTypeInformation()));
+		this.entityGraphHintIndex = findEntityGraphHintIndex();
 	}
 
 	/**
@@ -62,10 +67,12 @@ public class JpaParameters extends Parameters<JpaParameters, JpaParameter> {
 	protected JpaParameters(ParametersSource parametersSource,
 			Function<MethodParameter, JpaParameter> parameterFactory) {
 		super(parametersSource, parameterFactory);
+		this.entityGraphHintIndex = findEntityGraphHintIndex();
 	}
 
 	JpaParameters(List<JpaParameter> parameters) {
 		super(parameters);
+		this.entityGraphHintIndex = findEntityGraphHintIndex();
 	}
 
 	@Override
@@ -80,6 +87,42 @@ public class JpaParameters extends Parameters<JpaParameters, JpaParameter> {
 		return hasLimitParameter() || hasPageableParameter();
 	}
 
+	@Override
+	public boolean hasSpecialParameter() {
+		return super.hasSpecialParameter() || hasEntityGraphHintParameter();
+	}
+
+	/**
+	 * @return {@code true} if the method signature declares an {@link EntityGraphHint} parameter.
+	 */
+	public boolean hasEntityGraphHintParameter() {
+		return entityGraphHintIndex != -1;
+	}
+
+	/**
+	 * @return the index of the {@link EntityGraphHint} parameter or {@code -1} if none exists.
+	 */
+	public int getEntityGraphHintIndex() {
+		return entityGraphHintIndex;
+	}
+
+	private int findEntityGraphHintIndex() {
+
+		int result = -1;
+
+		for (JpaParameter parameter : this) {
+
+			if (!parameter.isEntityGraphHintParameter()) {
+				continue;
+			}
+
+			Assert.isTrue(result == -1, "Only one EntityGraphHint parameter is allowed");
+			result = parameter.getIndex();
+		}
+
+		return result;
+	}
+
 	/**
 	 * Custom {@link Parameter} implementation adding parameters of type {@link Temporal} to the special ones.
 	 *
@@ -89,6 +132,7 @@ public class JpaParameters extends Parameters<JpaParameters, JpaParameter> {
 	public static class JpaParameter extends Parameter {
 
 		private final @Nullable Temporal annotation;
+		private final boolean entityGraphHintParameter;
 
 		@SuppressWarnings("deprecation")
 		private @Nullable TemporalType temporalType;
@@ -102,6 +146,7 @@ public class JpaParameters extends Parameters<JpaParameters, JpaParameter> {
 
 			super(parameter, domainType);
 			this.annotation = parameter.getParameterAnnotation(Temporal.class);
+			this.entityGraphHintParameter = EntityGraphHint.class.isAssignableFrom(parameter.getParameterType());
 			this.temporalType = null;
 			if (!isDateParameter() && hasTemporalParamAnnotation()) {
 				throw new IllegalArgumentException(
@@ -110,8 +155,17 @@ public class JpaParameters extends Parameters<JpaParameters, JpaParameter> {
 		}
 
 		@Override
+		public boolean isSpecialParameter() {
+			return super.isSpecialParameter() || isEntityGraphHintParameter();
+		}
+
+		@Override
 		public boolean isBindable() {
 			return super.isBindable() || isTemporalParameter();
+		}
+
+		boolean isEntityGraphHintParameter() {
+			return entityGraphHintParameter;
 		}
 
 		/**

--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/JpaParametersParameterAccessor.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/JpaParametersParameterAccessor.java
@@ -25,6 +25,7 @@ import org.springframework.data.domain.Range;
 import org.springframework.data.domain.Score;
 import org.springframework.data.domain.ScoringFunction;
 import org.springframework.data.domain.Similarity;
+import org.springframework.data.jpa.repository.EntityGraphHint;
 import org.springframework.data.jpa.repository.query.JpaParameters.JpaParameter;
 import org.springframework.data.repository.query.Parameter;
 import org.springframework.data.repository.query.Parameters;
@@ -64,6 +65,15 @@ public class JpaParametersParameterAccessor extends ParametersParameterAccessor 
 	@Override
 	public Object[] getValues() {
 		return super.getValues();
+	}
+
+	public @Nullable EntityGraphHint<?> getEntityGraphHint() {
+
+		if (!parameters.hasEntityGraphHintParameter()) {
+			return null;
+		}
+
+		return (EntityGraphHint<?>) super.getValue(parameters.getEntityGraphHintIndex());
 	}
 
 	/**

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/EntityGraphHintUnitTests.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/EntityGraphHintUnitTests.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2026-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.jpa.repository;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.data.core.TypedPropertyPath;
+import org.springframework.data.jpa.domain.sample.User;
+import org.springframework.data.jpa.repository.EntityGraph.EntityGraphType;
+
+/**
+ * Unit tests for {@link EntityGraphHint}.
+ *
+ * @author YeongJae Min
+ */
+class EntityGraphHintUnitTests {
+
+	@BeforeEach
+	void setUp() {
+		System.setProperty("spring.data.lambda-reader.filter-stacktrace", "false");
+	}
+
+	@Test // GH-4175
+	void createsFetchGraphFromPropertyReferences() {
+
+		EntityGraphHint<User> hint = EntityGraphHint.fetch(User::getFirstname, User::getRoles);
+
+		assertThat(hint.getType()).isEqualTo(EntityGraphType.FETCH);
+		assertThat(hint.getAttributePaths()).containsExactly("firstname", "roles");
+	}
+
+	@Test // GH-4175
+	void createsLoadGraphFromNestedPropertyPath() {
+
+		EntityGraphHint<User> hint = EntityGraphHint
+				.load(TypedPropertyPath.of(User::getManager).then(User::getLastname));
+
+		assertThat(hint.getType()).isEqualTo(EntityGraphType.LOAD);
+		assertThat(hint.getAttributePaths()).containsExactly("manager.lastname");
+	}
+
+	@Test // GH-4175
+	void createsNamedGraphHint() {
+
+		EntityGraphHint<User> hint = EntityGraphHint.fetch("User.overview");
+
+		assertThat(hint.getType()).isEqualTo(EntityGraphType.FETCH);
+		assertThat(hint.getName()).isEqualTo("User.overview");
+		assertThat(hint.getAttributePaths()).isEmpty();
+	}
+
+	@Test // GH-4175
+	void rejectsEmptyPropertyPaths() {
+		assertThatIllegalArgumentException().isThrownBy(EntityGraphHint::fetch);
+	}
+}

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/EntityGraphRepositoryMethodsIntegrationTests.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/EntityGraphRepositoryMethodsIntegrationTests.java
@@ -182,7 +182,7 @@ class EntityGraphRepositoryMethodsIntegrationTests {
 				.describedAs("roles should be fetched with the EntityGraphHint parameter") //
 				.isTrue();
 		assertThat(util.isLoaded(user, "colleagues")) //
-				.describedAs("colleagues should not be fetched from the declared 'User.detail' graph") //
+				.describedAs("colleagues should not be fetched from the declared entity graph") //
 				.isFalse();
 	}
 

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/EntityGraphRepositoryMethodsIntegrationTests.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/EntityGraphRepositoryMethodsIntegrationTests.java
@@ -167,6 +167,25 @@ class EntityGraphRepositoryMethodsIntegrationTests {
 		softly.assertAll();
 	}
 
+	@Test // GH-4175
+	void shouldPreferEntityGraphHintParameterOverDeclaredEntityGraph() {
+
+		assumeThat(currentEntityManagerIsAJpa21EntityManager(em)).isTrue();
+
+		em.flush();
+		em.clear();
+
+		User user = repository.getOneWithEntityGraphHintById(tom.getId(), EntityGraphHint.fetch(User::getRoles));
+
+		assertThat(user).isNotNull();
+		assertThat(util.isLoaded(user, "roles")) //
+				.describedAs("roles should be fetched with the EntityGraphHint parameter") //
+				.isTrue();
+		assertThat(util.isLoaded(user, "colleagues")) //
+				.describedAs("colleagues should not be fetched from the declared 'User.detail' graph") //
+				.isFalse();
+	}
+
 	@Test // DATAJPA-790, DATAJPA-1087
 	void shouldRespectConfiguredJpaEntityGraphWithPaginationAndQueryDslPredicates() {
 

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/UserRepositoryTests.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/UserRepositoryTests.java
@@ -866,7 +866,7 @@ class UserRepositoryTests {
 
 		flushTestUsers();
 
-		assertThat(repository.findByFirstname("Oliver", null)).containsOnly(firstUser);
+		assertThat(repository.findByFirstname("Oliver", (Pageable) null)).containsOnly(firstUser);
 
 		Page<User> page = repository.findByFirstnameIn(Pageable.unpaged(), "Oliver");
 		assertThat(page.getNumberOfElements()).isOne();
@@ -875,6 +875,21 @@ class UserRepositoryTests {
 		page = repository.findAll(Pageable.unpaged());
 		assertThat(page.getNumberOfElements()).isEqualTo(4);
 		assertThat(page.getContent()).contains(firstUser, secondUser, thirdUser, fourthUser);
+	}
+
+	@Test // GH-4175
+	void appliesEntityGraphHintParameterToQueryMethod() {
+
+		firstUser.addRole(adminRole);
+		flushTestUsers();
+		em.clear();
+
+		List<User> users = repository.findByFirstname("Oliver", EntityGraphHint.fetch(User::getRoles));
+
+		em.clear();
+
+		assertThat(users).containsOnly(firstUser);
+		assertThat(users).allSatisfy(it -> assertThat(it.getRoles()).hasSize(1));
 	}
 
 	@Test // DATAJPA-207

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/aot/JpaRepositoryContributorIntegrationTests.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/aot/JpaRepositoryContributorIntegrationTests.java
@@ -40,6 +40,7 @@ import org.springframework.data.domain.Sort;
 import org.springframework.data.jpa.domain.sample.Role;
 import org.springframework.data.jpa.domain.sample.SpecialUser;
 import org.springframework.data.jpa.domain.sample.User;
+import org.springframework.data.jpa.repository.EntityGraphHint;
 import org.springframework.data.util.Streamable;
 import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 import org.springframework.transaction.annotation.Transactional;
@@ -680,6 +681,24 @@ class JpaRepositoryContributorIntegrationTests {
 		User han = chewie.getManager();
 		assertThat(han.getRoles()).isNotInstanceOf(HibernateProxy.class);
 		assertThat(han.getManager()).isInstanceOf(HibernateProxy.class);
+	}
+
+	@Test // GH-4175
+	void shouldApplyEntityGraphHintParameter() {
+
+		User chewie = fragment.findByFirstname("Chewbacca", EntityGraphHint.fetch(User::getRoles));
+
+		em.clear();
+
+		assertThat(chewie.getRoles()).hasSize(1);
+	}
+
+	@Test // GH-4175
+	void shouldApplyDeclaredEntityGraphIfEntityGraphHintParameterIsNull() {
+
+		User chewie = fragment.findWithEntityGraphHintByFirstname("Chewbacca", null);
+
+		assertThat(chewie.getManager()).isNotInstanceOf(HibernateProxy.class);
 	}
 
 	@Test // GH-3830

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/aot/JpaRepositoryContributorIntegrationTests.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/aot/JpaRepositoryContributorIntegrationTests.java
@@ -704,7 +704,7 @@ class JpaRepositoryContributorIntegrationTests {
 	@Test // GH-4175
 	void shouldPreferEntityGraphHintParameterOverDeclaredEntityGraph() {
 
-		User chewie = fragment.findWithEntityGraphHintByFirstname("Chewbacca", EntityGraphHint.fetch(User::getRoles));
+		User chewie = fragment.findWithAdHocEntityGraphHintByFirstname("Chewbacca", EntityGraphHint.fetch(User::getRoles));
 
 		em.clear();
 

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/aot/JpaRepositoryContributorIntegrationTests.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/aot/JpaRepositoryContributorIntegrationTests.java
@@ -701,6 +701,17 @@ class JpaRepositoryContributorIntegrationTests {
 		assertThat(chewie.getManager()).isNotInstanceOf(HibernateProxy.class);
 	}
 
+	@Test // GH-4175
+	void shouldPreferEntityGraphHintParameterOverDeclaredEntityGraph() {
+
+		User chewie = fragment.findWithEntityGraphHintByFirstname("Chewbacca", EntityGraphHint.fetch(User::getRoles));
+
+		em.clear();
+
+		assertThat(chewie.getRoles()).hasSize(1);
+		assertThat(chewie.getManager()).isInstanceOf(HibernateProxy.class);
+	}
+
 	@Test // GH-3830
 	void shouldQuerySubtype() {
 

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/aot/UserRepository.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/aot/UserRepository.java
@@ -29,6 +29,7 @@ import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.jpa.domain.sample.User;
 import org.springframework.data.jpa.repository.EntityGraph;
+import org.springframework.data.jpa.repository.EntityGraphHint;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.NativeQuery;
 import org.springframework.data.jpa.repository.Query;
@@ -256,6 +257,11 @@ interface UserRepository extends CrudRepository<User, Integer> {
 
 	@EntityGraph(type = EntityGraph.EntityGraphType.FETCH, attributePaths = { "roles", "manager.roles" })
 	User findWithDeclaredEntityGraphByFirstname(String firstname);
+
+	User findByFirstname(String firstname, EntityGraphHint<User> entityGraph);
+
+	@EntityGraph(type = EntityGraph.EntityGraphType.FETCH, value = "User.detail")
+	User findWithEntityGraphHintByFirstname(String firstname, EntityGraphHint<User> entityGraph);
 
 	@Query("select u from User u where u.emailAddress = ?1 AND TYPE(u) = ?2")
 	<T extends User> T findByEmailAddress(String emailAddress, Class<T> type);

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/aot/UserRepository.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/aot/UserRepository.java
@@ -263,6 +263,9 @@ interface UserRepository extends CrudRepository<User, Integer> {
 	@EntityGraph(type = EntityGraph.EntityGraphType.FETCH, value = "User.detail")
 	User findWithEntityGraphHintByFirstname(String firstname, EntityGraphHint<User> entityGraph);
 
+	@EntityGraph(attributePaths = { "manager" })
+	User findWithAdHocEntityGraphHintByFirstname(String firstname, EntityGraphHint<User> entityGraph);
+
 	@Query("select u from User u where u.emailAddress = ?1 AND TYPE(u) = ?2")
 	<T extends User> T findByEmailAddress(String emailAddress, Class<T> type);
 

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/AbstractJpaQueryTests.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/AbstractJpaQueryTests.java
@@ -20,6 +20,7 @@ import static org.assertj.core.api.Assumptions.*;
 import static org.mockito.Mockito.*;
 import static org.springframework.data.jpa.support.EntityManagerTestUtils.*;
 
+import jakarta.persistence.AttributeNode;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.LockModeType;
 import jakarta.persistence.PersistenceContext;
@@ -38,6 +39,7 @@ import org.springframework.data.jpa.domain.sample.User;
 import org.springframework.data.jpa.provider.PersistenceProvider;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.EntityGraph.EntityGraphType;
+import org.springframework.data.jpa.repository.EntityGraphHint;
 import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.QueryHints;
 import org.springframework.data.projection.SpelAwareProxyProjectionFactory;
@@ -148,6 +150,58 @@ class AbstractJpaQueryTests {
 		verify(result).setHint("jakarta.persistence.loadgraph", entityGraph);
 	}
 
+	@Test // GH-4175
+	@Transactional
+	void shouldAddNamedEntityGraphHintParameter() throws Exception {
+
+		assumeThat(currentEntityManagerIsAJpa21EntityManager(em)).isTrue();
+
+		JpaQueryMethod queryMethod = getMethod("findByFirstname", String.class, EntityGraphHint.class);
+		jakarta.persistence.EntityGraph<?> entityGraph = em.getEntityGraph("User.overview");
+
+		AbstractJpaQuery jpaQuery = new DummyJpaQuery(queryMethod, em);
+		Query result = jpaQuery.createQuery(new JpaParametersParameterAccessor(queryMethod.getParameters(),
+				new Object[] { "Dave", EntityGraphHint.fetch("User.overview") }));
+
+		verify(result).setHint("jakarta.persistence.fetchgraph", entityGraph);
+	}
+
+	@Test // GH-4175
+	@Transactional
+	void shouldAddTypedPropertyPathEntityGraphHintParameter() throws Exception {
+
+		assumeThat(currentEntityManagerIsAJpa21EntityManager(em)).isTrue();
+
+		JpaQueryMethod queryMethod = getMethod("findWithEntityGraphHint", EntityGraphHint.class);
+		AbstractJpaQuery jpaQuery = new DummyJpaQuery(queryMethod, em);
+
+		Query result = jpaQuery.createQuery(new JpaParametersParameterAccessor(queryMethod.getParameters(),
+				new Object[] { EntityGraphHint.fetch(User::getRoles) }));
+
+		ArgumentCaptor<jakarta.persistence.EntityGraph> captor = ArgumentCaptor
+				.forClass(jakarta.persistence.EntityGraph.class);
+
+		verify(result).setHint(eq("jakarta.persistence.fetchgraph"), captor.capture());
+		assertThat(captor.getValue().getAttributeNodes()).extracting(it -> ((AttributeNode<?>) it).getAttributeName())
+				.containsExactly("roles");
+	}
+
+	@Test // GH-4175
+	@Transactional
+	void shouldAddJpaEntityGraphHintParameter() throws Exception {
+
+		assumeThat(currentEntityManagerIsAJpa21EntityManager(em)).isTrue();
+
+		JpaQueryMethod queryMethod = getMethod("findWithEntityGraphHint", EntityGraphHint.class);
+		jakarta.persistence.EntityGraph<User> entityGraph = em.createEntityGraph(User.class);
+
+		AbstractJpaQuery jpaQuery = new DummyJpaQuery(queryMethod, em);
+		Query result = jpaQuery.createQuery(new JpaParametersParameterAccessor(queryMethod.getParameters(),
+				new Object[] { EntityGraphHint.load(entityGraph) }));
+
+		verify(result).setHint("jakarta.persistence.loadgraph", entityGraph);
+	}
+
 	@Test // GH-3137
 	void shouldCreateHibernateJpaParameterParametersAccessorForNativeQuery() throws Exception {
 
@@ -201,9 +255,13 @@ class AbstractJpaQueryTests {
 		@QueryHints(value = { @QueryHint(name = "bar", value = "foo") }, forCounting = false)
 		List<User> findByFirstname(String firstname);
 
+		List<User> findByFirstname(String firstname, EntityGraphHint<User> entityGraph);
+
 		@Lock(LockModeType.PESSIMISTIC_WRITE)
 		@org.springframework.data.jpa.repository.Query("select u from User u where u.id = ?1")
 		List<User> findOneLocked(Integer primaryKey);
+
+		List<User> findWithEntityGraphHint(EntityGraphHint<User> entityGraph);
 
 		// DATAJPA-466
 		@EntityGraph(value = "User.detail", type = EntityGraphType.LOAD)

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/JpaParametersUnitTests.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/JpaParametersUnitTests.java
@@ -22,9 +22,11 @@ import jakarta.persistence.TemporalType;
 
 import java.lang.reflect.Method;
 import java.util.Date;
+import java.util.Optional;
 
 import org.junit.jupiter.api.Test;
 
+import org.springframework.data.jpa.repository.EntityGraphHint;
 import org.springframework.data.jpa.repository.Temporal;
 import org.springframework.data.jpa.repository.query.JpaParameters.JpaParameter;
 import org.springframework.data.repository.Repository;
@@ -55,8 +57,50 @@ class JpaParametersUnitTests {
 		assertThat(parameter.isTemporalParameter()).isFalse();
 	}
 
+	@Test // GH-4175
+	void discoversEntityGraphHintParameterConfiguration() throws Exception {
+
+		Method method = SampleRepository.class.getMethod("withEntityGraphHint", String.class, EntityGraphHint.class);
+
+		JpaParameters parameters = new JpaParameters(ParametersSource.of(method));
+
+		assertThat(parameters.hasEntityGraphHintParameter()).isTrue();
+		assertThat(parameters.getEntityGraphHintIndex()).isEqualTo(1);
+		assertThat(parameters.hasSpecialParameter()).isTrue();
+		assertThat(parameters.getParameter(1).isSpecialParameter()).isTrue();
+		assertThat(parameters.getBindableParameters().getNumberOfParameters()).isOne();
+		assertThat(parameters.getBindableParameter(0).getType()).isEqualTo(String.class);
+	}
+
+	@Test // GH-4175
+	void rejectsMultipleEntityGraphHintParameters() throws Exception {
+
+		Method method = SampleRepository.class.getMethod("withMultipleEntityGraphHints", EntityGraphHint.class,
+				EntityGraphHint.class);
+
+		assertThatIllegalArgumentException().isThrownBy(() -> new JpaParameters(ParametersSource.of(method)));
+	}
+
+	@Test // GH-4175
+	void doesNotConsiderWrappedEntityGraphHintSpecialParameter() throws Exception {
+
+		Method method = SampleRepository.class.getMethod("withWrappedEntityGraphHint", Optional.class);
+
+		JpaParameters parameters = new JpaParameters(ParametersSource.of(method));
+
+		assertThat(parameters.hasEntityGraphHintParameter()).isFalse();
+		assertThat(parameters.getParameter(0).isSpecialParameter()).isFalse();
+		assertThat(parameters.getBindableParameters().getNumberOfParameters()).isOne();
+	}
+
 	interface SampleRepository extends Repository<String, String> {
 
 		void foo(@Temporal(TIMESTAMP) Date date, String firstname);
+
+		void withEntityGraphHint(String firstname, EntityGraphHint<String> entityGraph);
+
+		void withMultipleEntityGraphHints(EntityGraphHint<String> first, EntityGraphHint<String> second);
+
+		void withWrappedEntityGraphHint(Optional<EntityGraphHint<String>> entityGraph);
 	}
 }

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/sample/RepositoryMethodsWithEntityGraphConfigRepository.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/sample/RepositoryMethodsWithEntityGraphConfigRepository.java
@@ -24,6 +24,7 @@ import org.springframework.data.jpa.domain.Specification;
 import org.springframework.data.jpa.domain.sample.User;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.EntityGraph.EntityGraphType;
+import org.springframework.data.jpa.repository.EntityGraphHint;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.querydsl.QuerydslPredicateExecutor;
 import org.springframework.data.repository.CrudRepository;
@@ -64,6 +65,10 @@ public interface RepositoryMethodsWithEntityGraphConfigRepository
 	// DATAJPA-696
 	@EntityGraph(attributePaths = { "roles", "colleagues.roles" })
 	User getOneWithAttributeNamesById(Integer id);
+
+	// GH-4175
+	@EntityGraph(type = EntityGraphType.FETCH, value = "User.detail")
+	User getOneWithEntityGraphHintById(Integer id, EntityGraphHint<User> entityGraph);
 
 	// DATAJPA-790
 	@Override

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/sample/RepositoryMethodsWithEntityGraphConfigRepository.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/sample/RepositoryMethodsWithEntityGraphConfigRepository.java
@@ -67,7 +67,7 @@ public interface RepositoryMethodsWithEntityGraphConfigRepository
 	User getOneWithAttributeNamesById(Integer id);
 
 	// GH-4175
-	@EntityGraph(type = EntityGraphType.FETCH, value = "User.detail")
+	@EntityGraph(attributePaths = { "colleagues" })
 	User getOneWithEntityGraphHintById(Integer id, EntityGraphHint<User> entityGraph);
 
 	// DATAJPA-790

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/sample/UserRepository.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/sample/UserRepository.java
@@ -43,6 +43,7 @@ import org.springframework.data.jpa.domain.sample.Address;
 import org.springframework.data.jpa.domain.sample.Role;
 import org.springframework.data.jpa.domain.sample.SpecialUser;
 import org.springframework.data.jpa.domain.sample.User;
+import org.springframework.data.jpa.repository.EntityGraphHint;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.jpa.repository.Modifying;
@@ -136,6 +137,8 @@ public interface UserRepository extends JpaRepository<User, Integer>, JpaSpecifi
 	 * Just returns the queried {@link Page}'s contents.
 	 */
 	List<User> findByFirstname(String firstname, Pageable pageable);
+
+	List<User> findByFirstname(String firstname, EntityGraphHint<User> entityGraph);
 
 	Page<User> findByFirstnameIn(Pageable pageable, String... firstnames);
 

--- a/src/main/antora/modules/ROOT/pages/jpa/query-methods.adoc
+++ b/src/main/antora/modules/ROOT/pages/jpa/query-methods.adoc
@@ -842,6 +842,10 @@ public class GroupInfo {
   @ManyToMany
   List<GroupMember> members = new ArrayList<GroupMember>();
 
+  public List<GroupMember> getMembers() {
+    return members;
+  }
+
   …
 }
 ----
@@ -874,6 +878,23 @@ public interface GroupRepository extends CrudRepository<GroupInfo, String> {
   GroupInfo getByGroupName(String name);
 
 }
+----
+====
+
+You can also select the entity graph per invocation by declaring an `EntityGraphHint` query method parameter. The hint can refer to type-safe property paths, a named entity graph, or a JPA `EntityGraph` instance.
+
+.Using an entity graph query method parameter
+====
+[source, java]
+----
+public interface GroupRepository extends CrudRepository<GroupInfo, String> {
+
+  GroupInfo getByGroupName(String name, EntityGraphHint<GroupInfo> entityGraph);
+
+}
+
+repository.getByGroupName("team", EntityGraphHint.fetch(GroupInfo::getMembers));
+repository.getByGroupName("team", EntityGraphHint.load("GroupInfo.detail"));
 ----
 ====
 


### PR DESCRIPTION
Repository query methods can now accept `EntityGraphHint` to select an entity graph per invocation.

The hint can be created from type-safe property paths, named entity graphs, or a JPA `EntityGraph` instance. We treat the hint as a special parameter so it is excluded from query binding and apply it for runtime and AOT query creation. If the argument is `null`, query creation falls back to the declared `@EntityGraph` metadata.

Includes unit and integration tests for parameter discovery, runtime query creation, repository execution, and AOT query generation.

Closes #4175

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).