### PR TITLE
Draft: Establish JPA 4 compatibility baseline with minimal changes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-jpa-parent</artifactId>
-	<version>4.2.0-SNAPSHOT</version>
+	<version>4.2.0-SNAPSHOT-JPA4</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data JPA Parent</name>
@@ -30,11 +30,12 @@
 		<antlr>4.13.2</antlr> <!-- align with Hibernate's parser -->
 		<eclipselink>5.0.0</eclipselink>
 		<eclipselink-next>5.0.0-SNAPSHOT</eclipselink-next>
-		<hibernate>7.4.0.Final</hibernate>
-		<hibernate-74-snapshots>7.4.1-SNAPSHOT</hibernate-74-snapshots>
+		<hibernate>8.0.0-SNAPSHOT</hibernate>
+		<hibernate-81-snapshots>8.1.0-SNAPSHOT</hibernate-81-snapshots>
 		<hsqldb>2.7.4</hsqldb>
 		<h2>2.3.232</h2>
-		<jakarta-persistence-api>3.2.0</jakarta-persistence-api>
+		<jakarta-persistence-api>4.0.0-M6</jakarta-persistence-api>
+		<jakarta-persistence-api-snapshot>4.0.0-SNAPSHOT</jakarta-persistence-api-snapshot>
 		<jsqlparser>5.3</jsqlparser>
 		<mysql-connector-java>9.7.0</mysql-connector-java>
 		<postgresql>42.7.11</postgresql>
@@ -44,6 +45,8 @@
 		<hibernate.groupId>org.hibernate</hibernate.groupId>
 		<antora-javadoc-artifactId>spring-data-jpa</antora-javadoc-artifactId>
 		<sonar.dynamicAnalysis>reuseReports</sonar.dynamicAnalysis>
+		<spring>7.1.0-SNAPSHOT</spring>
+		<jakarta-annotation-api>3.0.0</jakarta-annotation-api>
 	</properties>
 
 	<modules>
@@ -63,9 +66,10 @@
 			</repositories>
 		</profile>
 		<profile>
-			<id>hibernate-74-snapshots</id>
+			<id>hibernate-81-snapshots</id>
 			<properties>
-				<hibernate>${hibernate-74-snapshots}</hibernate>
+				<hibernate>${hibernate-81-snapshots}</hibernate>
+				<jakarta-persistence-api>${jakarta-persistence-api-snapshot}</jakarta-persistence-api>
 			</properties>
 			<repositories>
 				<repository>
@@ -284,6 +288,13 @@
 	</build>
 
 	<repositories>
+		<repository>
+			<id>sonatype-central</id>
+			<url>https://central.sonatype.com/repository/maven-snapshots</url>
+			<releases>
+				<enabled>false</enabled>
+			</releases>
+		</repository>
 		<repository>
 			<id>spring-snapshot</id>
 			<url>https://repo.spring.io/snapshot</url>

--- a/spring-data-envers/pom.xml
+++ b/spring-data-envers/pom.xml
@@ -4,12 +4,12 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-envers</artifactId>
-	<version>4.2.0-SNAPSHOT</version>
+	<version>4.2.0-SNAPSHOT-JPA4</version>
 
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-jpa-parent</artifactId>
-		<version>4.2.0-SNAPSHOT</version>
+		<version>4.2.0-SNAPSHOT-JPA4</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-jpa-distribution/pom.xml
+++ b/spring-data-jpa-distribution/pom.xml
@@ -13,7 +13,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-jpa-parent</artifactId>
-		<version>4.2.0-SNAPSHOT</version>
+		<version>4.2.0-SNAPSHOT-JPA4</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-jpa/pom.xml
+++ b/spring-data-jpa/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-jpa</artifactId>
-	<version>4.2.0-SNAPSHOT</version>
+	<version>4.2.0-SNAPSHOT-JPA4</version>
 
 	<name>Spring Data JPA</name>
 	<description>Spring Data module for JPA repositories.</description>
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-jpa-parent</artifactId>
-		<version>4.2.0-SNAPSHOT</version>
+		<version>4.2.0-SNAPSHOT-JPA4</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/provider/HibernateUtils.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/provider/HibernateUtils.java
@@ -17,9 +17,9 @@ package org.springframework.data.jpa.provider;
 
 import org.hibernate.query.NativeQuery;
 import org.hibernate.query.Query;
-import org.hibernate.query.spi.SqmQuery;
-import org.hibernate.query.sql.spi.NamedNativeQueryMemento;
-import org.hibernate.query.sqm.spi.NamedSqmQueryMemento;
+import org.hibernate.query.internal.AbstractSqmQuery;
+import org.hibernate.query.named.spi.NamedNativeQueryMemento;
+import org.hibernate.query.named.spi.NamedSqmQueryMemento;
 import org.jspecify.annotations.Nullable;
 
 /**
@@ -31,6 +31,7 @@ import org.jspecify.annotations.Nullable;
  * @author Jens Schauder
  * @author Donghun Shin
  * @author Greg Turnquist
+ * @author Oscar Fanchin
  * @since 1.10.2
  * @soundtrack Benny Greb - Soulfood (Live, https://www.youtube.com/watch?v=9_ErMa_CtSw)
  */
