### PR TITLE
Consider sort defined by sortBy(…) in fluent Specification slice and unpaged queries.

### DIFF
--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/support/FetchableFluentQueryBySpecification.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/support/FetchableFluentQueryBySpecification.java
@@ -54,6 +54,7 @@ import org.springframework.util.Assert;
  * @param <R> Result type
  * @author Greg Turnquist
  * @author Christoph Strobl
+ * @author kmdy7991
  * @since 3.0
  */
 class FetchableFluentQueryBySpecification<S, R> extends FluentQuerySupport<S, R>
@@ -175,18 +176,18 @@ class FetchableFluentQueryBySpecification<S, R> extends FluentQuerySupport<S, R>
 
 	@Override
 	public Slice<R> slice(Pageable pageable) {
-		return pageable.isUnpaged() ? new PageImpl<>(all(pageable.getSort())) : readSlice(pageable);
+		return pageable.isUnpaged() ? new PageImpl<>(all(pageable.getSortOr(this.sort))) : readSlice(pageable);
 	}
 
 	@Override
 	public Page<R> page(Pageable pageable) {
-		return pageable.isUnpaged() ? new PageImpl<>(all(pageable.getSort())) : readPage(pageable, spec);
+		return pageable.isUnpaged() ? new PageImpl<>(all(pageable.getSortOr(this.sort))) : readPage(pageable, spec);
 	}
 
 	@Override
 	@SuppressWarnings({ "rawtypes", "unchecked" })
 	public Page<R> page(Pageable pageable, Specification<?> countSpec) {
-		return pageable.isUnpaged() ? new PageImpl<>(all(pageable.getSort()))
+		return pageable.isUnpaged() ? new PageImpl<>(all(pageable.getSortOr(this.sort)))
 				: readPage(pageable, (Specification) countSpec);
 	}
 
@@ -225,7 +226,7 @@ class FetchableFluentQueryBySpecification<S, R> extends FluentQuerySupport<S, R>
 
 	private Slice<R> readSlice(Pageable pageable) {
 
-		TypedQuery<S> pagedQuery = createSortedAndProjectedQuery(pageable.getSort());
+		TypedQuery<S> pagedQuery = createSortedAndProjectedQuery(pageable.getSortOr(this.sort));
 
 		if (pageable.isPaged()) {
 			pagedQuery.setFirstResult(PageableUtils.getOffsetAsInteger(pageable));
@@ -245,7 +246,7 @@ class FetchableFluentQueryBySpecification<S, R> extends FluentQuerySupport<S, R>
 
 	private Slice<R> readSlice(Pageable pageable, @Nullable Specification<S> countSpec) {
 
-		TypedQuery<S> pagedQuery = createSortedAndProjectedQuery(pageable.getSort());
+		TypedQuery<S> pagedQuery = createSortedAndProjectedQuery(pageable.getSortOr(this.sort));
 
 		if (pageable.isPaged()) {
 			pagedQuery.setFirstResult(PageableUtils.getOffsetAsInteger(pageable));

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/UserRepositoryTests.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/UserRepositoryTests.java
@@ -105,6 +105,7 @@ import org.springframework.transaction.annotation.Transactional;
  * @author Krzysztof Krason
  * @author Yanming Zhou
  * @author Ilya Bakaev
+ * @author kmdy7991
  */
 @ExtendWith(SpringExtension.class)
 @ContextConfiguration("classpath:application-context.xml")
@@ -2983,6 +2984,39 @@ class UserRepositoryTests {
 		assertThat(slice).isNotInstanceOf(Page.class);
 		assertThat(slice).hasSize(3);
 		assertThat(slice.hasNext()).isFalse();
+	}
+
+	@Test // GH-4297
+	void findByFluentSpecificationSliceWithUnsortedPageable() {
+
+		flushTestUsers();
+
+		Slice<User> slice = repository.findBy(userHasFirstnameLike("v"),
+				q -> q.sortBy(Sort.by("firstname")).slice(PageRequest.of(0, 2)));
+
+		assertThat(slice.getContent()).containsExactly(thirdUser, firstUser);
+		assertThat(slice.hasNext()).isTrue();
+	}
+
+	@Test // GH-4297
+	void findByFluentSpecificationWithUnpagedPageableAppliesSortBy() {
+
+		flushTestUsers();
+
+		Page<User> page = repository.findBy(userHasFirstnameLike("v"),
+				q -> q.sortBy(Sort.by(DESC, "firstname")).page(Pageable.unpaged()));
+
+		assertThat(page.getContent()).containsExactly(fourthUser, firstUser, thirdUser);
+
+		Slice<User> slice = repository.findBy(userHasFirstnameLike("v"),
+				q -> q.sortBy(Sort.by(DESC, "firstname")).slice(Pageable.unpaged()));
+
+		assertThat(slice.getContent()).containsExactly(fourthUser, firstUser, thirdUser);
+
+		page = repository.findBy(userHasFirstnameLike("v"), q -> q.sortBy(Sort.by(DESC, "firstname"))
+				.page(Pageable.unpaged(), (root, query, criteriaBuilder) -> null));
+
+		assertThat(page.getContent()).containsExactly(fourthUser, firstUser, thirdUser);
 	}
 
 	@Test // GH-3727


### PR DESCRIPTION
`FetchableFluentQueryBySpecification` uses `pageable.getSort()` in `readSlice(…)` and in the unpaged branches of `slice(…)`, `page(…)`, and `page(…, countSpec)`, so a `Pageable` without a sort drops the sort configured through `sortBy(…)`. The Querydsl counterpart, `FetchableFluentQueryByPredicate`, uses `pageable.getSortOr(this.sort)` in the analogous page/slice paths and keeps the fluent sort as the fallback.

This change applies the same `getSortOr(…)` fallback to the Specification variant and adds regression tests for the unsorted-`PageRequest` slice path and the unpaged terminals. The existing GH-3762 tests only use `PageRequest`s that carry a sort (the override case), which is why the missing fallback went unnoticed.

Tests:
- `./mvnw.cmd -pl spring-data-jpa -Dtest=UserRepositoryTests test`

---
- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).

Closes #4297