### PR TITLE
Reject missing explicitly named queries

### DIFF
--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/JpaQueryLookupStrategy.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/JpaQueryLookupStrategy.java
@@ -171,7 +171,15 @@ public final class JpaQueryLookupStrategy {
 
 			RepositoryQuery query = NamedQuery.lookupFrom(method, em, configuration);
 
-			return query != null ? query : NO_QUERY;
+			if (query != null) {
+				return query;
+			}
+
+			if (method.hasAnnotatedQueryName()) {
+				throw QueryCreationException.create(method, String.format("Did not find named query '%s'", name));
+			}
+
+			return NO_QUERY;
 		}
 
 		private @Nullable DeclaredQuery getCountQuery(JpaQueryMethod method, NamedQueries namedQueries, EntityManager em) {

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/JpaQueryLookupStrategyUnitTests.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/JpaQueryLookupStrategyUnitTests.java
@@ -153,6 +153,21 @@ class JpaQueryLookupStrategyUnitTests {
 		assertThat(repositoryQuery).isInstanceOf(AbstractStringBasedJpaQuery.class);
 	}
 
+	@Test // DATAJPA-1417
+	void rejectsMissingExplicitNamedQuery() throws Exception {
+
+		QueryLookupStrategy strategy = JpaQueryLookupStrategy.create(em, queryMethodFactory, Key.CREATE_IF_NOT_FOUND,
+				CONFIG);
+		Method method = UserRepository.class.getMethod("annotatedQueryNameOnly", String.class, String.class, String.class);
+		RepositoryMetadata metadata = new DefaultRepositoryMetadata(UserRepository.class);
+
+		when(em.createNamedQuery("missing-query")).thenThrow(new IllegalArgumentException());
+
+		assertThatExceptionOfType(QueryCreationException.class)
+				.isThrownBy(() -> strategy.resolveQuery(method, metadata, projectionFactory, namedQueries))
+				.withMessageContaining("Did not find named query 'missing-query'");
+	}
+
 	@Test // GH-2018
 	void namedQueryWithSortShouldThrowIllegalStateException() throws NoSuchMethodException {
 
@@ -227,6 +242,9 @@ class JpaQueryLookupStrategyUnitTests {
 
 		@Query(value = "select foo from Foo foo", name = "my-query-name")
 		User annotatedQueryWithQueryAndQueryName();
+
+		@Query(name = "missing-query")
+		List<User> annotatedQueryNameOnly(String firstname, String lastname, String emailAddress);
 
 		@Query("SELECT * FROM table WHERE (json_col->'jsonKey')::jsonb \\?\\? :param ")
 		List<User> customQueryWithQuestionMarksAndNamedParam(String param);


### PR DESCRIPTION
DATAJPA-1417 changes named query lookup so that repository methods explicitly declaring `@Query(name = …)` fail fast when the named query cannot be resolved.

Previously, if the configured named query was missing from both `NamedQueries` and the `EntityManager`, lookup could continue into query derivation. That fallback produced a misleading parameter-count error for methods whose name did not match the declared query parameters.

### Changes

- Reject unresolved explicit `@Query(name = …)` declarations with a `QueryCreationException`.
- Keep existing fallback behavior for methods that do not explicitly declare a named query.
- Add a regression test covering the missing explicit named query path.

### Tests

- `.\mvnw.cmd -pl spring-data-jpa -Dtest=JpaQueryLookupStrategyUnitTests test`
- `.\mvnw.cmd -pl spring-data-jpa -Dtest=PreprocessedQueryUnitTests test`
