### PR TITLE
Add HQL single-character member coverage.

### DIFF
--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/HqlQueryRendererTests.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/HqlQueryRendererTests.java
@@ -1815,6 +1815,39 @@ class HqlQueryRendererTests extends JpqlQueryRendererTckTests {
 				""");
 	}
 
+	@Test // GH-4278
+	void singleCharacterLiteralAsHqlCollectionMemberExpression() {
+
+		assertQuery("""
+				select p
+				from Person p
+				where 'c' member of p.addresses
+				""");
+
+		assertQuery("""
+				select p
+				from Person p
+				where 'c' not member of p.addresses
+				""");
+
+		assertQuery("""
+				select p
+				from Person p
+				where exists (select p2 from Person p2 where 'c' member of p2.addresses)
+				""");
+
+		assertQuery("""
+				update Person p
+				set p.name = 'x'
+				where 'c' member of p.addresses
+				""");
+
+		assertQuery("""
+				delete from Person p
+				where 'c' member of p.addresses
+				""");
+	}
+
 	@Test // GH-4272
 	void columnFunctionWithCastTarget() {
 


### PR DESCRIPTION
Add focused HQL renderer coverage for single-character string literals used as the left operand of collection membership predicates.

As a follow-up to #4278, I also checked the JPQL/EQL grammar change for unintended widening. The only meaningful new parse surface is the intended collection membership predicate shape (`MEMBER OF`/`NOT MEMBER OF`); common existing single-character literal positions such as comparisons, `IN`, constructors, `LIKE`, `TRIM`, functions, `CASE`, and update assignments continue to parse as before.

HQL does not share the same root cause because quoted strings are handled as `STRING_LITERAL`, without a separate single-character token. This PR leaves the HQL grammar unchanged and adds coverage for `member of`, `not member of`, subquery, update, and delete surfaces.

Verified with the HQL query renderer test suite.

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).

See #4278
