### PR TITLE
Allow generic type parameter for QuerydslRepositorySupport.

### DIFF
--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/support/QuerydslRepositorySupport.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/support/QuerydslRepositorySupport.java
@@ -15,155 +15,65 @@
  */
 package org.springframework.data.jpa.repository.support;
 
-import jakarta.annotation.PostConstruct;
-import org.jspecify.annotations.Nullable;
-
-import jakarta.persistence.EntityManager;
-
-import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.ResolvableType;
 import org.springframework.stereotype.Repository;
-import org.springframework.util.Assert;
 
-import com.querydsl.core.dml.DeleteClause;
-import com.querydsl.core.dml.UpdateClause;
-import com.querydsl.core.types.EntityPath;
 import com.querydsl.core.types.dsl.PathBuilder;
-import com.querydsl.core.types.dsl.PathBuilderFactory;
-import com.querydsl.jpa.JPQLQuery;
-import com.querydsl.jpa.impl.JPADeleteClause;
-import com.querydsl.jpa.impl.JPAUpdateClause;
 
 /**
  * Base class for implementing repositories using Querydsl library.
  *
  * @author Oliver Gierke
  * @author Mark Paluch
+ * @author Maxim Shabanov
  */
 @Repository
-public abstract class QuerydslRepositorySupport {
+public abstract non-sealed class QuerydslRepositorySupport<T> extends QuerydslRepositorySupportBase {
 
-	private final PathBuilder<?> builder;
+    /**
+     * Creates a new {@link QuerydslRepositorySupport} instance.
+     * <p>
+     * This constructor automatically detects the domain type {@code T} by resolving the generic parameter of the
+     * concrete subclass.
+     * 
+     * @throws IllegalArgumentException if the domain type {@code T} cannot be resolved from the generic signature of
+     *             the subclass.
+     */
+    public QuerydslRepositorySupport() {
+        super();
+    }
 
-	private @Nullable EntityManager entityManager;
-	private @Nullable Querydsl querydsl;
+    /**
+     * Creates a new {@link QuerydslRepositorySupport} instance for the given domain type.
+     *
+     * @param domainClass must not be {@literal null}.
+     */
+    public QuerydslRepositorySupport(Class<?> domainClass) {
+        super(domainClass);
+    }
 
-	/**
-	 * Creates a new {@link QuerydslRepositorySupport} instance for the given domain type.
-	 *
-	 * @param domainClass must not be {@literal null}.
-	 */
-	public QuerydslRepositorySupport(Class<?> domainClass) {
+    /**
+     * Returns a type-safe {@link PathBuilder} for the configured domain type {@code T}.
+     *
+     * @return the Querdsl {@link PathBuilder}.
+     */
+    @SuppressWarnings("unchecked")
+    @Override
+    protected PathBuilder<T> getBuilder() {
+        return (PathBuilder<T>) super.getBuilder();
+    }
 
-		Assert.notNull(domainClass, "Domain class must not be null");
-		this.builder = new PathBuilderFactory().create(domainClass);
-	}
+    @Override
+    Class<?> resolveDomainClass() {
 
-	/**
-	 * Setter to inject {@link EntityManager}.
-	 *
-	 * @param entityManager must not be {@literal null}.
-	 */
-	@Autowired
-	public void setEntityManager(EntityManager entityManager) {
+        Class<?> domainClass = ResolvableType.forClass(this.getClass()).as(QuerydslRepositorySupport.class)
+                .getGeneric(0).resolve();
 
-		Assert.notNull(entityManager, "EntityManager must not be null");
-		this.querydsl = new Querydsl(entityManager, builder);
-		this.entityManager = entityManager;
-	}
+        if (domainClass == null) {
+            throw new IllegalArgumentException(
+                    String.format("Could not resolve generic parameter for %s", this.getClass()));
+        }
 
-	/**
-	 * Callback to verify configuration. Used by containers.
-	 */
-	@PostConstruct
-	public void validate() {
-		Assert.notNull(entityManager, "EntityManager must not be null");
-		Assert.notNull(querydsl, "Querydsl must not be null");
-	}
-
-	/**
-	 * Returns the {@link EntityManager}.
-	 *
-	 * @return the entityManager
-	 */
-	protected @Nullable EntityManager getEntityManager() {
-		return entityManager;
-	}
-
-	/**
-	 * Returns a fresh {@link JPQLQuery}.
-	 *
-	 * @param paths must not be {@literal null}.
-	 * @return the Querydsl {@link JPQLQuery}.
-	 */
-	protected JPQLQuery<Object> from(EntityPath<?>... paths) {
-		return getRequiredQuerydsl().createQuery(paths);
-	}
-
-	/**
-	 * Returns a {@link JPQLQuery} for the given {@link EntityPath}.
-	 *
-	 * @param path must not be {@literal null}.
-	 * @return
-	 */
-	protected <T> JPQLQuery<T> from(EntityPath<T> path) {
-		return getRequiredQuerydsl().createQuery(path).select(path);
-	}
-
-	/**
-	 * Returns a fresh {@link DeleteClause}.
-	 *
-	 * @param path
-	 * @return the Querydsl {@link DeleteClause}.
-	 */
-	protected DeleteClause<JPADeleteClause> delete(EntityPath<?> path) {
-		return new JPADeleteClause(getRequiredEntityManager(), path);
-	}
-
-	/**
-	 * Returns a fresh {@link UpdateClause}.
-	 *
-	 * @param path
-	 * @return the Querydsl {@link UpdateClause}.
-	 */
-	protected UpdateClause<JPAUpdateClause> update(EntityPath<?> path) {
-		return new JPAUpdateClause(getRequiredEntityManager(), path);
-	}
-
-	/**
-	 * Returns a {@link PathBuilder} for the configured domain type.
-	 *
-	 * @param <T>
-	 * @return the Querdsl {@link PathBuilder}.
-	 */
-	@SuppressWarnings("unchecked")
-	protected <T> PathBuilder<T> getBuilder() {
-		return (PathBuilder<T>) builder;
-	}
-
-	/**
-	 * Returns the underlying Querydsl helper instance.
-	 *
-	 * @return
-	 */
-	protected @Nullable Querydsl getQuerydsl() {
-		return this.querydsl;
-	}
-
-	private Querydsl getRequiredQuerydsl() {
-
-		if (querydsl == null) {
-			throw new IllegalStateException("Querydsl is null");
-		}
-
-		return querydsl;
-	}
-
-	private EntityManager getRequiredEntityManager() {
-
-		if (entityManager == null) {
-			throw new IllegalStateException("EntityManager is null");
-		}
-
-		return entityManager;
-	}
+        return domainClass;
+    }
 }

--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/support/QuerydslRepositorySupportBase.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/support/QuerydslRepositorySupportBase.java
@@ -1,0 +1,178 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.jpa.repository.support;
+
+import jakarta.annotation.PostConstruct;
+import jakarta.persistence.EntityManager;
+
+import org.jspecify.annotations.Nullable;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.util.Assert;
+
+import com.querydsl.core.dml.DeleteClause;
+import com.querydsl.core.dml.UpdateClause;
+import com.querydsl.core.types.EntityPath;
+import com.querydsl.core.types.dsl.PathBuilder;
+import com.querydsl.core.types.dsl.PathBuilderFactory;
+import com.querydsl.jpa.JPQLQuery;
+import com.querydsl.jpa.impl.JPADeleteClause;
+import com.querydsl.jpa.impl.JPAUpdateClause;
+
+/**
+ * Base class for QuerydslRepositorySupport
+ *
+ * @author Oliver Gierke
+ * @author Mark Paluch
+ * @author Maxim Shabanov
+ */
+abstract sealed class QuerydslRepositorySupportBase permits QuerydslRepositorySupport {
+
+	private final PathBuilder<?> builder;
+
+	private @Nullable EntityManager entityManager;
+	private @Nullable Querydsl querydsl;
+
+	/**
+	 * Creates a new {@link QuerydslRepositorySupportBase} instance for the given domain type.
+	 *
+	 * @param domainClass must not be {@literal null}.
+	 */
+	protected QuerydslRepositorySupportBase(Class<?> domainClass) {
+		Assert.notNull(domainClass, "Domain class must not be null");
+		this.builder = new PathBuilderFactory().create(domainClass);
+	}
+
+	/**
+	 * Creates a new {@link QuerydslRepositorySupportBase}.
+	 * <p>
+	 * This constructor resolves the domain type at runtime by invoking {@link #resolveDomainClass()}.
+	 */
+	protected QuerydslRepositorySupportBase() {
+		Class<?> domainClass = resolveDomainClass();
+		this.builder = new PathBuilderFactory().create(domainClass);
+	}
+
+	/**
+	 * Setter to inject {@link EntityManager}.
+	 *
+	 * @param entityManager must not be {@literal null}.
+	 */
+	@Autowired
+	public void setEntityManager(EntityManager entityManager) {
+
+		Assert.notNull(entityManager, "EntityManager must not be null");
+		this.querydsl = new Querydsl(entityManager, builder);
+		this.entityManager = entityManager;
+	}
+
+	/**
+	 * Callback to verify configuration. Used by containers.
+	 */
+	@PostConstruct
+	public void validate() {
+		Assert.notNull(entityManager, "EntityManager must not be null");
+		Assert.notNull(querydsl, "Querydsl must not be null");
+	}
+
+	/**
+	 * Returns the {@link EntityManager}.
+	 *
+	 * @return the entityManager
+	 */
+	protected @Nullable EntityManager getEntityManager() {
+		return entityManager;
+	}
+
+	/**
+	 * Returns a fresh {@link JPQLQuery}.
+	 *
+	 * @param paths must not be {@literal null}.
+	 * @return the Querydsl {@link JPQLQuery}.
+	 */
+	protected JPQLQuery<Object> from(EntityPath<?>... paths) {
+		return getRequiredQuerydsl().createQuery(paths);
+	}
+
+	/**
+	 * Returns a {@link JPQLQuery} for the given {@link EntityPath}.
+	 *
+	 * @param path must not be {@literal null}.
+	 * @return
+	 */
+	protected <E> JPQLQuery<E> from(EntityPath<E> path) {
+		return getRequiredQuerydsl().createQuery(path).select(path);
+	}
+
+	/**
+	 * Returns a fresh {@link DeleteClause}.
+	 *
+	 * @param path
+	 * @return the Querydsl {@link DeleteClause}.
+	 */
+	protected DeleteClause<JPADeleteClause> delete(EntityPath<?> path) {
+		return new JPADeleteClause(getRequiredEntityManager(), path);
+	}
+
+	/**
+	 * Returns a fresh {@link UpdateClause}.
+	 *
+	 * @param path
+	 * @return the Querydsl {@link UpdateClause}.
+	 */
+	protected UpdateClause<JPAUpdateClause> update(EntityPath<?> path) {
+		return new JPAUpdateClause(getRequiredEntityManager(), path);
+	}
+
+	/**
+	 * Returns a {@link PathBuilder} for the configured domain type.
+	 *
+	 * @param <T>
+	 * @return the Querdsl {@link PathBuilder}.
+	 */
+	@SuppressWarnings("unchecked")
+	protected <T> PathBuilder<T> getBuilder() {
+		return (PathBuilder<T>) builder;
+	}
+
+	/**
+	 * Returns the underlying Querydsl helper instance.
+	 *
+	 * @return
+	 */
+	protected @Nullable Querydsl getQuerydsl() {
+		return this.querydsl;
+	}
+
+	abstract Class<?> resolveDomainClass();
+
+	private Querydsl getRequiredQuerydsl() {
+
+		if (querydsl == null) {
+			throw new IllegalStateException("Querydsl is null");
+		}
+
+		return querydsl;
+	}
+
+	private EntityManager getRequiredEntityManager() {
+
+		if (entityManager == null) {
+			throw new IllegalStateException("EntityManager is null");
+		}
+
+		return entityManager;
+	}
+}

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/support/QuerydslRepositorySupportIntegrationTests.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/support/QuerydslRepositorySupportIntegrationTests.java
@@ -41,6 +41,7 @@ import org.springframework.transaction.annotation.Transactional;
  * @author Oliver Gierke
  * @author Thomas Darimont
  * @author Mark Paluch
+ * @author Maxim Shabanov
  */
 @Transactional
 @ContextConfiguration
@@ -72,6 +73,11 @@ class QuerydslRepositorySupportIntegrationTests {
 		}
 
 		@Bean
+		public MemberRepositoryUsingQueryDsl memberRepo() {
+			return new MemberRepositoryUsingQueryDsl();
+		}
+
+		@Bean
 		public EntityManagerContainer entityManagerContainer() {
 			return new EntityManagerContainer();
 		}
@@ -89,6 +95,7 @@ class QuerydslRepositorySupportIntegrationTests {
 	@Autowired org.springframework.data.jpa.repository.support.QuerydslRepositorySupportTests.UserRepository repository;
 	@Autowired CustomRepoUsingQueryDsl querydslCustom;
 	@Autowired ReconfiguringUserRepositoryImpl reconfiguredRepo;
+	@Autowired MemberRepositoryUsingQueryDsl memberRepository;
 
 	@PersistenceContext(unitName = "querydsl") EntityManager em;
 
@@ -110,6 +117,14 @@ class QuerydslRepositorySupportIntegrationTests {
 
 		assertThat(querydslCustom).isNotNull();
 		assertThat(querydslCustom.getEntityManager().getEntityManagerFactory()) //
+				.isEqualTo(em.getEntityManagerFactory());
+	}
+
+	@Test // GH-4300
+	void createsRepositoryWithMemberRepositoryUsingQueryDsl() {
+
+		assertThat(memberRepository).isNotNull();
+		assertThat(memberRepository.getEntityManager().getEntityManagerFactory()) //
 				.isEqualTo(em.getEntityManagerFactory());
 	}
 
@@ -136,5 +151,9 @@ class QuerydslRepositorySupportIntegrationTests {
 		public CustomRepoUsingQueryDsl() {
 			super(User.class);
 		}
+	}
+
+	static class MemberRepositoryUsingQueryDsl extends QuerydslRepositorySupport<User> {
+
 	}
 }


### PR DESCRIPTION
Closes #4300

This PR aligns `QuerydslRepositorySupport` with the rest of Spring Data by inferring the domain type from generics, removing the need for manual constructor arguments.
The existing constructor is kept to ensure full backward compatibility.

### Changes
- Extracted common logic into a new `QuerydslRepositorySupportBase` class.
- Made `QuerydslRepositorySupport<T>` generic.
- `getBuilder()` now returns a properly typed `PathBuilder<T>` instead of `PathBuilder<?>`.
- Added an integration test to verify that a repository extending `QuerydslRepositorySupport<User>` (without an explicit constructor) correctly resolves the domain type and initializes the `EntityManager`.