### PR TITLE
Detect deeply nested function aliases in `QueryUtils`.

### DIFF
--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/QueryUtils.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/QueryUtils.java
@@ -91,6 +91,7 @@ import org.springframework.util.StringUtils;
  * @author Alim Naizabek
  * @author Jakub Soltys
  * @author Young-ho Kim
+ * @author Jewoo Shin
  */
 public abstract class QueryUtils {
 
@@ -140,7 +141,6 @@ public abstract class QueryUtils {
 	private static final int COMPLEX_COUNT_FIRST_INDEX = 3;
 
 	private static final Pattern PUNCTATION_PATTERN = compile(".*((?![._])[\\p{Punct}|\\s])");
-	private static final Pattern FUNCTION_PATTERN;
 	private static final Pattern FIELD_ALIAS_PATTERN;
 
 	private static final String UNSAFE_PROPERTY_REFERENCE = "Sort expression '%s' must only contain property references or "
@@ -182,14 +182,6 @@ public abstract class QueryUtils {
 		builder.append("\\)");
 
 		CONSTRUCTOR_EXPRESSION = compile(builder.toString(), CASE_INSENSITIVE + DOTALL);
-
-		builder = new StringBuilder();
-		// any function call including parameters within the brackets;
-		builder.append("\\w+\\s*\\((?:[^()]+|\\([^()]*\\))+\\)");
-		// the potential alias
-		builder.append("\\s+(?:as)+\\s+([\\w\\.]+)");
-
-		FUNCTION_PATTERN = compile(builder.toString(), CASE_INSENSITIVE);
 
 		builder = new StringBuilder();
 		builder.append("[^\\s\\(\\)]+"); // No white char no bracket
@@ -405,18 +397,121 @@ public abstract class QueryUtils {
 	static Set<String> getFunctionAliases(String query) {
 
 		Set<String> result = new HashSet<>();
-		Matcher matcher = FUNCTION_PATTERN.matcher(query);
 
-		while (matcher.find()) {
+		for (int i = 0; i < query.length(); i++) {
 
-			String alias = matcher.group(1);
-
-			if (StringUtils.hasText(alias)) {
-				result.add(alias);
+			if (!Character.isJavaIdentifierStart(query.charAt(i))) {
+				continue;
 			}
+
+			int functionEnd = readJavaIdentifier(query, i + 1);
+			int openingParenthesis = skipWhitespace(query, functionEnd);
+
+			if (openingParenthesis >= query.length() || query.charAt(openingParenthesis) != '(') {
+				i = functionEnd;
+				continue;
+			}
+
+			int closingParenthesis = findClosingParenthesis(query, openingParenthesis);
+
+			if (closingParenthesis == -1) {
+				i = functionEnd;
+				continue;
+			}
+
+			int aliasKeyword = skipWhitespace(query, closingParenthesis + 1);
+
+			if (!hasAsKeyword(query, aliasKeyword)) {
+				i = functionEnd;
+				continue;
+			}
+
+			int aliasStart = skipWhitespace(query, aliasKeyword + 2);
+			int aliasEnd = readAlias(query, aliasStart);
+
+			if (aliasEnd > aliasStart) {
+				result.add(query.substring(aliasStart, aliasEnd));
+			}
+
+			i = closingParenthesis;
 		}
 
 		return result;
+	}
+
+	private static int readJavaIdentifier(String query, int offset) {
+
+		while (offset < query.length() && Character.isJavaIdentifierPart(query.charAt(offset))) {
+			offset++;
+		}
+
+		return offset;
+	}
+
+	private static int skipWhitespace(String query, int offset) {
+
+		while (offset < query.length() && Character.isWhitespace(query.charAt(offset))) {
+			offset++;
+		}
+
+		return offset;
+	}
+
+	private static int findClosingParenthesis(String query, int openingParenthesis) {
+
+		int depth = 0;
+		boolean quoted = false;
+
+		for (int i = openingParenthesis; i < query.length(); i++) {
+
+			char current = query.charAt(i);
+
+			if (current == '\'') {
+
+				if (quoted && i + 1 < query.length() && query.charAt(i + 1) == '\'') {
+					i++;
+					continue;
+				}
+
+				quoted = !quoted;
+				continue;
+			}
+
+			if (quoted) {
+				continue;
+			}
+
+			if (current == '(') {
+				depth++;
+			} else if (current == ')' && --depth == 0) {
+				return i;
+			}
+		}
+
+		return -1;
+	}
+
+	private static boolean hasAsKeyword(String query, int offset) {
+
+		return offset + 2 < query.length() //
+				&& query.regionMatches(true, offset, "as", 0, 2) //
+				&& Character.isWhitespace(query.charAt(offset + 2));
+	}
+
+	private static int readAlias(String query, int offset) {
+
+		while (offset < query.length()) {
+
+			char current = query.charAt(offset);
+
+			if (!Character.isLetterOrDigit(current) && current != '_' && current != '.') {
+				break;
+			}
+
+			offset++;
+		}
+
+		return offset;
 	}
 
 	private static String toJpaDirection(Order order) {

--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/QueryUtils.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/QueryUtils.java
@@ -404,25 +404,25 @@ public abstract class QueryUtils {
 				continue;
 			}
 
-			int functionEnd = readJavaIdentifier(query, i + 1);
-			int openingParenthesis = skipWhitespace(query, functionEnd);
+			int functionNameEnd = readJavaIdentifier(query, i + 1);
+			int functionOpeningParenthesis = skipWhitespace(query, functionNameEnd);
 
-			if (openingParenthesis >= query.length() || query.charAt(openingParenthesis) != '(') {
-				i = functionEnd;
+			if (functionOpeningParenthesis >= query.length() || query.charAt(functionOpeningParenthesis) != '(') {
+				i = functionNameEnd;
 				continue;
 			}
 
-			int closingParenthesis = findClosingParenthesis(query, openingParenthesis);
+			int functionClosingParenthesis = findClosingParenthesis(query, functionOpeningParenthesis);
 
-			if (closingParenthesis == -1) {
-				i = functionEnd;
+			if (functionClosingParenthesis == -1) {
+				i = functionNameEnd;
 				continue;
 			}
 
-			int aliasKeyword = skipWhitespace(query, closingParenthesis + 1);
+			int aliasKeyword = skipWhitespace(query, functionClosingParenthesis + 1);
 
 			if (!hasAsKeyword(query, aliasKeyword)) {
-				i = functionEnd;
+				i = functionNameEnd;
 				continue;
 			}
 
@@ -433,7 +433,7 @@ public abstract class QueryUtils {
 				result.add(query.substring(aliasStart, aliasEnd));
 			}
 
-			i = closingParenthesis;
+			i = functionClosingParenthesis;
 		}
 
 		return result;

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/QueryUtilsUnitTests.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/QueryUtilsUnitTests.java
@@ -53,6 +53,7 @@ import org.springframework.data.jpa.domain.JpaSort;
  * @author Eduard Dudar
  * @author Mark Paluch
  * @author Young-ho Kim
+ * @author Jewoo Shin
  */
 class QueryUtilsUnitTests {
 
@@ -583,6 +584,22 @@ class QueryUtilsUnitTests {
 		assertThat(getFunctionAliases("SELECT COALESCE(COUNT(id), 0) AS cnt FROM User u")).containsExactly("cnt");
 		assertThat(getFunctionAliases("SELECT UPPER(TRIM(name)) AS cleanName FROM User u")).containsExactly("cleanName");
 		assertThat(getFunctionAliases("SELECT NVL(SUM(price), 0) AS total FROM Order o")).containsExactly("total");
+	}
+
+	@Test // GH-4242
+	void discoversFunctionAliasWithDeeplyNestedFunctionArguments() {
+
+		assertThat(getFunctionAliases("SELECT COALESCE(NULLIF(TRIM(name), ''), 'unknown') AS normalized FROM User u"))
+				.containsExactly("normalized");
+	}
+
+	@Test // GH-4242
+	void doesNotPrefixDeeplyNestedFunctionAliasSortProperty() {
+
+		String query = "SELECT COALESCE(NULLIF(TRIM(m.name), ''), 'unknown') AS normalized FROM Magazine m";
+		Sort sort = Sort.by("normalized");
+
+		assertThat(applySorting(query, sort, "m")).endsWith("order by normalized asc");
 	}
 
 	@Test // GH-3911

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/QueryUtilsUnitTests.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/QueryUtilsUnitTests.java
@@ -540,7 +540,7 @@ class QueryUtilsUnitTests {
 	@Test // DATAJPA-965, DATAJPA-970
 	void doesNotPrefixAliasedFunctionCallNameWhenQueryStringContainsMultipleWhiteSpaces() {
 
-		String query = "SELECT  AVG(  m.price  )   AS   avgPrice   FROM Magazine   m";
+		String query = "SELECT  AVG  (  m.price  )   AS   avgPrice   FROM Magazine   m";
 		Sort sort = Sort.by("avgPrice");
 
 		assertThat(applySorting(query, sort, "m")).endsWith("order by avgPrice asc");
@@ -591,6 +591,13 @@ class QueryUtilsUnitTests {
 
 		assertThat(getFunctionAliases("SELECT COALESCE(NULLIF(TRIM(name), ''), 'unknown') AS normalized FROM User u"))
 				.containsExactly("normalized");
+	}
+
+	@Test // GH-4242
+	void discoversFunctionAliasesWithParenthesesInQuotedArguments() {
+
+		assertThat(getFunctionAliases("SELECT COALESCE(name, '(') AS opening FROM User u")).containsExactly("opening");
+		assertThat(getFunctionAliases("SELECT COALESCE(name, ')') AS closing FROM User u")).containsExactly("closing");
 	}
 
 	@Test // GH-4242


### PR DESCRIPTION
`QueryUtils` now detects aliases for deeply nested function expressions such as `COALESCE(NULLIF(TRIM(...), ...), ...) AS normalized`. It scans balanced parentheses while respecting quoted function arguments so `applySorting(...)` keeps select aliases unqualified instead of treating them as entity properties.

See #4242

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [ ] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
