### PR TITLE
Allow KEY and VALUE in JPQL/EQL collection membership predicates.

### DIFF
--- a/spring-data-jpa/src/main/antlr4/org/springframework/data/jpa/repository/query/Eql.g4
+++ b/spring-data-jpa/src/main/antlr4/org/springframework/data/jpa/repository/query/Eql.g4
@@ -388,6 +388,7 @@ collection_member_expression
 entity_or_value_expression
     : single_valued_object_path_expression
     | state_field_path_expression
+    | map_field_identification_variable
     | simple_entity_or_value_expression
     ;
 

--- a/spring-data-jpa/src/main/antlr4/org/springframework/data/jpa/repository/query/Jpql.g4
+++ b/spring-data-jpa/src/main/antlr4/org/springframework/data/jpa/repository/query/Jpql.g4
@@ -388,6 +388,7 @@ collection_member_expression
 entity_or_value_expression
     : single_valued_object_path_expression
     | state_field_path_expression
+    | map_field_identification_variable
     | simple_entity_or_value_expression
     ;
 

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/JpqlQueryRendererTckTests.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/JpqlQueryRendererTckTests.java
@@ -744,6 +744,28 @@ abstract class JpqlQueryRendererTckTests {
 	}
 
 	@Test
+	void mapFieldIdentificationVariableAsCollectionMemberExpression() {
+
+		assertQuery("""
+				SELECT i
+				FROM Item i JOIN i.photos p
+				WHERE VALUE(p) MEMBER OF i.photoValues
+				""");
+
+		assertQuery("""
+				SELECT i
+				FROM Item i JOIN i.photos p
+				WHERE KEY(p) MEMBER OF i.photoKeys
+				""");
+
+		assertQuery("""
+				SELECT i
+				FROM Item i JOIN i.photos p
+				WHERE VALUE(p) NOT MEMBER OF i.photoValues
+				""");
+	}
+
+	@Test
 	void existsSubSelectExample1() {
 
 		assertQuery("""


### PR DESCRIPTION
Allow JPQL and EQL collection membership predicates to use map key and value expressions as the left operand.

Jakarta Persistence section 4.6.9 describes the left operand with `state_valued_path_expression`, which includes map field identification variables such as `KEY(...)` and `VALUE(...)`. The current JPQL/EQL grammars use the narrower `state_field_path_expression` at this point, so queries such as `SELECT i FROM Item i JOIN i.photos p WHERE VALUE(p) MEMBER OF i.photoValues` fail before rendering.

HQL already accepts the same shape, and Hibernate ORM and EclipseLink accept these forms at `EntityManager#createQuery(...)` time.

This PR adds `map_field_identification_variable` to the JPQL/EQL collection membership left operand and covers `VALUE(...) MEMBER OF`, `KEY(...) MEMBER OF`, and `VALUE(...) NOT MEMBER OF` in the shared renderer TCK.

Verified with ANTLR generation and the JPQL/EQL/HQL query renderer test suite.

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
