### PR TITLE
Introduce JpaAnnotationMetadata for AOT repository generation

### DIFF
--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/aot/EntityGraphLookup.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/aot/EntityGraphLookup.java
@@ -42,7 +42,11 @@ import org.springframework.util.StringUtils;
  * @author Mark Paluch
  * @since 4.0
  */
-record EntityGraphLookup(EntityManagerFactory entityManagerFactory) {
+record EntityGraphLookup(EntityManagerFactory entityManagerFactory, JpaAnnotationMetadata annotationMetadata) {
+
+	EntityGraphLookup(EntityManagerFactory entityManagerFactory) {
+		this(entityManagerFactory, JpaAnnotationMetadata.empty());
+	}
 
 	@SuppressWarnings("unchecked")
 	public @Nullable AotEntityGraph findEntityGraph(MergedAnnotation<EntityGraph> entityGraph,
@@ -60,12 +64,14 @@ record EntityGraphLookup(EntityManagerFactory entityManagerFactory) {
 
 		for (Class<?> candidate : candidates) {
 
+			for (String entityGraphName : entityGraphNames) {
+				if (annotationMetadata.hasNamedEntityGraph(candidate, entityGraphName)) {
+					return new AotEntityGraph(entityGraphName, type, Collections.emptyList());
+				}
+			}
+
 			Map<String, jakarta.persistence.EntityGraph<?>> namedEntityGraphs = entityManagerFactory
 					.getNamedEntityGraphs(Class.class.cast(candidate));
-
-			if (namedEntityGraphs.isEmpty()) {
-				continue;
-			}
 
 			for (String entityGraphName : entityGraphNames) {
 				if (namedEntityGraphs.containsKey(entityGraphName)) {

--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/aot/JpaAnnotationMetadata.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/aot/JpaAnnotationMetadata.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright 2025-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.jpa.repository.aot;
+
+import jakarta.persistence.Converter;
+import jakarta.persistence.Embeddable;
+import jakarta.persistence.Entity;
+import jakarta.persistence.MappedSuperclass;
+import jakarta.persistence.NamedEntityGraph;
+import jakarta.persistence.NamedNativeQuery;
+import jakarta.persistence.NamedQuery;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.springframework.core.annotation.MergedAnnotations;
+import org.springframework.data.repository.config.AotRepositoryContext;
+import org.springframework.util.Assert;
+
+/**
+ * JPA mapping metadata collected from annotations without initializing an {@link jakarta.persistence.EntityManagerFactory}.
+ * <p>
+ * Provides access to {@link NamedQuery}, {@link NamedNativeQuery}, and {@link NamedEntityGraph} declarations on entity
+ * types for AOT repository generation. This is a first step toward GH-4166: AOT still bootstraps an
+ * {@code EntityManagerFactory} for metamodel access and query derivation. Annotation metadata supplements named query
+ * and entity graph resolution ahead of {@code EntityManagerFactory} lookups.
+ * <p>
+ * Not in scope for this type: full domain model mapping metadata, {@code orm.xml} declarations, Hibernate-specific
+ * annotations, or eliminating the {@code EntityManagerFactory} bootstrap entirely.
+ *
+ * @author LordKay-sudo
+ * @since 4.2
+ * @see <a href="https://github.com/spring-projects/spring-data-jpa/issues/4166">GH-4166</a>
+ */
+public final class JpaAnnotationMetadata {
+
+	/**
+	 * Named query definition collected from {@link NamedQuery} or {@link NamedNativeQuery}.
+	 *
+	 * @param name query name
+	 * @param query query string
+	 * @param nativeQuery whether the query is a native SQL query
+	 */
+	public record NamedQueryDefinition(String name, String query, boolean nativeQuery) {
+	}
+
+	private final Map<String, NamedQueryDefinition> namedQueries;
+
+	private final Map<String, Set<String>> namedEntityGraphsByClassName;
+
+	private JpaAnnotationMetadata(Map<String, NamedQueryDefinition> namedQueries,
+			Map<String, Set<String>> namedEntityGraphsByClassName) {
+
+		this.namedQueries = Map.copyOf(namedQueries);
+		this.namedEntityGraphsByClassName = namedEntityGraphsByClassName.entrySet().stream()
+				.collect(Collectors.toUnmodifiableMap(Map.Entry::getKey, entry -> Set.copyOf(entry.getValue())));
+	}
+
+	/**
+	 * Collect annotation metadata from the given entity types.
+	 */
+	public static JpaAnnotationMetadata from(Collection<Class<?>> entityTypes) {
+
+		Assert.notNull(entityTypes, "Entity types must not be null");
+
+		Map<String, NamedQueryDefinition> namedQueries = new HashMap<>();
+		Map<String, Set<String>> namedEntityGraphs = new HashMap<>();
+
+		for (Class<?> entityType : entityTypes) {
+			collect(entityType, namedQueries, namedEntityGraphs);
+		}
+
+		return new JpaAnnotationMetadata(namedQueries, namedEntityGraphs);
+	}
+
+	/**
+	 * Collect annotation metadata from Jakarta Persistence-annotated types in the given {@link AotRepositoryContext}.
+	 */
+	public static JpaAnnotationMetadata from(AotRepositoryContext repositoryContext) {
+
+		Assert.notNull(repositoryContext, "AotRepositoryContext must not be null");
+
+		return from(repositoryContext.getResolvedTypes().stream().filter(JpaAnnotationMetadata::isJakartaAnnotated).toList());
+	}
+
+	public static JpaAnnotationMetadata empty() {
+		return new JpaAnnotationMetadata(Map.of(), Map.of());
+	}
+
+	public Optional<NamedQueryDefinition> findNamedQuery(String name) {
+		return Optional.ofNullable(namedQueries.get(name));
+	}
+
+	public boolean hasNamedEntityGraph(Class<?> entityType, String name) {
+
+		Set<String> graphNames = namedEntityGraphsByClassName.get(entityType.getName());
+		return graphNames != null && graphNames.contains(name);
+	}
+
+	private static void collect(Class<?> entityType, Map<String, NamedQueryDefinition> namedQueries,
+			Map<String, Set<String>> namedEntityGraphs) {
+
+		MergedAnnotations metadata = MergedAnnotations.from(entityType);
+
+		metadata.stream(NamedQuery.class).distinct().forEach(annotation -> {
+			registerNamedQuery(namedQueries, annotation.getString("name"), annotation.getString("query"), false);
+		});
+
+		metadata.stream(NamedNativeQuery.class).distinct().forEach(annotation -> {
+			registerNamedQuery(namedQueries, annotation.getString("name"), annotation.getString("query"), true);
+		});
+
+		Set<String> graphNames = new HashSet<>();
+		metadata.stream(NamedEntityGraph.class).distinct().forEach(annotation -> {
+			graphNames.add(annotation.getString("name"));
+		});
+
+		if (!graphNames.isEmpty()) {
+			namedEntityGraphs.put(entityType.getName(), graphNames);
+		}
+	}
+
+	private static void registerNamedQuery(Map<String, NamedQueryDefinition> namedQueries, String name, String query,
+			boolean nativeQuery) {
+
+		Assert.hasText(name, "Named query name must not be empty");
+		Assert.hasText(query, () -> "Named query [%s] must declare a query string".formatted(name));
+		namedQueries.put(name, new NamedQueryDefinition(name, query, nativeQuery));
+	}
+
+	private static boolean isJakartaAnnotated(Class<?> type) {
+
+		return type.isAnnotationPresent(Entity.class) //
+				|| type.isAnnotationPresent(Embeddable.class) //
+				|| type.isAnnotationPresent(MappedSuperclass.class) //
+				|| type.isAnnotationPresent(Converter.class);
+	}
+
+}

--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/aot/JpaRepositoryContributor.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/aot/JpaRepositoryContributor.java
@@ -93,13 +93,15 @@ public class JpaRepositoryContributor extends RepositoryContributor {
 
 		super(repositoryContext);
 
+		JpaAnnotationMetadata annotationMetadata = JpaAnnotationMetadata.from(repositoryContext);
+
 		this.entityManagerFactory = entityManagerFactory;
 		this.metamodel = entityManagerFactory.getMetamodel();
 		this.persistenceUnitUtil = entityManagerFactory.getPersistenceUnitUtil();
 		this.persistenceProvider = PersistenceProvider.fromEntityManagerFactory(entityManagerFactory);
 		this.queriesFactory = new QueriesFactory(repositoryContext.getConfigurationSource(), entityManagerFactory,
-				repositoryContext.getRequiredClassLoader());
-		this.entityGraphLookup = new EntityGraphLookup(entityManagerFactory);
+				entityManagerFactory.getMetamodel(), repositoryContext.getRequiredClassLoader(), annotationMetadata);
+		this.entityGraphLookup = new EntityGraphLookup(entityManagerFactory, annotationMetadata);
 		this.context = repositoryContext;
 	}
 

--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/aot/QueriesFactory.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/aot/QueriesFactory.java
@@ -64,6 +64,7 @@ import org.springframework.util.StringUtils;
 class QueriesFactory {
 
 	private final EntityManagerFactory entityManagerFactory;
+	private final JpaAnnotationMetadata annotationMetadata;
 	private final NamedQueries namedQueries;
 	private final Metamodel metamodel;
 	private final EscapeCharacter escapeCharacter;
@@ -71,15 +72,22 @@ class QueriesFactory {
 
 	public QueriesFactory(RepositoryConfigurationSource configurationSource, EntityManagerFactory entityManagerFactory,
 			ClassLoader classLoader) {
-		this(configurationSource, entityManagerFactory, entityManagerFactory.getMetamodel(), classLoader);
+		this(configurationSource, entityManagerFactory, entityManagerFactory.getMetamodel(), classLoader,
+				JpaAnnotationMetadata.empty());
 	}
 
 	public QueriesFactory(RepositoryConfigurationSource configurationSource, EntityManagerFactory entityManagerFactory,
 			Metamodel metamodel, ClassLoader classLoader) {
+		this(configurationSource, entityManagerFactory, metamodel, classLoader, JpaAnnotationMetadata.empty());
+	}
+
+	public QueriesFactory(RepositoryConfigurationSource configurationSource, EntityManagerFactory entityManagerFactory,
+			Metamodel metamodel, ClassLoader classLoader, JpaAnnotationMetadata annotationMetadata) {
 
 		this.metamodel = metamodel;
 		this.namedQueries = getNamedQueries(configurationSource, classLoader);
 		this.entityManagerFactory = entityManagerFactory;
+		this.annotationMetadata = annotationMetadata;
 
 		Optional<Character> escapeCharacter = configurationSource.getAttribute("escapeCharacter", Character.class);
 		this.escapeCharacter = escapeCharacter.map(EscapeCharacter::of).orElse(EscapeCharacter.DEFAULT);
@@ -137,7 +145,8 @@ class QueriesFactory {
 	}
 
 	private boolean hasNamedQuery(ReturnedType returnedType, String queryName) {
-		return namedQueries.hasQuery(queryName) || getNamedQuery(returnedType, queryName) != null;
+		return namedQueries.hasQuery(queryName) || annotationMetadata.findNamedQuery(queryName).isPresent()
+				|| getNamedQuery(returnedType, queryName) != null;
 	}
 
 	private AotQueries buildStringQuery(ReturnedType returnedType, QueryEnhancerSelector selector,
@@ -220,6 +229,17 @@ class QueriesFactory {
 
 			DeclaredQuery query = isNative ? DeclaredQuery.nativeQuery(queryString) : DeclaredQuery.jpqlQuery(queryString);
 			return StringAotQuery.named(queryName, EntityQuery.create(query, selector), false);
+		}
+
+		Optional<JpaAnnotationMetadata.NamedQueryDefinition> annotationQuery = annotationMetadata.findNamedQuery(queryName);
+
+		if (annotationQuery.isPresent()) {
+
+			JpaAnnotationMetadata.NamedQueryDefinition definition = annotationQuery.get();
+			boolean nativeQuery = definition.nativeQuery() || isNative;
+			DeclaredQuery query = nativeQuery ? DeclaredQuery.nativeQuery(definition.query())
+					: DeclaredQuery.jpqlQuery(definition.query());
+			return StringAotQuery.named(queryName, EntityQuery.create(query, selector), true);
 		}
 
 		TypedQueryReference<?> namedQuery = getNamedQuery(returnedType, queryName);

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/aot/EntityGraphLookupUnitTests.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/aot/EntityGraphLookupUnitTests.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2025-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.jpa.repository.aot;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import jakarta.persistence.EntityManagerFactory;
+
+import java.lang.reflect.Method;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.core.annotation.MergedAnnotations;
+import org.springframework.data.jpa.domain.sample.User;
+import org.springframework.data.jpa.provider.QueryExtractor;
+import org.springframework.data.jpa.repository.EntityGraph;
+import org.springframework.data.jpa.repository.query.JpaQueryMethod;
+import org.springframework.data.projection.SpelAwareProxyProjectionFactory;
+import org.springframework.data.repository.Repository;
+import org.springframework.data.repository.config.AotRepositoryInformation;
+import org.springframework.data.repository.core.RepositoryInformation;
+import org.springframework.data.repository.core.support.AbstractRepositoryMetadata;
+
+/**
+ * Unit tests for {@link EntityGraphLookup}.
+ *
+ * @author LordKay-sudo
+ */
+class EntityGraphLookupUnitTests {
+
+	@Test // GH-4166
+	void resolvesNamedEntityGraphFromAnnotationMetadataWithoutEntityManagerFactoryGraphs() throws NoSuchMethodException {
+
+		EntityManagerFactory entityManagerFactory = mock(EntityManagerFactory.class);
+		when(entityManagerFactory.getNamedEntityGraphs(User.class)).thenReturn(Map.of());
+
+		JpaAnnotationMetadata annotationMetadata = JpaAnnotationMetadata.from(List.of(User.class));
+		EntityGraphLookup lookup = new EntityGraphLookup(entityManagerFactory, annotationMetadata);
+
+		RepositoryInformation repositoryInformation = new AotRepositoryInformation(
+				AbstractRepositoryMetadata.getMetadata(NamedEntityGraphRepository.class),
+				NamedEntityGraphRepository.class, Collections.emptyList());
+
+		Method method = NamedEntityGraphRepository.class.getMethod("findWithNamedEntityGraphByFirstname", String.class);
+		JpaQueryMethod queryMethod = new JpaQueryMethod(method, repositoryInformation,
+				new SpelAwareProxyProjectionFactory(), mock(QueryExtractor.class));
+
+		AotEntityGraph entityGraph = lookup.findEntityGraph(MergedAnnotations.from(method).get(EntityGraph.class),
+				repositoryInformation, queryMethod.getResultProcessor().getReturnedType(), queryMethod);
+
+		assertThat(entityGraph).isNotNull();
+		assertThat(entityGraph.name()).isEqualTo("User.detail");
+		assertThat(entityGraph.type()).isEqualTo(EntityGraph.EntityGraphType.FETCH);
+		assertThat(entityGraph.attributePaths()).isEmpty();
+	}
+
+	interface NamedEntityGraphRepository extends Repository<User, Long> {
+
+		@EntityGraph(type = EntityGraph.EntityGraphType.FETCH, value = "User.detail")
+		User findWithNamedEntityGraphByFirstname(String firstname);
+	}
+
+}

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/aot/JpaAnnotationMetadataUnitTests.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/aot/JpaAnnotationMetadataUnitTests.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2025-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.jpa.repository.aot;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.data.jpa.domain.sample.AuditableUser;
+import org.springframework.data.jpa.domain.sample.User;
+import org.springframework.data.repository.config.AotRepositoryContext;
+
+/**
+ * Unit tests for {@link JpaAnnotationMetadata}.
+ *
+ * @author LordKay-sudo
+ */
+class JpaAnnotationMetadataUnitTests {
+
+	@Test // GH-4166
+	void collectsNamedQueriesFromEntityAnnotations() {
+
+		JpaAnnotationMetadata metadata = JpaAnnotationMetadata.from(List.of(User.class, AuditableUser.class));
+
+		assertThat(metadata.findNamedQuery("User.findByEmailAddress")).hasValueSatisfying(query -> {
+			assertThat(query.nativeQuery()).isFalse();
+			assertThat(query.query()).isEqualTo("SELECT u FROM User u WHERE u.emailAddress = ?1");
+		});
+
+		assertThat(metadata.findNamedQuery("AuditableUser.findByFirstname")).hasValueSatisfying(query -> {
+			assertThat(query.nativeQuery()).isFalse();
+			assertThat(query.query()).isEqualTo("SELECT u FROM AuditableUser u WHERE u.firstname = ?1");
+		});
+
+		assertThat(metadata.findNamedQuery("User.findByNativeNamedQueryWithPageable")).hasValueSatisfying(query -> {
+			assertThat(query.nativeQuery()).isTrue();
+			assertThat(query.query()).contains("SD_USER");
+		});
+	}
+
+	@Test // GH-4166
+	void collectsNamedEntityGraphsFromEntityAnnotations() {
+
+		JpaAnnotationMetadata metadata = JpaAnnotationMetadata.from(List.of(User.class));
+
+		assertThat(metadata.hasNamedEntityGraph(User.class, "User.overview")).isTrue();
+		assertThat(metadata.hasNamedEntityGraph(User.class, "User.detail")).isTrue();
+		assertThat(metadata.hasNamedEntityGraph(User.class, "User.missing")).isFalse();
+	}
+
+	@Test // GH-4166
+	void emptyMetadataDoesNotExposeQueriesOrGraphs() {
+
+		JpaAnnotationMetadata metadata = JpaAnnotationMetadata.empty();
+
+		assertThat(metadata.findNamedQuery("User.findByEmailAddress")).isEmpty();
+		assertThat(metadata.hasNamedEntityGraph(User.class, "User.overview")).isFalse();
+	}
+
+	@Test // GH-4166
+	void collectsMetadataFromAotRepositoryContext() {
+
+		AotRepositoryContext context = org.mockito.Mockito.mock(AotRepositoryContext.class);
+		org.mockito.Mockito.when(context.getResolvedTypes()).thenReturn(Set.of(User.class, String.class));
+
+		JpaAnnotationMetadata metadata = JpaAnnotationMetadata.from(context);
+
+		assertThat(metadata.findNamedQuery("User.findByEmailAddress")).isPresent();
+		assertThat(metadata.hasNamedEntityGraph(User.class, "User.detail")).isTrue();
+	}
+
+}

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/aot/QueriesFactoryUnitTests.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/aot/QueriesFactoryUnitTests.java
@@ -22,15 +22,19 @@ import static org.mockito.Mockito.*;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EntityManagerFactory;
 import jakarta.persistence.Id;
+import jakarta.persistence.metamodel.Metamodel;
 
 import java.lang.reflect.Method;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.List;
+import java.util.Map;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.core.annotation.MergedAnnotations;
+import org.springframework.data.jpa.domain.sample.User;
 import org.springframework.data.jpa.provider.QueryExtractor;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.jpa.repository.query.JpaQueryMethod;
@@ -79,6 +83,47 @@ class QueriesFactoryUnitTests {
 				.extracting(StringAotQuery::getQueryString).isEqualTo("select t from CustomNamed t");
 		assertThat(generatedQueries.count()).asInstanceOf(type(StringAotQuery.class))
 				.extracting(StringAotQuery::getQueryString).isEqualTo("select count(t) from CustomNamed t");
+	}
+
+	@Test // GH-4166
+	void resolvesNamedQueryFromAnnotationMetadataWithoutEntityManagerFactoryNamedQueries() throws NoSuchMethodException {
+
+		RepositoryConfigurationSource configSource = mock(RepositoryConfigurationSource.class);
+		EntityManagerFactory entityManagerFactory = mock(EntityManagerFactory.class);
+		Metamodel metamodel = mock(Metamodel.class);
+
+		when(entityManagerFactory.getMetamodel()).thenReturn(metamodel);
+		when(entityManagerFactory.getNamedQueries(org.mockito.ArgumentMatchers.any())).thenReturn(Map.of());
+
+		JpaAnnotationMetadata annotationMetadata = JpaAnnotationMetadata.from(List.of(User.class));
+		QueriesFactory annotationBackedFactory = new QueriesFactory(configSource, entityManagerFactory, metamodel,
+				getClass().getClassLoader(), annotationMetadata);
+
+		RepositoryInformation repositoryInformation = new AotRepositoryInformation(
+				AbstractRepositoryMetadata.getMetadata(NamedQueryRepository.class), NamedQueryRepository.class,
+				Collections.emptyList());
+
+		Method method = NamedQueryRepository.class.getMethod("findByEmailAddress");
+		JpaQueryMethod queryMethod = new JpaQueryMethod(method, repositoryInformation,
+				new SpelAwareProxyProjectionFactory(), mock(QueryExtractor.class));
+
+		AotQueries generatedQueries = annotationBackedFactory.createQueries(repositoryInformation,
+				queryMethod.getResultProcessor().getReturnedType(), QueryEnhancerSelector.DEFAULT_SELECTOR,
+				MergedAnnotations.from(method).get(Query.class), queryMethod);
+
+		assertThat(generatedQueries.result()).asInstanceOf(type(StringAotQuery.class))
+				.satisfies(query -> {
+					assertThat(query).isInstanceOf(AotQuery.NamedQuery.class);
+					assertThat(((AotQuery.NamedQuery) query).getQueryName()).isEqualTo("User.findByEmailAddress");
+					assertThat(((AotQuery.NamedQuery) query).isManaged()).isTrue();
+					assertThat(query.getQueryString()).isEqualTo("SELECT u FROM User u WHERE u.emailAddress = ?1");
+				});
+	}
+
+	interface NamedQueryRepository extends Repository<User, Long> {
+
+		@Query(name = "User.findByEmailAddress")
+		User findByEmailAddress();
 	}
 
 	interface MyRepository extends Repository<MyEntity, Long> {


### PR DESCRIPTION
## Summary

Introduces `JpaAnnotationMetadata` to collect `@NamedQuery`, `@NamedNativeQuery`, and `@NamedEntityGraph` from entity types via `MergedAnnotations` during AOT processing, and wires it into `QueriesFactory` and `EntityGraphLookup` so those declarations resolve from annotations before falling back to `EntityManagerFactory`.

This is a **first step toward [GH-4166](https://github.com/spring-projects/spring-data-jpa/issues/4166)** — it does **not** close that issue.

## Scope

### In scope (this PR)

- Collect `@NamedQuery`, `@NamedNativeQuery`, and `@NamedEntityGraph` from `@Entity`, `@MappedSuperclass`, `@Embeddable`, and `@Converter` types in `AotRepositoryContext.getResolvedTypes()`
- Resolve named queries and entity graphs from annotation metadata **before** `EntityManagerFactory` lookups in AOT code generation
- Unit tests for metadata collection and wiring (`QueriesFactory`, `EntityGraphLookup`)

### Out of scope (follow-ups for GH-4166)

- Eliminating `EntityManagerFactory` bootstrap during AOT (still required for metamodel, derived queries, and `TypedQueryReference` resolution)
- Full domain model mapping metadata (`@Table`, attribute mappings, associations)
- `orm.xml` / persistence-unit descriptor parsing
- Hibernate-specific annotations beyond standard Jakarta Persistence

Resolution order for named queries: properties file → annotation metadata → `EntityManagerFactory.getNamedQueries()`.

## Test plan

- [x] `JpaAnnotationMetadataUnitTests` (4 tests)
- [x] `QueriesFactoryUnitTests` — annotation-backed named query without EMF named queries
- [x] `EntityGraphLookupUnitTests` — annotation-backed entity graph without EMF graphs
- [x] `org.springframework.data.jpa.repository.aot.*Tests` (94 tests)
