### PR TITLE
Allow whitespace in JPQL and EQL JDBC escape literals.

### DIFF
--- a/spring-data-jpa/src/main/antlr4/org/springframework/data/jpa/repository/query/Eql.g4
+++ b/spring-data-jpa/src/main/antlr4/org/springframework/data/jpa/repository/query/Eql.g4
@@ -699,9 +699,25 @@ pattern_value
 
 date_time_timestamp_literal
     : STRINGLITERAL
-    | DATELITERAL
-    | TIMELITERAL
-    | TIMESTAMPLITERAL
+    | jdbc_date_literal
+    | jdbc_time_literal
+    | jdbc_timestamp_literal
+    ;
+
+jdbc_date_literal
+    : DATE_ESCAPE_START generic_temporal_literal_text '}'
+    ;
+
+jdbc_time_literal
+    : TIME_ESCAPE_START generic_temporal_literal_text '}'
+    ;
+
+jdbc_timestamp_literal
+    : TIMESTAMP_ESCAPE_START generic_temporal_literal_text '}'
+    ;
+
+generic_temporal_literal_text
+    : STRINGLITERAL
     ;
 
 entity_type_literal
@@ -1030,6 +1046,6 @@ STRINGLITERAL               : '\'' (~ ('\'' | '\\')|'\\')* '\'' ;
 FLOATLITERAL                : ('0' .. '9')* '.' ('0' .. '9')+ (E ('0' .. '9')+)* (F|D)?;
 INTLITERAL                  : ('0' .. '9')+ ;
 LONGLITERAL                 : ('0' .. '9')+ L;
-DATELITERAL                 : '{' D STRINGLITERAL '}';
-TIMELITERAL                 : '{' T STRINGLITERAL '}';
-TIMESTAMPLITERAL            : '{' T S STRINGLITERAL '}';
+TIMESTAMP_ESCAPE_START      : '{' T S;
+DATE_ESCAPE_START           : '{' D;
+TIME_ESCAPE_START           : '{' T;

--- a/spring-data-jpa/src/main/antlr4/org/springframework/data/jpa/repository/query/Jpql.g4
+++ b/spring-data-jpa/src/main/antlr4/org/springframework/data/jpa/repository/query/Jpql.g4
@@ -692,9 +692,25 @@ pattern_value
 
 date_time_timestamp_literal
     : STRINGLITERAL
-    | DATELITERAL
-    | TIMELITERAL
-    | TIMESTAMPLITERAL
+    | jdbc_date_literal
+    | jdbc_time_literal
+    | jdbc_timestamp_literal
+    ;
+
+jdbc_date_literal
+    : DATE_ESCAPE_START generic_temporal_literal_text '}'
+    ;
+
+jdbc_time_literal
+    : TIME_ESCAPE_START generic_temporal_literal_text '}'
+    ;
+
+jdbc_timestamp_literal
+    : TIMESTAMP_ESCAPE_START generic_temporal_literal_text '}'
+    ;
+
+generic_temporal_literal_text
+    : STRINGLITERAL
     ;
 
 entity_type_literal
