### PR TITLE
Resolve is-prefixed Boolean property paths against the JPA metamodel

### DIFF
--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/ExpressionFactorySupport.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/ExpressionFactorySupport.java
@@ -28,8 +28,11 @@ import jakarta.persistence.metamodel.SingularAttribute;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.AnnotatedElement;
 import java.lang.reflect.Member;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import org.jspecify.annotations.Nullable;
@@ -42,6 +45,7 @@ import org.springframework.util.StringUtils;
  * Support class to build expression factories for JPA query creation.
  *
  * @author Mark Paluch
+ * @author Seongho Eom
  * @since 4.0
  */
 class ExpressionFactorySupport {
@@ -168,6 +172,79 @@ class ExpressionFactorySupport {
 		}
 
 		return singularAttribute.getType() instanceof ManagedType<?> managedType ? managedType : null;
+	}
+
+	/**
+	 * Resolve the {@link Attribute} for a parsed {@link PropertyPath} segment.
+	 * <p>
+	 * Resolves {@code segment} against {@code managedType} first. If no such attribute exists and {@code segment} is a
+	 * Boolean {@code is}-prefixed property name, resolves the attribute that property access derives from the very same
+	 * getter: {@code isActive} is mapped onto the {@code active} attribute if that attribute is read through
+	 * {@code isActive()}. Names are not treated as aliases otherwise.
+	 *
+	 * @param managedType the type declaring the attribute, can be {@literal null}.
+	 * @param segment the parsed property path segment.
+	 * @return the resolved attribute or {@literal null} if the segment cannot be resolved.
+	 */
+	static @Nullable Attribute<?, ?> findAttribute(@Nullable ManagedType<?> managedType, String segment) {
+
+		if (managedType == null) {
+			return null;
+		}
+
+		try {
+			return managedType.getAttribute(segment);
+		} catch (IllegalArgumentException ex) {
+			// ManagedType may be erased for some vendor if the attribute is declared as generic, or the attribute is
+			// named after the JavaBeans property of a Boolean is-getter.
+		}
+
+		if (segment.length() < 3 || !segment.startsWith("is") || !Character.isUpperCase(segment.charAt(2))) {
+			return null;
+		}
+
+		try {
+
+			Attribute<?, ?> attribute = managedType.getAttribute(StringUtils.uncapitalizeAsProperty(segment.substring(2)));
+			return isReadThrough(attribute, segment) ? attribute : null;
+		} catch (IllegalArgumentException ex) {
+			return null;
+		}
+	}
+
+	/**
+	 * @return {@literal true} if {@code attribute} is read through a zero-argument {@code boolean} or {@code Boolean}
+	 *         getter named {@code getterName}.
+	 */
+	private static boolean isReadThrough(Attribute<?, ?> attribute, String getterName) {
+
+		return attribute.getJavaMember() instanceof Method method && method.getName().equals(getterName)
+				&& method.getParameterCount() == 0
+				&& (method.getReturnType() == boolean.class || method.getReturnType() == Boolean.class);
+	}
+
+	/**
+	 * Resolve every segment of {@code path} into its JPA metamodel attribute name, starting at {@code model}. Segments
+	 * that cannot be resolved are retained as parsed.
+	 *
+	 * @param model the model declaring the first segment, can be {@literal null}.
+	 * @param path the property path to resolve.
+	 * @return the resolved attribute names, one per path segment.
+	 */
+	static List<String> toAttributeNames(@Nullable Object model, PropertyPath path) {
+
+		List<String> names = new ArrayList<>();
+		ManagedType<?> managedType = getManagedTypeForModel(model);
+
+		for (PropertyPath current = path; current != null; current = current.next()) {
+
+			Attribute<?, ?> attribute = findAttribute(managedType, current.getSegment());
+
+			names.add(attribute != null ? attribute.getName() : current.getSegment());
+			managedType = attribute != null ? getManagedTypeForModel(attribute) : null;
+		}
+
+		return names;
 	}
 
 	public interface ModelPathResolver {

--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/JpqlQueryBuilder.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/JpqlQueryBuilder.java
@@ -46,6 +46,7 @@ import org.springframework.util.StringUtils;
  * @author Mark Paluch
  * @author Choi Wang Gyu
  * @author Jeongwon Ryu
+ * @author Seongho Eom
  * @since 4.0
  */
 @SuppressWarnings("JavadocDeclaration")
@@ -1634,9 +1635,15 @@ public final class JpqlQueryBuilder {
 	 * @param path
 	 * @param origin
 	 * @param onTheJoin whether the path should target the join itself instead of matching {@link PropertyPath}.
+	 * @param attributePath the path rendered as JPA metamodel attribute names, or {@literal null} to render the parsed
+	 *          {@link PropertyPath#toDotPath() property path}.
 	 */
-	record PathAndOrigin(PropertyPath path, Origin origin,
-			boolean onTheJoin) implements PathExpression {
+	record PathAndOrigin(PropertyPath path, Origin origin, boolean onTheJoin,
+			@Nullable String attributePath) implements PathExpression {
+
+		PathAndOrigin(PropertyPath path, Origin origin, boolean onTheJoin) {
+			this(path, origin, onTheJoin, null);
+		}
 
 		@Override
 		public PropertyPath getPropertyPath() {
@@ -1647,7 +1654,7 @@ public final class JpqlQueryBuilder {
 		public String render(RenderContext context) {
 
 			if (path().hasNext() || !onTheJoin()) {
-				return context.prefixWithAlias(origin(), path().toDotPath());
+				return context.prefixWithAlias(origin(), attributePath() != null ? attributePath() : path().toDotPath());
 			} else {
 				return context.getAlias(origin());
 			}
@@ -1656,7 +1663,7 @@ public final class JpqlQueryBuilder {
 		public Expression parent() {
 
 			if (origin instanceof Join join) {
-				return new PathAndOrigin(path(), join.source(), false);
+				return new PathAndOrigin(path(), join.source(), false, attributePath());
 			}
 
 			throw new IllegalStateException("Cannot obtain parent expression for non-join origin: " + origin);

--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/JpqlUtils.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/JpqlUtils.java
@@ -32,6 +32,7 @@ import org.springframework.util.Assert;
  *
  * @author Mark Paluch
  * @author Christoph Strobl
+ * @author Seongho Eom
  */
 class JpqlUtils {
 
@@ -76,7 +77,8 @@ class JpqlUtils {
 
 			// if it does not require an outer join and is a leaf, simply get the segment
 			if (!requiresOuterJoin && (isLeafProperty || isRelationshipId)) {
-				return new JpqlQueryBuilder.PathAndOrigin(property, source, false);
+				return new JpqlQueryBuilder.PathAndOrigin(property, source, false,
+						String.join(".", toAttributeNames(from, property)));
 			}
 
 			// get or create the join
@@ -110,19 +112,16 @@ class JpqlUtils {
 				@Nullable ManagedType<?> managedType, @Nullable Bindable<?> fallback) {
 
 			String segment = path.getSegment();
-			if (managedType != null) {
-				try {
-					return managedType.getAttribute(segment);
-				} catch (IllegalArgumentException ex) {
-					// ManagedType may be erased for some vendor if the attribute is declared as generic
-				}
+			Attribute<?, ?> attribute = findAttribute(managedType, segment);
+			if (attribute != null) {
+				return attribute;
 			}
 
 			if (metamodel != null && fallback != null) {
 
 				Class<?> fallbackType = fallback.getBindableJavaType();
 				try {
-					return metamodel.managedType(fallbackType).getAttribute(segment);
+					return findAttribute(metamodel.managedType(fallbackType), segment);
 				} catch (IllegalArgumentException e) {
 					// nothing to do here
 				}

--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/QueryUtils.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/QueryUtils.java
@@ -91,6 +91,7 @@ import org.springframework.util.StringUtils;
  * @author Alim Naizabek
  * @author Jakub Soltys
  * @author Young-ho Kim
+ * @author Seongho Eom
  */
 public abstract class QueryUtils {
 
@@ -847,12 +848,11 @@ public abstract class QueryUtils {
 
 			// if it does not require an outer join and is a leaf or relationship id, simply get rest of the segment path
 			if (!requiresOuterJoin && (isLeafProperty || isRelationshipId)) {
-				Path<T> trailingPath = from.get(segment);
-				while (property.hasNext()) {
-					property = property.next();
-					trailingPath = trailingPath.get(property.getSegment());
+				Path<?> trailingPath = from;
+				for (String attributeName : toAttributeNames(from.getModel(), property)) {
+					trailingPath = trailingPath.get(attributeName);
 				}
-				return trailingPath;
+				return (Expression<T>) trailingPath;
 			}
 
 			// get or create the join
@@ -993,12 +993,9 @@ public abstract class QueryUtils {
 					Supplier<Path<?>> fallback) {
 
 				String segment = path.getSegment();
-				if (managedType != null) {
-					try {
-						return (Bindable<?>) managedType.getAttribute(segment);
-					} catch (IllegalArgumentException ex) {
-						// ManagedType may be erased for some vendor if the attribute is declared as generic
-					}
+				Attribute<?, ?> attribute = findAttribute(managedType, segment);
+				if (attribute != null) {
+					return (Bindable<?>) attribute;
 				}
 
 				return (Bindable<?>) fallback.get().get(segment);

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/JpaKeysetScrollQueryCreatorTests.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/JpaKeysetScrollQueryCreatorTests.java
@@ -45,6 +45,7 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
  * Unit tests for {@link JpaKeysetScrollQueryCreator}.
  *
  * @author Mark Paluch
+ * @author Seongho Eom
  */
 @ExtendWith(SpringExtension.class)
 @ContextConfiguration("classpath:hibernate-infrastructure.xml")
@@ -97,6 +98,31 @@ class JpaKeysetScrollQueryCreatorTests {
 				""");
 	}
 
+	@Test // GH-4303
+	void shouldResolveJpaMetamodelAttributeNameForKeysetScrolling() throws Exception {
+
+		Map<String, Object> keys = Map.of("id", 1L, "isActive", false);
+		KeysetScrollPosition position = ScrollPosition.of(keys, ScrollPosition.Direction.FORWARD);
+		Method method = IsActiveRepo.class.getMethod("findTop3ByOrderByIsActiveAsc", ScrollPosition.class);
+
+		PersistenceProvider provider = PersistenceProvider.fromEntityManager(entityManager);
+		JpaQueryMethod queryMethod = new JpaQueryMethod(method,
+				AbstractRepositoryMetadata.getMetadata(IsActiveRepo.class), new SpelAwareProxyProjectionFactory(), provider);
+		PartTree tree = new PartTree(method.getName(), PartTreeJpaQueryIntegrationTests.IsActivePropertyAccess.class);
+		ParameterMetadataProvider metadataProvider = new ParameterMetadataProvider(queryMethod.getParameters(),
+				EscapeCharacter.DEFAULT, JpqlQueryTemplates.UPPER);
+		JpaMetamodelEntityInformation<PartTreeJpaQueryIntegrationTests.IsActivePropertyAccess, Long> entityInformation = new JpaMetamodelEntityInformation<>(
+				PartTreeJpaQueryIntegrationTests.IsActivePropertyAccess.class, entityManager.getMetamodel(),
+				entityManager.getEntityManagerFactory().getPersistenceUnitUtil());
+		JpaKeysetScrollQueryCreator creator = new JpaKeysetScrollQueryCreator(tree,
+				queryMethod.getResultProcessor().getReturnedType(), metadataProvider, JpqlQueryTemplates.UPPER,
+				entityInformation, position, entityManager);
+
+		String query = creator.createQuery();
+
+		assertThat(query).contains(".active", "?1", "?2").doesNotContain(".isActive");
+	}
+
 	private JpaKeysetScrollQueryCreator getJpaKeysetScrollQueryCreator(KeysetScrollPosition position, Method method) {
 
 		PersistenceProvider provider = PersistenceProvider.fromEntityManager(entityManager);
@@ -118,6 +144,12 @@ class JpaKeysetScrollQueryCreatorTests {
 		Window<User> findTop3ByFirstnameStartingWithOrderByFirstnameAscEmailAddressAsc(String firstname,
 				ScrollPosition position);
 
+	}
+
+	interface IsActiveRepo extends Repository<PartTreeJpaQueryIntegrationTests.IsActivePropertyAccess, Long> {
+
+		Window<PartTreeJpaQueryIntegrationTests.IsActivePropertyAccess> findTop3ByOrderByIsActiveAsc(
+				ScrollPosition position);
 	}
 
 }

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/KeysetScrollSpecificationUnitTests.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/KeysetScrollSpecificationUnitTests.java
@@ -19,14 +19,21 @@ import static org.assertj.core.api.Assertions.*;
 
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
+import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.criteria.CriteriaQuery;
+import jakarta.persistence.criteria.Root;
+
+import java.util.Map;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.data.domain.KeysetScrollPosition;
 import org.springframework.data.domain.ScrollPosition;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.domain.Sort.Order;
 import org.springframework.data.jpa.domain.sample.SampleWithIdClass;
 import org.springframework.data.jpa.domain.sample.User;
+import org.springframework.data.jpa.provider.HibernateUtils;
 import org.springframework.data.jpa.repository.support.JpaMetamodelEntityInformation;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
@@ -36,6 +43,7 @@ import org.springframework.transaction.annotation.Transactional;
  * Unit tests for {@link KeysetScrollSpecification}.
  *
  * @author Mark Paluch
+ * @author Seongho Eom
  */
 @ExtendWith(SpringExtension.class)
 @ContextConfiguration("classpath:hibernate-infrastructure.xml")
@@ -72,6 +80,29 @@ class KeysetScrollSpecificationUnitTests {
 						em.getEntityManagerFactory().getPersistenceUnitUtil()));
 
 		assertThat(sort).extracting(Order::getProperty).containsExactly("id", "firstname");
+	}
+
+	@Test // GH-4303
+	void shouldResolveJpaMetamodelAttributeNameForKeysetPredicate() {
+
+		Map<String, Object> keys = Map.of("id", 1L, "isActive", false);
+		KeysetScrollPosition position = ScrollPosition.of(keys, ScrollPosition.Direction.FORWARD);
+		JpaMetamodelEntityInformation<PartTreeJpaQueryIntegrationTests.IsActivePropertyAccess, Long> entityInformation = new JpaMetamodelEntityInformation<>(
+				PartTreeJpaQueryIntegrationTests.IsActivePropertyAccess.class, em.getMetamodel(),
+				em.getEntityManagerFactory().getPersistenceUnitUtil());
+		KeysetScrollSpecification<PartTreeJpaQueryIntegrationTests.IsActivePropertyAccess> specification = new KeysetScrollSpecification<>(
+				position, Sort.by("isActive"), entityInformation);
+		CriteriaBuilder builder = em.getCriteriaBuilder();
+		CriteriaQuery<PartTreeJpaQueryIntegrationTests.IsActivePropertyAccess> query = builder
+				.createQuery(PartTreeJpaQueryIntegrationTests.IsActivePropertyAccess.class);
+		Root<PartTreeJpaQueryIntegrationTests.IsActivePropertyAccess> root = query
+				.from(PartTreeJpaQueryIntegrationTests.IsActivePropertyAccess.class);
+
+		query.where(specification.createPredicate(root, builder));
+
+		assertThat(HibernateUtils.getHibernateQuery(em.createQuery(query).unwrap(org.hibernate.query.Query.class)))
+				.contains(".active")
+				.doesNotContain(".isActive");
 	}
 
 }

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/PartTreeJpaQueryIntegrationTests.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/PartTreeJpaQueryIntegrationTests.java
@@ -17,7 +17,12 @@ package org.springframework.data.jpa.repository.query;
 
 import static org.assertj.core.api.Assertions.*;
 
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import jakarta.persistence.Embedded;
+import jakarta.persistence.Entity;
 import jakarta.persistence.EntityManager;
+import jakarta.persistence.Id;
 import jakarta.persistence.PersistenceContext;
 import jakarta.persistence.Query;
 import jakarta.persistence.Tuple;
@@ -62,6 +67,7 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
  * @author Jens Schauder
  * @author Krzysztof Krason
  * @author Christoph Strobl
+ * @author Seongho Eom
  */
 @ExtendWith(SpringExtension.class)
 @ContextConfiguration("classpath:hibernate-infrastructure.xml")
@@ -260,6 +266,88 @@ class PartTreeJpaQueryIntegrationTests {
 		assertThat(total).isInstanceOf(Number.class).isNotInstanceOf(Tuple.class);
 	}
 
+	@Test // GH-4303
+	void resolvesPropertyPathAgainstJpaMetamodelAttributeName() throws Exception {
+
+		JpaQueryMethod queryMethod = getQueryMethod(IsActiveRepository.class, "findByIsActiveTrue");
+		PartTreeJpaQuery jpaQuery = new PartTreeJpaQuery(queryMethod, entityManager);
+
+		Query query = jpaQuery.createQuery(getAccessor(queryMethod, new Object[0]));
+
+		assertThat(HibernateUtils.getHibernateQuery(query.unwrap(HIBERNATE_NATIVE_QUERY))).contains(".active = TRUE");
+
+		queryMethod = getQueryMethod(IsActiveRepository.class, "findByIsEnabledTrue");
+		jpaQuery = new PartTreeJpaQuery(queryMethod, entityManager);
+
+		query = jpaQuery.createQuery(getAccessor(queryMethod, new Object[0]));
+
+		assertThat(HibernateUtils.getHibernateQuery(query.unwrap(HIBERNATE_NATIVE_QUERY))).contains(".enabled = TRUE");
+
+		queryMethod = getQueryMethod(IsActiveRepository.class, "findByIsVerifiedTrue");
+		jpaQuery = new PartTreeJpaQuery(queryMethod, entityManager);
+
+		query = jpaQuery.createQuery(getAccessor(queryMethod, new Object[0]));
+
+		assertThat(HibernateUtils.getHibernateQuery(query.unwrap(HIBERNATE_NATIVE_QUERY))).contains(".verified = TRUE");
+	}
+
+	@Test // GH-4303
+	void doesNotResolveArbitraryAccessorNameAsJpaAttribute() throws Exception {
+
+		JpaQueryMethod queryMethod = getQueryMethod(GetFooRepository.class, "findByGetFoo", String.class);
+		PartTreeJpaQuery jpaQuery = new PartTreeJpaQuery(queryMethod, entityManager);
+
+		assertThatThrownBy(() -> jpaQuery.createQuery(getAccessor(queryMethod, new Object[] { "foo" })))
+				.hasMessageContaining("getFoo");
+	}
+
+	@Test // GH-4303
+	void prefersDirectJpaAttributeName() throws Exception {
+
+		JpaQueryMethod queryMethod = getQueryMethod(IsActiveFieldAccessRepository.class, "findByIsActiveTrue");
+		PartTreeJpaQuery jpaQuery = new PartTreeJpaQuery(queryMethod, entityManager);
+
+		Query query = jpaQuery.createQuery(getAccessor(queryMethod, new Object[0]));
+
+		assertThat(HibernateUtils.getHibernateQuery(query.unwrap(HIBERNATE_NATIVE_QUERY))).contains(".isActive = TRUE");
+	}
+
+	@Test // GH-4303
+	void resolvesNestedPropertyPathAgainstJpaMetamodelAttributeName() throws Exception {
+
+		JpaQueryMethod queryMethod = getQueryMethod(NestedIsActiveRepository.class, "findByDetailsIsActiveTrue");
+		PartTreeJpaQuery jpaQuery = new PartTreeJpaQuery(queryMethod, entityManager);
+
+		Query query = jpaQuery.createQuery(getAccessor(queryMethod, new Object[0]));
+
+		assertThat(HibernateUtils.getHibernateQuery(query.unwrap(HIBERNATE_NATIVE_QUERY)))
+				.contains("JOIN", ".details", ".active = TRUE").doesNotContain(".isActive");
+	}
+
+	@Test // GH-4303
+	void resolvesJpaMetamodelAttributeNameForOrderingAndCountOrExistsProjection() throws Exception {
+
+		JpaQueryMethod queryMethod = getQueryMethod(IsActiveRepository.class, "findByOrderByIsActiveDesc");
+		PartTreeJpaQuery jpaQuery = new PartTreeJpaQuery(queryMethod, entityManager);
+
+		Query query = jpaQuery.createQuery(getAccessor(queryMethod, new Object[0]));
+		assertThat(HibernateUtils.getHibernateQuery(query.unwrap(HIBERNATE_NATIVE_QUERY)))
+				.contains("ORDER BY").containsIgnoringCase(".active DESC").doesNotContain(".isActive");
+
+		queryMethod = getQueryMethod(IsActiveRepository.class, "existsByIsActiveTrue");
+		jpaQuery = new PartTreeJpaQuery(queryMethod, entityManager);
+
+		query = jpaQuery.createQuery(getAccessor(queryMethod, new Object[0]));
+		assertThat(HibernateUtils.getHibernateQuery(query.unwrap(HIBERNATE_NATIVE_QUERY))).contains(".active = TRUE");
+
+		queryMethod = getQueryMethod(IsActiveRepository.class, "countByIsActiveTrue");
+		jpaQuery = new PartTreeJpaQuery(queryMethod, entityManager);
+
+		query = jpaQuery.createQuery(getAccessor(queryMethod, new Object[0]));
+		assertThat(HibernateUtils.getHibernateQuery(query.unwrap(HIBERNATE_NATIVE_QUERY)))
+				.contains("COUNT", ".active = TRUE").doesNotContain(".isActive");
+	}
+
 	private void testIgnoreCase(String methodName, Object... values) throws Exception {
 
 		Class<?>[] parameterTypes = new Class[values.length];
@@ -351,6 +439,150 @@ class PartTreeJpaQueryIntegrationTests {
 
 	interface ProjectionPagingRepository extends Repository<User, Integer> {
 		Page<UserNameProjection> findByFirstname(String firstname, Pageable pageable);
+	}
+
+	interface IsActiveRepository extends Repository<IsActivePropertyAccess, Long> {
+		List<IsActivePropertyAccess> findByIsActiveTrue();
+
+		List<IsActivePropertyAccess> findByIsEnabledTrue();
+
+		List<IsActivePropertyAccess> findByIsVerifiedTrue();
+
+		List<IsActivePropertyAccess> findByOrderByIsActiveDesc();
+
+		boolean existsByIsActiveTrue();
+
+		long countByIsActiveTrue();
+	}
+
+	interface IsActiveFieldAccessRepository extends Repository<IsActiveFieldAccess, Long> {
+		List<IsActiveFieldAccess> findByIsActiveTrue();
+	}
+
+	interface NestedIsActiveRepository extends Repository<NestedIsActivePropertyAccess, Long> {
+		List<NestedIsActivePropertyAccess> findByDetailsIsActiveTrue();
+	}
+
+	interface GetFooRepository extends Repository<GetFooPropertyAccess, Long> {
+		List<GetFooPropertyAccess> findByGetFoo(String foo);
+	}
+
+	@Entity(name = "IsActivePropertyAccess")
+	static class IsActivePropertyAccess {
+
+		private Long id;
+		private boolean isActive;
+		private boolean isEnabled;
+		private Boolean isVerified;
+
+		@Id
+		public Long getId() {
+			return id;
+		}
+
+		public void setId(Long id) {
+			this.id = id;
+		}
+
+		@Column(nullable = false)
+		public boolean isActive() {
+			return isActive;
+		}
+
+		public void setActive(boolean active) {
+			isActive = active;
+		}
+
+		@Column(nullable = false)
+		public boolean isEnabled() {
+			return isEnabled;
+		}
+
+		public void setEnabled(boolean enabled) {
+			isEnabled = enabled;
+		}
+
+		@Column
+		public Boolean isVerified() {
+			return isVerified;
+		}
+
+		public void setVerified(Boolean verified) {
+			isVerified = verified;
+		}
+	}
+
+	@Entity(name = "GetFooPropertyAccess")
+	static class GetFooPropertyAccess {
+
+		private Long id;
+		private String getFoo;
+
+		@Id
+		public Long getId() {
+			return id;
+		}
+
+		public void setId(Long id) {
+			this.id = id;
+		}
+
+		@Column
+		public String getFoo() {
+			return getFoo;
+		}
+
+		public void setFoo(String foo) {
+			getFoo = foo;
+		}
+	}
+
+	@Entity(name = "IsActiveFieldAccess")
+	static class IsActiveFieldAccess {
+
+		@Id Long id;
+
+		@Column boolean isActive;
+	}
+
+	@Entity(name = "NestedIsActivePropertyAccess")
+	static class NestedIsActivePropertyAccess {
+
+		private Long id;
+		private ActiveDetails details;
+
+		@Id
+		public Long getId() {
+			return id;
+		}
+
+		public void setId(Long id) {
+			this.id = id;
+		}
+
+		@Embedded
+		public ActiveDetails getDetails() {
+			return details;
+		}
+
+		public void setDetails(ActiveDetails details) {
+			this.details = details;
+		}
+	}
+
+	@Embeddable
+	static class ActiveDetails {
+
+		private boolean isActive;
+
+		@Column(nullable = false)
+		public boolean isActive() {
+			return isActive;
+		}
+
+		public void setActive(boolean active) {
+			isActive = active;
+		}
 	}
 
 }

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/QueryUtilsIntegrationTests.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/QueryUtilsIntegrationTests.java
@@ -35,6 +35,7 @@ import jakarta.persistence.criteria.JoinType;
 import jakarta.persistence.criteria.Nulls;
 import jakarta.persistence.criteria.Path;
 import jakarta.persistence.criteria.Root;
+import jakarta.persistence.metamodel.Attribute;
 import jakarta.persistence.spi.PersistenceProvider;
 import jakarta.persistence.spi.PersistenceProviderResolver;
 import jakarta.persistence.spi.PersistenceProviderResolverHolder;
@@ -76,12 +77,63 @@ import org.springframework.transaction.annotation.Transactional;
  * @author Diego Krupitza
  * @author Krzysztof Krason
  * @author Jakub Soltys
+ * @author Seongho Eom
  */
 @ExtendWith(SpringExtension.class)
 @ContextConfiguration("classpath:hibernate-infrastructure.xml")
 class QueryUtilsIntegrationTests {
 
 	@PersistenceContext EntityManager em;
+
+	@Test // GH-4303
+	void resolvesPropertyPathAgainstJpaMetamodelAttributeName() {
+
+		CriteriaBuilder builder = em.getCriteriaBuilder();
+		CriteriaQuery<PartTreeJpaQueryIntegrationTests.IsActivePropertyAccess> query = builder
+				.createQuery(PartTreeJpaQueryIntegrationTests.IsActivePropertyAccess.class);
+		Root<PartTreeJpaQueryIntegrationTests.IsActivePropertyAccess> from = query
+				.from(PartTreeJpaQueryIntegrationTests.IsActivePropertyAccess.class);
+
+		Path<?> expression = (Path<?>) QueryUtils.toExpressionRecursively(from,
+				PropertyPath.from("isActive", PartTreeJpaQueryIntegrationTests.IsActivePropertyAccess.class));
+
+		assertThat(expression.getModel()).isInstanceOf(Attribute.class);
+		assertThat(((Attribute<?, ?>) expression.getModel()).getName()).isEqualTo("active");
+
+		expression = (Path<?>) QueryUtils.toExpressionRecursively(from,
+				PropertyPath.from("isVerified", PartTreeJpaQueryIntegrationTests.IsActivePropertyAccess.class));
+
+		assertThat(expression.getModel()).isInstanceOf(Attribute.class);
+		assertThat(((Attribute<?, ?>) expression.getModel()).getName()).isEqualTo("verified");
+	}
+
+	@Test // GH-4303
+	void prefersDirectJpaAttributeAndResolvesNestedPropertyPath() {
+
+		CriteriaBuilder builder = em.getCriteriaBuilder();
+		CriteriaQuery<PartTreeJpaQueryIntegrationTests.IsActiveFieldAccess> fieldAccessQuery = builder
+				.createQuery(PartTreeJpaQueryIntegrationTests.IsActiveFieldAccess.class);
+		Root<PartTreeJpaQueryIntegrationTests.IsActiveFieldAccess> fieldAccessRoot = fieldAccessQuery
+				.from(PartTreeJpaQueryIntegrationTests.IsActiveFieldAccess.class);
+
+		Path<?> expression = (Path<?>) QueryUtils.toExpressionRecursively(fieldAccessRoot,
+				PropertyPath.from("isActive", PartTreeJpaQueryIntegrationTests.IsActiveFieldAccess.class));
+
+		assertThat(expression.getModel()).isInstanceOf(Attribute.class);
+		assertThat(((Attribute<?, ?>) expression.getModel()).getName()).isEqualTo("isActive");
+
+		CriteriaQuery<PartTreeJpaQueryIntegrationTests.NestedIsActivePropertyAccess> nestedQuery = builder
+				.createQuery(PartTreeJpaQueryIntegrationTests.NestedIsActivePropertyAccess.class);
+		Root<PartTreeJpaQueryIntegrationTests.NestedIsActivePropertyAccess> nestedRoot = nestedQuery
+				.from(PartTreeJpaQueryIntegrationTests.NestedIsActivePropertyAccess.class);
+
+		expression = (Path<?>) QueryUtils.toExpressionRecursively(nestedRoot,
+				PropertyPath.from("details.isActive",
+						PartTreeJpaQueryIntegrationTests.NestedIsActivePropertyAccess.class));
+
+		assertThat(expression.getModel()).isInstanceOf(Attribute.class);
+		assertThat(((Attribute<?, ?>) expression.getModel()).getName()).isEqualTo("active");
+	}
 
 	@Test // DATAJPA-403
 	void reusesExistingJoinForExpression() {

--- a/spring-data-jpa/src/test/resources/META-INF/persistence.xml
+++ b/spring-data-jpa/src/test/resources/META-INF/persistence.xml
@@ -67,6 +67,11 @@
 		<class>org.springframework.data.jpa.repository.support.JpaMetamodelEntityInformationIntegrationTests$EntityWithNestedIdClass</class>
 		<class>org.springframework.data.jpa.repository.support.JpaMetamodelEntityInformationIntegrationTests$EntityWithIdClass</class>
 		<class>org.springframework.data.jpa.repository.support.JpaMetamodelEntityInformationIntegrationTests$EntityWithPrivateIdGetter</class>
+		<class>org.springframework.data.jpa.repository.query.PartTreeJpaQueryIntegrationTests$IsActivePropertyAccess</class>
+		<class>org.springframework.data.jpa.repository.query.PartTreeJpaQueryIntegrationTests$GetFooPropertyAccess</class>
+		<class>org.springframework.data.jpa.repository.query.PartTreeJpaQueryIntegrationTests$IsActiveFieldAccess</class>
+		<class>org.springframework.data.jpa.repository.query.PartTreeJpaQueryIntegrationTests$NestedIsActivePropertyAccess</class>
+		<class>org.springframework.data.jpa.repository.query.PartTreeJpaQueryIntegrationTests$ActiveDetails</class>
 		<class>org.springframework.data.jpa.domain.sample.Trade</class>
 		<class>org.springframework.data.jpa.domain.sample.TradeOrder</class>
 		<class>org.springframework.data.jpa.domain.sample.TradeItem</class>

--- a/src/main/antora/modules/ROOT/pages/jpa/query-methods.adoc
+++ b/src/main/antora/modules/ROOT/pages/jpa/query-methods.adoc
@@ -35,6 +35,10 @@ public interface UserRepository extends Repository<User, Long> {
 We create a query using JPQL  translating into the following query: `select u from User u where u.emailAddress = ?1 and u.lastname = ?2`. Spring Data JPA does a property check and traverses nested properties, as described in xref:repositories/query-methods-details.adoc#repositories.query-methods.query-property-expressions[Property Expressions].
 ====
 
+For property-access entities, Spring Data JPA can reconcile an `is`-prefixed Boolean property path with the attribute name derived from its JPA getter.
+This allows a Boolean domain property named `isActive`, backed by an `isActive()` accessor and exposed by JPA as the `active` attribute, to be used in a query method such as `findByIsActiveTrue()`.
+The same rule applies to Kotlin and Java domain types and is limited to `boolean` or `Boolean` accessors whose names start with `is` followed by an uppercase character.
+
 The following table describes the keywords supported for JPA and what a method containing that keyword translates to:
 
 .Supported keywords inside method names


### PR DESCRIPTION
Closes #4303

A Kotlin Boolean property named `isActive` is exposed to Spring Data as `isActive`, while a JPA property-access mapping derives the metamodel attribute `active` from the `isActive()` getter. As a result, `findByIsActiveTrue()` parses successfully but renders an invalid JPA path.

The parsed segment is now resolved against the JPA metamodel first. If no direct attribute exists, the decapitalized name is used only when the metamodel attribute is read through the same zero-argument `boolean` or `Boolean` getter. Direct attributes such as a field-access `isActive` retain precedence, so this does not introduce general accessor-name aliasing.

The change covers JPQL and Criteria derived-query paths, with regression tests for direct-attribute precedence, nested paths, keyset use, and an unrelated `getFoo` accessor.

<!--

Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
Make sure that:

-->

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