@@ -48,7 +49,7 @@ public abstract class HibernateUtils {
 
 		try {
 			// Try the new Hibernate implementation first
-			if (query instanceof SqmQuery sqmQuery) {
+			if (query instanceof AbstractSqmQuery sqmQuery) {
 
 				String hql = sqmQuery.getQueryString();
 
@@ -89,7 +90,7 @@ public abstract class HibernateUtils {
 	public static boolean isNativeQuery(Object query) {
 
 		// Try the new Hibernate implementation first
-		if (query instanceof SqmQuery) {
+		if (query instanceof AbstractSqmQuery<?>) {
 			return false;
 		}
 
@@ -105,6 +106,23 @@ public abstract class HibernateUtils {
 
 		if (query instanceof NamedNativeQueryMemento<?>) {
 			return true;
+		}
+		// This change handles the query proxying mechanism introduced in Spring Framework 7.0.9 and 7.1.
+		// See https://github.com/spring-projects/spring-framework/issues/36878.
+		if (query instanceof jakarta.persistence.Query jpaQuery) {
+			try {
+				jpaQuery.unwrap(NativeQuery.class);
+				return true;
+			} catch (Exception ignored) {
+				// Not a native Hibernate query; try the general Hibernate query type.
+			}
+
+			try {
+				jpaQuery.unwrap(Query.class);
+				return false;
+			} catch (Exception ignored) {
+				// Not an unwrap-compatible Hibernate query.
+			}
 		}
 
 		return false;

--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/provider/PersistenceProvider.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/provider/PersistenceProvider.java
@@ -43,7 +43,7 @@ import org.eclipse.persistence.queries.ScrollableCursor;
 import org.hibernate.ScrollMode;
 import org.hibernate.ScrollableResults;
 import org.hibernate.proxy.HibernateProxy;
-import org.hibernate.query.SelectionQuery;
+import org.hibernate.query.MutationOrSelectionQuery;
 import org.jspecify.annotations.Nullable;
 
 import org.springframework.aop.framework.AopProxyUtils;
@@ -65,6 +65,7 @@ import org.springframework.util.StringUtils;
  * @author Greg Turnquist
  * @author Yuriy Tsarkov
  * @author Ariel Morelli Andres
+ * @author Oscar Fanchin
  */
 public enum PersistenceProvider implements QueryExtractor, ProxyIdAccessor, QueryComment {
 
@@ -124,9 +125,11 @@ public enum PersistenceProvider implements QueryExtractor, ProxyIdAccessor, Quer
 		@Override
 		public long getResultCount(Query resultQuery, LongSupplier countSupplier) {
 
+			// Hibernate 8 may expose a selection query as MutationOrSelectionQuery instead of SelectionQuery.
+			// Check the query kind before adapting it to the selection-specific contract.
 			if (TransactionSynchronizationManager.isActualTransactionActive()
-					&& resultQuery instanceof SelectionQuery<?> sq) {
-				return sq.getResultCount();
+					&& resultQuery instanceof MutationOrSelectionQuery sq && sq.isSelectionQuery()) {
+				return sq.asSelectionQuery().getResultCount();
 			}
 
 			return super.getResultCount(resultQuery, countSupplier);

--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/aot/AotMetamodel.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/aot/AotMetamodel.java
@@ -53,8 +53,8 @@ import org.hibernate.query.sqm.mutation.spi.MultiTableHandler;
 import org.hibernate.query.sqm.mutation.spi.MultiTableHandlerBuildResult;
 import org.hibernate.query.sqm.mutation.spi.SqmMultiTableInsertStrategy;
 import org.hibernate.query.sqm.mutation.spi.SqmMultiTableMutationStrategy;
-import org.hibernate.query.sqm.tree.SqmDeleteOrUpdateStatement;
-import org.hibernate.query.sqm.tree.insert.SqmInsertStatement;
+import org.hibernate.query.sqm.tree.spi.SqmDeleteOrUpdateStatement;
+import org.hibernate.query.sqm.tree.spi.insert.SqmInsertStatement;
 import org.hibernate.sql.ast.SqlAstTranslatorFactory;
 import org.hibernate.sql.ast.spi.StandardSqlAstTranslatorFactory;
 import org.hibernate.sql.exec.spi.JdbcParameterBindings;
@@ -67,14 +67,16 @@ import org.springframework.data.util.Lazy;
 import org.springframework.data.util.ReflectionUtils;
 import org.springframework.orm.jpa.persistenceunit.PersistenceManagedTypes;
 import org.springframework.orm.jpa.persistenceunit.SpringPersistenceUnitInfo;
+import org.springframework.util.ClassUtils;
 import org.springframework.util.CollectionUtils;
-
+import org.hibernate.dialect.DatabaseVersion;
 /**
  * AOT metamodel implementation that uses Hibernate to build the metamodel.
  *
  * @author Christoph Strobl
  * @author Mark Paluch
  * @author Oliver Drotbohm
+ * @author Oscar Fanchin
  * @since 4.0
  */
 class AotMetamodel implements Metamodel {
@@ -101,11 +103,14 @@ class AotMetamodel implements Metamodel {
 	public AotMetamodel(Collection<String> managedTypes, @Nullable URL persistenceUnitRootUrl,
 			Map<String, Object> jpaProperties) {
 
-		SpringPersistenceUnitInfo persistenceUnitInfo = new SpringPersistenceUnitInfo(
-				managedTypes.getClass().getClassLoader());
+		// managedTypes may be backed by a bootstrap-loaded JDK collection whose class loader is null.
+		// Use the application class loader so that the persistence unit can resolve managed entity classes.
+			ClassLoader classLoader = ClassUtils.getDefaultClassLoader();
+			SpringPersistenceUnitInfo persistenceUnitInfo = new SpringPersistenceUnitInfo(
+					classLoader != null ? classLoader : AotMetamodel.class.getClassLoader());
 		persistenceUnitInfo.setPersistenceUnitName("AotMetamodel");
 		persistenceUnitInfo.setPersistenceUnitRootUrl(persistenceUnitRootUrl);
-
+		persistenceUnitInfo.setExcludeUnlistedClasses(true);
 		this.entityManagerFactory = init(() -> {
 
 			managedTypes.forEach(persistenceUnitInfo::addManagedClassName);
@@ -202,8 +207,13 @@ class AotMetamodel implements Metamodel {
 	@NullUnmarked
 	@SuppressWarnings("deprecation")
 	static class SpringDataJpaAotDialect extends Dialect {
+		// Hibernate 8 requires an explicit database version when constructing a Dialect.
+		// Use a synthetic version because AOT bootstrap does not connect to a database.
+		protected SpringDataJpaAotDialect(DatabaseVersion version) {
+			super(version);
+		}
 
-		static SpringDataJpaAotDialect INSTANCE = new SpringDataJpaAotDialect();
+		static SpringDataJpaAotDialect INSTANCE = new SpringDataJpaAotDialect(DatabaseVersion.make(1, 0));
 
 		public boolean isCurrentTimestampSelectStringCallable() {
 			return false;

--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/JpaQueryExecution.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/JpaQueryExecution.java
@@ -69,6 +69,7 @@ import org.springframework.util.ReflectionUtils;
  * @author Jens Schauder
  * @author Gabriel Basilio
  * @author Greg Turnquist
+ * @author Oscar Fanchin
  */
 public abstract class JpaQueryExecution {
 
@@ -493,11 +494,11 @@ public abstract class JpaQueryExecution {
 				return query.extractOutputValue(procedure);
 			} finally {
 
-				if (procedure instanceof AutoCloseable ac) {
-					try {
-						ac.close();
-					} catch (Exception ignored) {}
-				}
+					if (procedure instanceof AutoCloseable) { // StoredProcedureQuery extends AutoCloseable as of Jakarta Persistence 4.0.
+						try {
+							((AutoCloseable) procedure).close();
+						} catch (Exception ignored) {}
+					}
 			}
 		}
 	}

--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/PartTreeJpaQuery.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/PartTreeJpaQuery.java
@@ -58,6 +58,7 @@ import org.springframework.util.Assert;
  * @author Jens Schauder
  * @author Mark Paluch
  * @author Сергей Цыпанов
+ * @author Oscar Fanchin
  */
 public class PartTreeJpaQuery extends AbstractJpaQuery {
 
@@ -125,10 +126,13 @@ public class PartTreeJpaQuery extends AbstractJpaQuery {
 		return queryPreparer.createQuery(accessor);
 	}
 
+	// SharedEntityManager may expose JPA 4 queries through a reduced proxy interface.
+	// Unwrap the underlying TypedQuery instead of casting the proxy directly.
+	// See https://github.com/spring-projects/spring-framework/issues/36878.
 	@Override
 	@SuppressWarnings("unchecked")
 	public TypedQuery<Long> doCreateCountQuery(JpaParametersParameterAccessor accessor) {
-		return (TypedQuery<Long>) countQuery.createQuery(accessor);
+		return (TypedQuery<Long>) (countQuery.createQuery(accessor).unwrap(TypedQuery.class));
 	}
 
 	@Override

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/CrudMethodMetadataUnitTests.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/CrudMethodMetadataUnitTests.java
@@ -58,7 +58,7 @@ class CrudMethodMetadataUnitTests {
 	@Mock CriteriaQuery<Role> criteriaQuery;
 	@Mock JpaEntityInformation<Role, Integer> information;
 	@Mock TypedQuery<Role> typedQuery;
-	@Mock jakarta.persistence.Query query;
+	@Mock jakarta.persistence.StatementOrTypedQuery query;
 	@Mock Metamodel metamodel;
 
 	private RoleRepository repository;

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/EclipseLinkRepositoryWithCompositeKeyTests.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/EclipseLinkRepositoryWithCompositeKeyTests.java
@@ -27,7 +27,7 @@ import org.springframework.test.context.ContextConfiguration;
  * @author Mark Paluch
  */
 @ContextConfiguration
-class EclipselinkRepositoryWithCompositeKeyTests extends RepositoryWithCompositeKeyTests {
+class EclipseLinkRepositoryWithCompositeKeyTests extends RepositoryWithCompositeKeyTests {
 
 	@ImportResource({ "classpath:hibernate-infrastructure.xml", "classpath:eclipselink.xml" })
 	static class TestConfig extends RepositoryWithIdClassKeyTests.Config {}

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/aot/AotMetamodelUnitTests.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/aot/AotMetamodelUnitTests.java
@@ -93,6 +93,7 @@ class AotMetamodelUnitTests {
 		SpringPersistenceUnitInfo persistenceUnitInfo = new SpringPersistenceUnitInfo(this.getClass().getClassLoader());
 		persistenceUnitInfo.setPersistenceUnitName("AotMetamodel");
 		persistenceUnitInfo.addManagedClassName(EntityEntity.class.getName());
+		persistenceUnitInfo.setExcludeUnlistedClasses(true);
 		PersistenceUnitInfoDescriptor persistenceUnit = new PersistenceUnitInfoDescriptor(
 				persistenceUnitInfo.asStandardPersistenceUnitInfo());
 

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/procedures/PostgresStoredProcedureIntegrationTests.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/procedures/PostgresStoredProcedureIntegrationTests.java
@@ -62,6 +62,7 @@ import org.testcontainers.postgresql.PostgreSQLContainer;
  * @author Yanming Zhou
  * @author Thorben Janssen
  * @author Mark Paluch
+ * @author Oscar Fanchin
  */
 @Transactional
 @ExtendWith(SpringExtension.class)
@@ -110,7 +111,8 @@ class PostgresStoredProcedureIntegrationTests {
 				new Employee(4, "Gabriel"));
 	}
 
-	@DisabledOnHibernate(value = "7",
+  // Same error with Hibernate 8
+	@DisabledOnHibernate(value = "8",
 			disabledReason = "class org.hibernate.metamodel.model.domain.internal.EntityTypeImpl cannot be cast to class org.hibernate.query.OutputableType (org.hibernate.metamodel.model.domain.internal.EntityTypeImpl and org.hibernate.query.OutputableType are in unnamed module of loader 'app')")
 	@Test // 2256
 	void testSingleEntityFromResultSet() {

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/projections/ProjectionsIntegrationTests.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/projections/ProjectionsIntegrationTests.java
@@ -56,6 +56,7 @@ import org.springframework.transaction.annotation.Transactional;
  * Integration tests for the behavior of projections.
  *
  * @author Jens Schauder
+ * @author Oscar Fanchin
  */
 @Transactional
 @ExtendWith(SpringExtension.class)
@@ -230,6 +231,7 @@ class ProjectionsIntegrationTests {
 			Properties properties = new Properties();
 			properties.setProperty("hibernate.hbm2ddl.auto", "create");
 			properties.setProperty("hibernate.dialect", "org.hibernate.dialect.HSQLDialect");
+			properties.setProperty("hibernate.xml_mapping_enabled", "false");
 			factoryBean.setJpaProperties(properties);
 
 			return factoryBean;

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/AbstractJpaQueryTests.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/AbstractJpaQueryTests.java
@@ -20,6 +20,7 @@ import static org.assertj.core.api.Assumptions.*;
 import static org.mockito.Mockito.*;
 import static org.springframework.data.jpa.support.EntityManagerTestUtils.*;
 
+import jakarta.persistence.AttributeNode;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.LockModeType;
 import jakarta.persistence.PersistenceContext;
@@ -55,6 +56,7 @@ import org.springframework.transaction.annotation.Transactional;
  * @author Mark Paluch
  * @author Krzysztof Krason
  * @author Julia Lee
+ * @author Oscar Fanchin
  */
 @ExtendWith(SpringExtension.class)
 @ContextConfiguration("classpath:hibernate-infrastructure.xml")
@@ -129,7 +131,14 @@ class AbstractJpaQueryTests {
 		AbstractJpaQuery jpaQuery = new DummyJpaQuery(queryMethod, em);
 		Query result = jpaQuery.createQuery(new JpaParametersParameterAccessor(queryMethod.getParameters(), new Object[0]));
 
-		verify(result).setHint("jakarta.persistence.fetchgraph", entityGraph);
+		ArgumentCaptor<Object> captor = ArgumentCaptor.forClass(Object.class);
+		verify(result).setHint(eq("jakarta.persistence.fetchgraph"), captor.capture());
+
+		assertThat(captor.getValue()).isInstanceOf(jakarta.persistence.EntityGraph.class);
+		jakarta.persistence.EntityGraph<?> actual = (jakarta.persistence.EntityGraph<?>) captor.getValue();
+
+		assertThat(actual.getName()).isEqualTo(entityGraph.getName());
+		assertThat(actual.getAttributeNodes()).extracting(AttributeNode::getAttributeName).containsExactly("roles");
 	}
 
 	@Test // DATAJPA-466
@@ -145,7 +154,15 @@ class AbstractJpaQueryTests {
 		Query result = jpaQuery
 				.createQuery(new JpaParametersParameterAccessor(queryMethod.getParameters(), new Object[] { 1 }));
 
-		verify(result).setHint("jakarta.persistence.loadgraph", entityGraph);
+		ArgumentCaptor<Object> captor = ArgumentCaptor.forClass(Object.class);
+		verify(result).setHint(eq("jakarta.persistence.loadgraph"), captor.capture());
+
+		assertThat(captor.getValue()).isInstanceOf(jakarta.persistence.EntityGraph.class);
+		jakarta.persistence.EntityGraph<?> actual = (jakarta.persistence.EntityGraph<?>) captor.getValue();
+
+		assertThat(actual.getName()).isEqualTo(entityGraph.getName());
+		assertThat(actual.getAttributeNodes()).extracting(AttributeNode::getAttributeName)
+				.containsExactlyInAnyOrder("manager", "roles", "colleagues");
 	}
 
 	@Test // GH-3137

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/HqlOrderExpressionVisitorUnitTests.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/HqlOrderExpressionVisitorUnitTests.java
@@ -27,8 +27,8 @@ import jakarta.persistence.criteria.Selection;
 
 import java.util.Locale;
 
-import org.hibernate.query.sqm.tree.SqmRenderContext;
-import org.hibernate.query.sqm.tree.select.SqmSelectStatement;
+import org.hibernate.query.sqm.tree.spi.SqmRenderContext;
+import org.hibernate.query.sqm.tree.spi.select.SqmSelectStatement;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
@@ -43,6 +43,7 @@ import org.springframework.transaction.annotation.Transactional;
  *
  * @author Greg Turnquist
  * @author Mark Paluch
+ * @author Oscar Fanchin
  */
 @ExtendWith(SpringExtension.class)
 @ContextConfiguration("classpath:application-context.xml")

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/Jpa21UtilsTests.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/Jpa21UtilsTests.java
@@ -27,7 +27,6 @@ import jakarta.persistence.Subgraph;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.Iterator;
 import java.util.List;
 
 import org.assertj.core.api.AbstractAssert;
@@ -51,6 +50,7 @@ import org.springframework.util.ObjectUtils;
  * @author Jens Schauder
  * @author Krzysztof Krason
  * @author Christoph Strobl
+ * @author Oscar Fanchin
  */
 @ExtendWith(SpringExtension.class)
 @ContextConfiguration("classpath:application-context.xml")
@@ -317,7 +317,7 @@ class Jpa21UtilsTests {
 
 		private List<String> extractSubgraphsAttributeNames() {
 
-			Iterator<Subgraph> iterator = attributeNode.getSubgraphs().values().iterator();
+			var iterator = attributeNode.getSubgraphs().values().iterator();
 
 			if (!iterator.hasNext()) {
 				return Collections.emptyList();

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/QueryUtilsIntegrationTests.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/QueryUtilsIntegrationTests.java
@@ -15,38 +15,9 @@
  */
 package org.springframework.data.jpa.repository.query;
 
-import static java.util.Collections.singletonList;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-
-import java.util.Collections;
-import java.util.List;
-import java.util.Set;
-import java.util.function.Consumer;
-import java.util.stream.Collectors;
-
-import org.hibernate.query.MutationOrSelectionQuery;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mockito;
-import org.springframework.dao.InvalidDataAccessApiUsageException;
-import org.springframework.data.core.PropertyPath;
-import org.springframework.data.domain.Sort;
-import org.springframework.data.domain.Sort.Direction;
-import org.springframework.data.jpa.domain.sample.Category;
-import org.springframework.data.jpa.domain.sample.Invoice;
-import org.springframework.data.jpa.domain.sample.InvoiceItem;
-import org.springframework.data.jpa.domain.sample.Order;
-import org.springframework.data.jpa.domain.sample.ReferencingEmbeddedIdExampleEmployee;
-import org.springframework.data.jpa.domain.sample.ReferencingIdClassExampleEmployee;
-import org.springframework.data.jpa.domain.sample.User;
-import org.springframework.data.jpa.infrastructure.HibernateTestUtils;
-import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
-import org.springframework.transaction.annotation.Transactional;
+import static java.util.Collections.*;
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
 
 import jakarta.persistence.Entity;
 import jakarta.persistence.EntityManager;
@@ -68,6 +39,33 @@ import jakarta.persistence.spi.PersistenceProvider;
 import jakarta.persistence.spi.PersistenceProviderResolver;
 import jakarta.persistence.spi.PersistenceProviderResolverHolder;
 
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+
+import org.hibernate.query.MutationOrSelectionQuery;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mockito;
+
+import org.springframework.dao.InvalidDataAccessApiUsageException;
+import org.springframework.data.core.PropertyPath;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.domain.Sort.Direction;
+import org.springframework.data.jpa.domain.sample.Category;
+import org.springframework.data.jpa.domain.sample.Invoice;
+import org.springframework.data.jpa.domain.sample.InvoiceItem;
+import org.springframework.data.jpa.domain.sample.Order;
+import org.springframework.data.jpa.domain.sample.ReferencingEmbeddedIdExampleEmployee;
+import org.springframework.data.jpa.domain.sample.ReferencingIdClassExampleEmployee;
+import org.springframework.data.jpa.domain.sample.User;
+import org.springframework.data.jpa.infrastructure.HibernateTestUtils;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.transaction.annotation.Transactional;
+
 /**
  * Integration tests for {@link QueryUtils}.
  *
@@ -78,6 +76,7 @@ import jakarta.persistence.spi.PersistenceProviderResolverHolder;
  * @author Diego Krupitza
  * @author Krzysztof Krason
  * @author Jakub Soltys
+ * @author Oscar Fanchin
  */
 @ExtendWith(SpringExtension.class)
 @ContextConfiguration("classpath:hibernate-infrastructure.xml")

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/QueryUtilsIntegrationTests.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/QueryUtilsIntegrationTests.java
@@ -15,9 +15,38 @@
  */
 package org.springframework.data.jpa.repository.query;
 
-import static java.util.Collections.*;
-import static org.assertj.core.api.Assertions.*;
-import static org.mockito.Mockito.*;
+import static java.util.Collections.singletonList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+
+import org.hibernate.query.MutationOrSelectionQuery;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mockito;
+import org.springframework.dao.InvalidDataAccessApiUsageException;
+import org.springframework.data.core.PropertyPath;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.domain.Sort.Direction;
+import org.springframework.data.jpa.domain.sample.Category;
+import org.springframework.data.jpa.domain.sample.Invoice;
+import org.springframework.data.jpa.domain.sample.InvoiceItem;
+import org.springframework.data.jpa.domain.sample.Order;
+import org.springframework.data.jpa.domain.sample.ReferencingEmbeddedIdExampleEmployee;
+import org.springframework.data.jpa.domain.sample.ReferencingIdClassExampleEmployee;
+import org.springframework.data.jpa.domain.sample.User;
+import org.springframework.data.jpa.infrastructure.HibernateTestUtils;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.transaction.annotation.Transactional;
 
 import jakarta.persistence.Entity;
 import jakarta.persistence.EntityManager;
@@ -38,33 +67,6 @@ import jakarta.persistence.criteria.Root;
 import jakarta.persistence.spi.PersistenceProvider;
 import jakarta.persistence.spi.PersistenceProviderResolver;
 import jakarta.persistence.spi.PersistenceProviderResolverHolder;
-
-import java.util.Collections;
-import java.util.List;
-import java.util.Set;
-import java.util.function.Consumer;
-import java.util.stream.Collectors;
-
-import org.hibernate.query.sqm.internal.SqmQueryImpl;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mockito;
-
-import org.springframework.dao.InvalidDataAccessApiUsageException;
-import org.springframework.data.core.PropertyPath;
-import org.springframework.data.domain.Sort;
-import org.springframework.data.domain.Sort.Direction;
-import org.springframework.data.jpa.domain.sample.Category;
-import org.springframework.data.jpa.domain.sample.Invoice;
-import org.springframework.data.jpa.domain.sample.InvoiceItem;
-import org.springframework.data.jpa.domain.sample.Order;
-import org.springframework.data.jpa.domain.sample.ReferencingEmbeddedIdExampleEmployee;
-import org.springframework.data.jpa.domain.sample.ReferencingIdClassExampleEmployee;
-import org.springframework.data.jpa.domain.sample.User;
-import org.springframework.data.jpa.infrastructure.HibernateTestUtils;
-import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
-import org.springframework.transaction.annotation.Transactional;
 
 /**
  * Integration tests for {@link QueryUtils}.
@@ -449,7 +451,7 @@ class QueryUtilsIntegrationTests {
 	void applyAndBindOptimizesIn() {
 
 		em.getCriteriaBuilder();
-		SqmQueryImpl<?> query = (SqmQueryImpl) QueryUtils
+		MutationOrSelectionQuery query = (MutationOrSelectionQuery) QueryUtils
 				.applyAndBind("DELETE FROM User u", List.of(new User(), new User()), em.unwrap(null));
 
 		assertThat(query.getQueryString()).isEqualTo("DELETE FROM User u where u IN (?1)");
@@ -460,7 +462,7 @@ class QueryUtilsIntegrationTests {
 	void applyAndBindExpandsToPositionalPlaceholders() {
 
 		em.getCriteriaBuilder();
-		SqmQueryImpl<?> query = (SqmQueryImpl) QueryUtils
+		MutationOrSelectionQuery query = (MutationOrSelectionQuery) QueryUtils
 				.applyAndBind("DELETE FROM User u", List.of(new User(), new User()), em.unwrap(null),
 						org.springframework.data.jpa.provider.PersistenceProvider.ECLIPSELINK);
 

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/SimpleJpaQueryUnitTests.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/SimpleJpaQueryUnitTests.java
@@ -61,7 +61,7 @@ import org.springframework.data.repository.query.QueryCreationException;
 import org.springframework.data.repository.query.RepositoryQuery;
 import org.springframework.data.repository.query.ResultProcessor;
 import org.springframework.data.repository.query.ValueExpressionDelegate;
-
+import jakarta.persistence.StatementOrTypedQuery;
 /**
  * Unit test for {@link SimpleJpaQuery}.
  *
@@ -75,6 +75,7 @@ import org.springframework.data.repository.query.ValueExpressionDelegate;
  * @author Erik Pellizzon
  * @author Christoph Strobl
  * @author Danny van den Elshout
+ * @author Oscar Fanchin
  */
 @ExtendWith(MockitoExtension.class)
 @MockitoSettings(strictness = Strictness.LENIENT)
@@ -90,7 +91,8 @@ class SimpleJpaQueryUnitTests {
 	@Mock EntityManager em;
 	@Mock EntityManagerFactory emf;
 	@Mock QueryExtractor extractor;
-	@Mock jakarta.persistence.Query query;
+	@Mock jakarta.persistence.StatementOrTypedQuery query;
+	@Mock jakarta.persistence.TypedQuery<User> queryNative;
 	@Mock TypedQuery<Long> typedQuery;
 	RepositoryMetadata metadata;
 	@Mock ParameterBinder binder;
@@ -102,7 +104,7 @@ class SimpleJpaQueryUnitTests {
 	void setUp() throws SecurityException, NoSuchMethodException {
 
 		when(em.getMetamodel()).thenReturn(metamodel);
-		when(em.createQuery(anyString())).thenReturn(query);
+		when(em.createQuery(anyString())).thenReturn((@Nullable StatementOrTypedQuery) query);
 		when(em.createQuery(anyString(), eq(Long.class))).thenReturn(typedQuery);
 		when(em.getEntityManagerFactory()).thenReturn(emf);
 		when(em.getDelegate()).thenReturn(em);
@@ -156,7 +158,7 @@ class SimpleJpaQueryUnitTests {
 
 		assertThat(jpaQuery).isInstanceOf(NativeJpaQuery.class);
 
-		when(em.createNativeQuery(anyString(), eq(User.class))).thenReturn(query);
+		when(em.createNativeQuery(anyString(), eq(User.class))).thenReturn(queryNative);
 
 		jpaQuery.createQuery(new JpaParametersParameterAccessor(queryMethod.getParameters(), new Object[] { "Matthews" }));
 
@@ -173,7 +175,7 @@ class SimpleJpaQueryUnitTests {
 
 		assertThat(jpaQuery).isInstanceOf(NativeJpaQuery.class);
 
-		when(em.createNativeQuery(anyString(), eq(User.class))).thenReturn(query);
+		when(em.createNativeQuery(anyString(), eq(User.class))).thenReturn(queryNative);
 
 		jpaQuery.createQuery(new JpaParametersParameterAccessor(queryMethod.getParameters(), new Object[] { "Matthews" }));
 

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/sample/UserRepository.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/sample/UserRepository.java
@@ -249,7 +249,11 @@ public interface UserRepository extends JpaRepository<User, Integer>, JpaSpecifi
 	// DATAJPA-132
 	List<User> findByActiveFalse();
 
-	@Query("select u.colleagues from User u where u = ?1")
+	// Previous query: select u.colleagues from User u where u = ?1
+	// Hibernate 8 no longer flattens the collection-valued path into individual elements.
+	// Join the association explicitly to preserve the expected List<User> result shape.
+	// See Jakarta Persistence specification, section 4.9.
+	@Query("select colleague from User u join u.colleagues colleague where u = ?1")
 	List<User> findColleaguesFor(User user);
 
 	// DATAJPA-188

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/support/QuerydslRepositorySupportTests.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/support/QuerydslRepositorySupportTests.java
@@ -37,7 +37,7 @@ import org.springframework.data.support.PageableExecutionUtils;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.transaction.annotation.Transactional;
-
+import org.junit.jupiter.api.Disabled;
 /**
  * Integration test for {@link QuerydslRepositorySupport}.
  *
@@ -46,7 +46,9 @@ import org.springframework.transaction.annotation.Transactional;
  * @author Jens Schauder
  * @author Krzysztof Krason
  * @author Mark Paluch
+ * @author Oscar Fanchin
  */
+@Disabled("Querydsl 5.1 is not binary-compatible with Jakarta Persistence 4.0")
 @ExtendWith(SpringExtension.class)
 @ContextConfiguration("classpath:hibernate-infrastructure.xml")
 @Transactional

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/support/TestcontainerConfigSupport.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/support/TestcontainerConfigSupport.java
@@ -42,6 +42,7 @@ import org.testcontainers.containers.JdbcDatabaseContainer;
  * Support class for integration testing with Testcontainers
  *
  * @author Mark Paluch
+ * @author Oscar Fanchin
  */
 public class TestcontainerConfigSupport {
 
@@ -79,7 +80,7 @@ public class TestcontainerConfigSupport {
 		Properties properties = new Properties();
 		properties.setProperty("hibernate.hbm2ddl.auto", getSchemaAction());
 		properties.setProperty("hibernate.dialect", dialect.getCanonicalName());
-
+		properties.setProperty("hibernate.xml_mapping_enabled", Boolean.FALSE.toString());
 		factoryBean.setJpaProperties(properties);
 
 		return factoryBean;

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/util/TestMetaModel.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/util/TestMetaModel.java
@@ -33,6 +33,7 @@ import org.springframework.orm.jpa.persistenceunit.SpringPersistenceUnitInfo;
 
 /**
  * @author Christoph Strobl
+ * @author Oscar Fanchin
  */
 public class TestMetaModel implements Metamodel {
 
@@ -99,9 +100,14 @@ public class TestMetaModel implements Metamodel {
 		persistenceUnitInfo.setPersistenceUnitName(persistenceUnit);
 		this.managedTypes.stream().map(Class::getName).forEach(persistenceUnitInfo::addManagedClassName);
 		persistenceUnitInfo.setPersistenceProviderClassName(HibernatePersistenceProvider.class.getName());
+		persistenceUnitInfo.setExcludeUnlistedClasses(true);
+
+		Map<String, Object> properties = Map.of( //
+				"hibernate.dialect", "org.hibernate.dialect.H2Dialect", //
+				"hibernate.xml_mapping_enabled", false);
 
 		return new EntityManagerFactoryBuilderImpl(
 				new PersistenceUnitInfoDescriptor(persistenceUnitInfo.asStandardPersistenceUnitInfo()) {},
-				Map.of("hibernate.dialect", "org.hibernate.dialect.H2Dialect")).build();
+				properties).build();
 	}
 }


### PR DESCRIPTION
## Summary

This draft provides an exploratory compatibility baseline for Jakarta Persistence 4 and Hibernate ORM 8.

The goal is to compile and run the existing Spring Data JPA functionality against this new baseline, validate the migration direction, and identify follow-up work.

This is not a complete or final support statement.

## Scope

- Minimal compatibility adaptations for Jakarta Persistence 4 and Hibernate ORM 8.
- Test adjustments required by API or provider behavior changes.
- Existing Spring Data JPA functionality only.

Support for new Jakarta Persistence 4 features is intentionally out of scope.

## Intentional exclusions

- EclipseLink tests are excluded because no Jakarta Persistence 4-compatible EclipseLink build is currently available.
- Querydsl tests are disabled because the Querydsl version currently used by the project is not compatible with Jakarta Persistence 4.

## Dependency baseline

This branch currently uses snapshot dependencies where required because the relevant Hibernate ORM and Jakarta Persistence APIs are still evolving.

More stable milestone builds are available, but they do not yet provide the compatibility surface required by this draft.

## Current status

- The project compiles.
- 3,591 tests were run: 3,413 passed, 108 were skipped, 7 failed, and 63 ended in errors.
- All 70 failures and errors are confined to three AOT repository test suites.
- All executed non-AOT tests pass, including the database-specific tests.
- The Spring Data Envers module test suite passes without failures.
- AOT named-query discovery requires dedicated follow-up work.

Test command:

mvn -pl spring-data-jpa -Pall-dbs clean process-test-classes \
  surefire:test@unit-test \
  surefire:test@integration-test \
  surefire:test@mysql-test \
  surefire:test@postgres-test \
  surefire:test@oracle-test \
  -Dmaven.test.failure.ignore=true -U

Full Surefire reports from the test run are attached.
[surefire-reports.zip](https://github.com/user-attachments/files/29703465/surefire-reports.zip)


## AOT note

The remaining AOT failures originate from named-query discovery in `QueriesFactory`.

With the current Hibernate ORM 8 baseline, untyped named queries may be represented by a `TypedQueryReference` whose result type is `null`.

`QueriesFactory` currently probes multiple result-type candidates, including `null`, when looking up named queries. Passing the `null` candidate to `EntityManagerFactory.getNamedQueries(Class<R>)` results in an NPE.

Removing the `null` candidate avoids the NPE but does not solve the underlying problem: untyped named queries can no longer be discovered. This causes AOT repository method contributions to be omitted and produces cascading metadata and integration-test failures.

This behavior needs further discussion and dedicated follow-up work, potentially involving coordination with Hibernate ORM.

## Related issues

Related to #4187  
Related to #4197

- [X] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [X] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [X] You submit test cases (unit or integration tests) that back your changes.
- [X] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
