### PR TITLE
Allow `REGEXP` modifier in HQL `LIKE` predicates.

### DIFF
--- a/spring-data-jpa/src/main/antlr4/org/springframework/data/jpa/repository/query/Hql.g4
+++ b/spring-data-jpa/src/main/antlr4/org/springframework/data/jpa/repository/query/Hql.g4
@@ -1487,7 +1487,7 @@ betweenExpression
 
 // https://docs.jboss.org/hibernate/orm/6.1/userguide/html_single/Hibernate_User_Guide.html#hql-like-predicate
 stringPatternMatching
-    : expression NOT? (LIKE | ILIKE) expression (ESCAPE (STRING_LITERAL | JAVA_STRING_LITERAL |parameter))?
+    : expression NOT? (LIKE | ILIKE) REGEXP? expression (ESCAPE (STRING_LITERAL | JAVA_STRING_LITERAL |parameter))?
     ;
 
 // https://docs.jboss.org/hibernate/orm/6.1/userguide/html_single/Hibernate_User_Guide.html#hql-elements-indices
@@ -1707,6 +1707,7 @@ nakedIdentifier
     | PRECEDING
     | QUARTER
     | RANGE
+    | REGEXP
     | RESPECT
     | RETURNING
     | RIGHT
@@ -1968,6 +1969,7 @@ POSITION                    : P O S I T I O N;
 PRECEDING                   : P R E C E D I N G;
 QUARTER                     : Q U A R T E R;
 RANGE                       : R A N G E;
+REGEXP                      : R E G E X P;
 RESPECT                     : R E S P E C T;
 RETURNING                   : R E T U R N I N G;
 RIGHT                       : R I G H T;

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/HqlQueryRendererTests.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/HqlQueryRendererTests.java
@@ -373,6 +373,14 @@ class HqlQueryRendererTests extends JpqlQueryRendererTckTests {
 				"from Call c ");
 	}
 
+	@Test
+	void likeRegexpPredicate() {
+
+		assertQuery("select p from Person p where p.name like regexp 'Jo.*'");
+		assertQuery("select p from Person p where p.name not like regexp 'Jo.*'");
+		assertQuery("select p from Person p where p.name ilike regexp 'jo.*'");
+	}
+
 	@Test // GH-3689
 	void currentDateFunctions() {
 


### PR DESCRIPTION
Hibernate's HQL parser accepts `LIKE REGEXP` and `ILIKE REGEXP` predicates, but Spring Data JPA's HQL grammar currently treats `regexp` as the pattern expression and rejects the actual pattern literal.

This change adds `REGEXP` as an HQL token and allows it as a modifier after `LIKE` or `ILIKE`, keeping standalone `REGEXP` predicates out of scope. HQL renderer round-trip coverage now verifies `LIKE REGEXP`, `NOT LIKE REGEXP`, and `ILIKE REGEXP`.

Verified with `./mvnw -pl spring-data-jpa generate-sources` and `./mvnw -pl spring-data-jpa -Dtest=HqlQueryRendererTests test`.

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