@@ -1032,6 +1048,6 @@ JAVASTRINGLITERAL           : '"' ( ('\\' [btnfr"']) | ~('"'))* '"';
 FLOATLITERAL                : ('0' .. '9')* '.' ('0' .. '9')+ (E ('0' .. '9')+)* (F|D)?;
 INTLITERAL                  : ('0' .. '9')+ ;
 LONGLITERAL                 : ('0' .. '9')+ L;
-DATELITERAL                 : '{' D STRINGLITERAL '}';
-TIMELITERAL                 : '{' T STRINGLITERAL '}';
-TIMESTAMPLITERAL            : '{' T S STRINGLITERAL '}';
+TIMESTAMP_ESCAPE_START      : '{' T S;
+DATE_ESCAPE_START           : '{' D;
+TIME_ESCAPE_START           : '{' T;

--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/EqlQueryRenderer.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/EqlQueryRenderer.java
@@ -689,6 +689,21 @@ class EqlQueryRenderer extends EqlBaseVisitor<QueryTokenStream> {
 	}
 
 	@Override
+	public QueryTokenStream visitJdbc_date_literal(EqlParser.Jdbc_date_literalContext ctx) {
+		return QueryTokenStream.ofJdbcEscape(ctx, ctx.generic_temporal_literal_text(), this::visit);
+	}
+
+	@Override
+	public QueryTokenStream visitJdbc_time_literal(EqlParser.Jdbc_time_literalContext ctx) {
+		return QueryTokenStream.ofJdbcEscape(ctx, ctx.generic_temporal_literal_text(), this::visit);
+	}
+
+	@Override
+	public QueryTokenStream visitJdbc_timestamp_literal(EqlParser.Jdbc_timestamp_literalContext ctx) {
+		return QueryTokenStream.ofJdbcEscape(ctx, ctx.generic_temporal_literal_text(), this::visit);
+	}
+
+	@Override
 	public QueryTokenStream visitBoolean_expression(EqlParser.Boolean_expressionContext ctx) {
 
 		if (ctx.subquery() != null) {

--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/HqlQueryRenderer.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/HqlQueryRenderer.java
@@ -500,40 +500,22 @@ class HqlQueryRenderer extends HqlBaseVisitor<QueryTokenStream> {
 	@Override
 	public QueryTokenStream visitJdbcTimestampLiteral(HqlParser.JdbcTimestampLiteralContext ctx) {
 
-		QueryRendererBuilder builder = QueryRenderer.builder();
-
-		builder.append(TOKEN_OPEN_BRACE);
-		builder.append(QueryTokens.token("ts"));
-		builder.appendInline(visit(ctx.dateTime() != null ? ctx.dateTime() : ctx.genericTemporalLiteralText()));
-		builder.append(QueryTokens.TOKEN_CLOSE_BRACE);
-
-		return builder;
+		ParserRuleContext literal = ctx.dateTime() != null ? ctx.dateTime() : ctx.genericTemporalLiteralText();
+		return QueryTokenStream.ofJdbcEscape(ctx, literal, this::visit);
 	}
 
 	@Override
 	public QueryTokenStream visitJdbcDateLiteral(HqlParser.JdbcDateLiteralContext ctx) {
 
-		QueryRendererBuilder builder = QueryRenderer.builder();
-
-		builder.append(TOKEN_OPEN_BRACE);
-		builder.append(QueryTokens.token("d"));
-		builder.append(visit(ctx.date() != null ? ctx.date() : ctx.genericTemporalLiteralText()));
-		builder.append(QueryTokens.TOKEN_CLOSE_BRACE);
-
-		return builder;
+		ParserRuleContext literal = ctx.date() != null ? ctx.date() : ctx.genericTemporalLiteralText();
+		return QueryTokenStream.ofJdbcEscape(ctx, literal, this::visit);
 	}
 
 	@Override
 	public QueryTokenStream visitJdbcTimeLiteral(HqlParser.JdbcTimeLiteralContext ctx) {
 
-		QueryRendererBuilder builder = QueryRenderer.builder();
-
-		builder.append(TOKEN_OPEN_BRACE);
-		builder.append(QueryTokens.token("t"));
-		builder.append(visit(ctx.time() != null ? ctx.time() : ctx.genericTemporalLiteralText()));
-		builder.append(QueryTokens.TOKEN_CLOSE_BRACE);
-
-		return builder;
+		ParserRuleContext literal = ctx.time() != null ? ctx.time() : ctx.genericTemporalLiteralText();
+		return QueryTokenStream.ofJdbcEscape(ctx, literal, this::visit);
 	}
 
 	@Override

--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/JpqlQueryRenderer.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/JpqlQueryRenderer.java
@@ -691,6 +691,21 @@ class JpqlQueryRenderer extends JpqlBaseVisitor<QueryTokenStream> {
 	}
 
 	@Override
+	public QueryTokenStream visitJdbc_date_literal(JpqlParser.Jdbc_date_literalContext ctx) {
+		return QueryTokenStream.ofJdbcEscape(ctx, ctx.generic_temporal_literal_text(), this::visit);
+	}
+
+	@Override
+	public QueryTokenStream visitJdbc_time_literal(JpqlParser.Jdbc_time_literalContext ctx) {
+		return QueryTokenStream.ofJdbcEscape(ctx, ctx.generic_temporal_literal_text(), this::visit);
+	}
+
+	@Override
+	public QueryTokenStream visitJdbc_timestamp_literal(JpqlParser.Jdbc_timestamp_literalContext ctx) {
+		return QueryTokenStream.ofJdbcEscape(ctx, ctx.generic_temporal_literal_text(), this::visit);
+	}
+
+	@Override
 	public QueryTokenStream visitBoolean_expression(JpqlParser.Boolean_expressionContext ctx) {
 
 		if (ctx.subquery() != null) {

--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/QueryTokenStream.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/QueryTokenStream.java
@@ -22,6 +22,7 @@ import java.util.Iterator;
 import java.util.NoSuchElementException;
 import java.util.function.Function;
 
+import org.antlr.v4.runtime.ParserRuleContext;
 import org.antlr.v4.runtime.tree.ParseTree;
 import org.antlr.v4.runtime.tree.TerminalNode;
 import org.antlr.v4.runtime.tree.Tree;
@@ -35,6 +36,7 @@ import org.springframework.util.CollectionUtils;
  *
  * @author Christoph Strobl
  * @author Mark Paluch
+ * @author Jewoo Shin
  * @since 3.4
  */
 interface QueryTokenStream extends Streamable<QueryToken> {
@@ -193,6 +195,33 @@ interface QueryTokenStream extends Streamable<QueryToken> {
 		builder.append(TOKEN_OPEN_PAREN);
 		builder.appendInline(nested);
 		builder.append(TOKEN_CLOSE_PAREN);
+
+		return builder.build();
+	}
+
+	/**
+	 * Creates a JDBC escape literal using the given marker and literal value.
+	 *
+	 * @param context the JDBC escape parser context.
+	 * @param literal the literal parser context.
+	 * @param visitor visitor function rendering the literal.
+	 * @return the composed token stream.
+	 */
+	static QueryTokenStream ofJdbcEscape(ParserRuleContext context, ParserRuleContext literal,
+			Function<ParseTree, QueryTokenStream> visitor) {
+
+		var escapeStart = context.getStart();
+		var literalStart = literal.getStart();
+
+		QueryRenderer.QueryRendererBuilder builder = QueryRenderer.builder();
+		builder.append(token(escapeStart));
+
+		if (escapeStart.getStopIndex() + 1 < literalStart.getStartIndex()) {
+			builder.append(TOKEN_SPACE);
+		}
+
+		builder.appendInline(visitor.apply(literal));
+		builder.append(TOKEN_CLOSE_BRACE);
 
 		return builder.build();
 	}

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/JpqlQueryRendererTckTests.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/JpqlQueryRendererTckTests.java
@@ -173,6 +173,9 @@ abstract class JpqlQueryRendererTckTests {
 		assertQuery("SELECT e FROM  Employee e WHERE e.startDate = {d'2012-01-03'}");
 		assertQuery("SELECT e FROM  Employee e WHERE e.startTime = {t'09:00:00'}");
 		assertQuery("SELECT e FROM  Employee e WHERE e.version = {ts'2012-01-03 09:00:00.000000001'}");
+		assertQuery("SELECT e FROM Employee e WHERE e.startDate = {d '2012-01-03'}");
+		assertQuery("SELECT e FROM Employee e WHERE e.startTime = {t '09:00:00'}");
+		assertQuery("SELECT e FROM Employee e WHERE e.version = {ts '2012-01-03 09:00:00.000000001'}");
 		assertQuery("SELECT e FROM  Employee e WHERE e.gender = org.acme.Gender.MALE");
 		assertQuery("UPDATE Employee e SET e.manager = NULL WHERE e.manager = :manager");
 	}


### PR DESCRIPTION
JPQL and EQL tokenize JDBC date, time, and timestamp escape literals as single tokens, requiring the marker to be directly followed by the quoted literal. This rejects common JDBC-style forms such as `{d '2012-01-03'}`.

This change aligns JPQL and EQL parsing with HQL's `*_ESCAPE_START` structure. A shared JPQL, EQL, and HQL rendering path preserves both whitespace and no-whitespace forms, covered by the shared renderer TCK.

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
