### PR TITLE
Run on JPA 3.2 and 4, from a single artifact.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -78,6 +78,42 @@
 			</repositories>
 		</profile>
 		<profile>
+			<id>h8</id>
+			<properties>
+				<hibernate>8.0.0-SNAPSHOT</hibernate>
+				<jakarta-persistence-api>4.0.0-M6</jakarta-persistence-api>
+				<spring>7.1.0-SNAPSHOT</spring>
+				<jakarta-annotation-api>3.0.0</jakarta-annotation-api>
+			</properties>
+			<repositories>
+				<repository>
+					<id>sonatype-central</id>
+					<url>https://central.sonatype.com/repository/maven-snapshots</url>
+					<releases>
+						<enabled>false</enabled>
+					</releases>
+				</repository>
+			</repositories>
+		</profile>
+		<profile>
+			<id>h8-next</id>
+			<properties>
+				<hibernate>8.1.0-SNAPSHOT</hibernate>
+				<jakarta-persistence-api>4.0.0-SNAPSHOT</jakarta-persistence-api>
+				<spring>7.1.0-SNAPSHOT</spring>
+				<jakarta-annotation-api>3.0.0</jakarta-annotation-api>
+			</properties>
+			<repositories>
+				<repository>
+					<id>sonatype-central</id>
+					<url>https://central.sonatype.com/repository/maven-snapshots</url>
+					<releases>
+						<enabled>false</enabled>
+					</releases>
+				</repository>
+			</repositories>
+		</profile>
+		<profile>
 			<id>all-dbs</id>
 			<build>
 				<plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-jpa-parent</artifactId>
-	<version>4.2.0-SNAPSHOT</version>
+	<version>4.2.x-GH-4197-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data JPA Parent</name>

--- a/pom.xml
+++ b/pom.xml
@@ -40,6 +40,7 @@
 		<postgresql>42.7.13</postgresql>
 		<oracle>23.26.3.0.0</oracle>
 		<springdata.commons>4.2.0-SNAPSHOT</springdata.commons>
+		<spring-instrument-agent>-javaagent:${settings.localRepository}/org/springframework/spring-instrument/${spring}/spring-instrument-${spring}.jar</spring-instrument-agent>
 
 		<hibernate.groupId>org.hibernate</hibernate.groupId>
 		<antora-javadoc-artifactId>spring-data-jpa</antora-javadoc-artifactId>
@@ -84,6 +85,7 @@
 				<jakarta-persistence-api>4.0.0-M6</jakarta-persistence-api>
 				<spring>7.1.0-SNAPSHOT</spring>
 				<jakarta-annotation-api>3.0.0</jakarta-annotation-api>
+				<spring-instrument-agent />
 			</properties>
 			<repositories>
 				<repository>
@@ -102,6 +104,7 @@
 				<jakarta-persistence-api>4.0.0-SNAPSHOT</jakarta-persistence-api>
 				<spring>7.1.0-SNAPSHOT</spring>
 				<jakarta-annotation-api>3.0.0</jakarta-annotation-api>
+				<spring-instrument-agent />
 			</properties>
 			<repositories>
 				<repository>

--- a/spring-data-envers/pom.xml
+++ b/spring-data-envers/pom.xml
@@ -4,12 +4,12 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-envers</artifactId>
-	<version>4.2.0-SNAPSHOT</version>
+	<version>4.2.x-GH-4197-SNAPSHOT</version>
 
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-jpa-parent</artifactId>
-		<version>4.2.0-SNAPSHOT</version>
+		<version>4.2.x-GH-4197-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-jpa-distribution/pom.xml
+++ b/spring-data-jpa-distribution/pom.xml
@@ -13,7 +13,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-jpa-parent</artifactId>
-		<version>4.2.0-SNAPSHOT</version>
+		<version>4.2.x-GH-4197-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-jpa/pom.xml
+++ b/spring-data-jpa/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-jpa</artifactId>
-	<version>4.2.0-SNAPSHOT</version>
+	<version>4.2.x-GH-4197-SNAPSHOT</version>
 
 	<name>Spring Data JPA</name>
 	<description>Spring Data module for JPA repositories.</description>
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-jpa-parent</artifactId>
-		<version>4.2.0-SNAPSHOT</version>
+		<version>4.2.x-GH-4197-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-jpa/pom.xml
+++ b/spring-data-jpa/pom.xml
@@ -363,7 +363,7 @@
 							</excludes>
 							<argLine>
 								-Xmx4G
-								-javaagent:${settings.localRepository}/org/springframework/spring-instrument/${spring}/spring-instrument-${spring}.jar
+								${spring-instrument-agent}
 							</argLine>
 						</configuration>
 					</execution>
@@ -380,7 +380,7 @@
 							<argLine>
 								-Xmx4G
 								-javaagent:${settings.localRepository}/org/eclipse/persistence/org.eclipse.persistence.jpa/${eclipselink}/org.eclipse.persistence.jpa-${eclipselink}.jar
-								-javaagent:${settings.localRepository}/org/springframework/spring-instrument/${spring}/spring-instrument-${spring}.jar
+								${spring-instrument-agent}
 							</argLine>
 						</configuration>
 					</execution>

--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/convert/QueryByExamplePredicateBuilder.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/convert/QueryByExamplePredicateBuilder.java
@@ -116,9 +116,7 @@ public class QueryByExamplePredicateBuilder {
 			return predicates.iterator().next();
 		}
 
-		Predicate[] array = predicates.toArray(new Predicate[0]);
-
-		return matcher.isAllMatching() ? cb.and(array) : cb.or(array);
+		return matcher.isAllMatching() ? cb.and(predicates) : cb.or(predicates);
 	}
 
 	@SuppressWarnings({ "rawtypes", "unchecked" })

--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/provider/AbstractHibernateAdapter.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/provider/AbstractHibernateAdapter.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2026-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.jpa.provider;
+
+import jakarta.persistence.Query;
+
+import java.lang.reflect.Method;
+import java.util.Map;
+
+import org.hibernate.query.SelectionQuery;
+import org.jspecify.annotations.Nullable;
+
+import org.springframework.util.ClassUtils;
+import org.springframework.util.ConcurrentReferenceHashMap;
+import org.springframework.util.ReflectionUtils;
+
+/**
+ * Reflective support shared by the version-specific {@link HibernateAdapter} implementations.
+ *
+ * @author Oscar Fanchin
+ * @since 4.2
+ */
+abstract class AbstractHibernateAdapter implements HibernateAdapter {
+
+	private final @Nullable Class<?> sqmQuery;
+	private final @Nullable Class<?> namedSqmQuery;
+	private final @Nullable Class<?> namedNativeQuery;
+
+	/**
+	 * Methods are resolved against the implementation class rather than against the marker interfaces: Hibernate 8's
+	 * {@code SqmStatementAccess} does not declare {@code getQueryString()}, so there is no stable interface to anchor
+	 * the lookup to.
+	 */
+	private final Map<MethodKey, Method> methodCache = new ConcurrentReferenceHashMap<>();
+
+	AbstractHibernateAdapter(ClassLoader classLoader, String sqmQuery, String namedSqmQuery, String namedNativeQuery) {
+
+		this.sqmQuery = loadClass(sqmQuery, classLoader);
+		this.namedSqmQuery = loadClass(namedSqmQuery, classLoader);
+		this.namedNativeQuery = loadClass(namedNativeQuery, classLoader);
+	}
+
+	@Override
+	public boolean isSqmQuery(Object query) {
+		return isInstance(sqmQuery, query);
+	}
+
+	@Override
+	public boolean isNamedSqmQuery(Object query) {
+		return isInstance(namedSqmQuery, query);
+	}
+
+	@Override
+	public boolean isNamedNativeQuery(Object query) {
+		return isInstance(namedNativeQuery, query);
+	}
+
+	@Override
+	public String getQueryString(Object query) {
+		return invokeStringMethod(query, "getQueryString");
+	}
+
+	@Override
+	public String getHqlString(Object query) {
+		return invokeStringMethod(query, "getHqlString");
+	}
+
+	@Override
+	public String getSqlString(Object query) {
+		return invokeStringMethod(query, "getSqlString");
+	}
+
+	@Override
+	public String getSqmStatement(Object query) {
+		return invokeStringMethod(invokeMethod(query, "getSqmStatement"), "toHqlString");
+	}
+
+	@Override
+	public @Nullable SelectionQuery<?> asSelectionQuery(Query query) {
+		return null;
+	}
+
+	private String invokeStringMethod(Object target, String methodName) {
+		return (String) invokeMethod(target, methodName);
+	}
+
+	private Object invokeMethod(Object target, String methodName) {
+
+		Method method = methodCache.computeIfAbsent(new MethodKey(target.getClass(), methodName), key -> {
+
+			Method resolved = ReflectionUtils.findMethod(key.type(), key.name());
+
+			if (resolved == null) {
+				throw new IllegalStateException("Cannot resolve method %s on %s".formatted(key.name(), key.type()));
+			}
+
+			// The implementation classes live in internal packages and are not necessarily public.
+			ReflectionUtils.makeAccessible(resolved);
+
+			return resolved;
+		});
+
+		return ReflectionUtils.invokeMethod(method, target);
+	}
+
+	private static boolean isInstance(@Nullable Class<?> type, Object query) {
+		return type != null && type.isInstance(query);
+	}
+
+	/**
+	 * Resolve the given type, returning {@literal null} when absent so that callers degrade to their legacy path instead
+	 * of failing during class initialization.
+	 */
+	static @Nullable Class<?> loadClass(String className, ClassLoader classLoader) {
+		return ClassUtils.isPresent(className, classLoader) ? ClassUtils.resolveClassName(className, classLoader) : null;
+	}
+
+	private record MethodKey(Class<?> type, String name) {}
+}

--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/provider/Hibernate7Adapter.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/provider/Hibernate7Adapter.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2026-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.jpa.provider;
+
+/**
+ * {@link HibernateAdapter} for the Hibernate 7 contracts.
+ * <p>
+ * Selection queries implement {@code SelectionQuery} directly on this generation, so {@code asSelectionQuery(…)} keeps
+ * the inherited {@literal null} answer and the caller's {@code instanceof} check covers it.
+ *
+ * @author Oscar Fanchin
+ * @since 4.2
+ */
+final class Hibernate7Adapter extends AbstractHibernateAdapter {
+
+	Hibernate7Adapter(ClassLoader classLoader) {
+		super(classLoader, "org.hibernate.query.spi.SqmQuery", "org.hibernate.query.sqm.spi.NamedSqmQueryMemento",
+				"org.hibernate.query.sql.spi.NamedNativeQueryMemento");
+	}
+}

--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/provider/Hibernate8Adapter.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/provider/Hibernate8Adapter.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2026-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.jpa.provider;
+
+import jakarta.persistence.Query;
+
+import java.lang.reflect.Method;
+
+import org.hibernate.query.SelectionQuery;
+import org.jspecify.annotations.Nullable;
+
+import org.springframework.util.ReflectionUtils;
+
+/**
+ * {@link HibernateAdapter} for the Hibernate 8 contracts.
+ *
+ * @author Oscar Fanchin
+ * @since 4.2
+ */
+final class Hibernate8Adapter extends AbstractHibernateAdapter {
+
+	static final String SQM_STATEMENT_ACCESS = "org.hibernate.query.sqm.spi.SqmStatementAccess";
+
+	private final @Nullable Class<?> mutationOrSelectionQuery;
+	private final @Nullable Method isSelectionQuery;
+	private final @Nullable Method asSelectionQuery;
+
+	Hibernate8Adapter(ClassLoader classLoader) {
+
+		super(classLoader, SQM_STATEMENT_ACCESS, "org.hibernate.query.named.spi.NamedSqmQueryMemento",
+				"org.hibernate.query.named.spi.NamedNativeQueryMemento");
+
+		this.mutationOrSelectionQuery = loadClass("org.hibernate.query.MutationOrSelectionQuery", classLoader);
+		this.isSelectionQuery = findMethod(mutationOrSelectionQuery, "isSelectionQuery");
+		this.asSelectionQuery = findMethod(mutationOrSelectionQuery, "asSelectionQuery");
+	}
+
+	@Override
+	public @Nullable SelectionQuery<?> asSelectionQuery(Query query) {
+
+		if (mutationOrSelectionQuery == null || isSelectionQuery == null || asSelectionQuery == null
+				|| !mutationOrSelectionQuery.isInstance(query)
+				|| !Boolean.TRUE.equals(ReflectionUtils.invokeMethod(isSelectionQuery, query))) {
+			return null;
+		}
+
+		Object selectionQuery = ReflectionUtils.invokeMethod(asSelectionQuery, query);
+
+		return selectionQuery instanceof SelectionQuery<?> candidate ? candidate : null;
+	}
+
+	private static @Nullable Method findMethod(@Nullable Class<?> type, String methodName) {
+		return type != null ? ReflectionUtils.findMethod(type, methodName) : null;
+	}
+}

--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/provider/HibernateAdapter.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/provider/HibernateAdapter.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2026-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.jpa.provider;
+
+import jakarta.persistence.Query;
+
+import org.hibernate.query.SelectionQuery;
+import org.jspecify.annotations.Nullable;
+
+import org.springframework.util.ClassUtils;
+
+/**
+ * Adapter bridging the contracts that changed between the Hibernate generations we support.
+ * <p>
+ * Hibernate 8 renamed and relocated the types Spring Data inspects to extract query strings, so the entire interaction
+ * has to go through reflection to keep a single binary compatible with both generations. See GH-4197.
+ *
+ * @author Oscar Fanchin
+ * @since 4.2
+ */
+interface HibernateAdapter {
+
+	/**
+	 * Select the adapter matching the Hibernate version on the classpath. Detection is based on type presence rather
+	 * than on the declared version, which is not reliable in shaded or repackaged distributions.
+	 */
+	static HibernateAdapter create() {
+
+		ClassLoader classLoader = HibernateAdapter.class.getClassLoader();
+
+		// Hibernate 8 replaced SqmQuery with SqmStatementAccess as the SQM access point.
+		return ClassUtils.isPresent(Hibernate8Adapter.SQM_STATEMENT_ACCESS, classLoader) //
+				? new Hibernate8Adapter(classLoader) //
+				: new Hibernate7Adapter(classLoader);
+	}
+
+	boolean isSqmQuery(Object query);
+
+	boolean isNamedSqmQuery(Object query);
+
+	boolean isNamedNativeQuery(Object query);
+
+	String getQueryString(Object query);
+
+	String getHqlString(Object query);
+
+	String getSqlString(Object query);
+
+	String getSqmStatement(Object query);
+
+	/**
+	 * Return the {@link SelectionQuery} the given query represents, or {@literal null} if it does not represent one.
+	 * Hibernate 8 no longer lets selection queries implement {@link SelectionQuery} directly, exposing them through
+	 * {@code MutationOrSelectionQuery} instead.
+	 */
+	@Nullable
+	SelectionQuery<?> asSelectionQuery(Query query);
+}

--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/provider/HibernateUtils.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/provider/HibernateUtils.java
@@ -17,10 +17,10 @@ package org.springframework.data.jpa.provider;
 
 import org.hibernate.query.NativeQuery;
 import org.hibernate.query.Query;
-import org.hibernate.query.spi.SqmQuery;
-import org.hibernate.query.sql.spi.NamedNativeQueryMemento;
-import org.hibernate.query.sqm.spi.NamedSqmQueryMemento;
 import org.jspecify.annotations.Nullable;
+
+import org.springframework.util.ClassUtils;
+import org.springframework.util.ReflectionUtils;
 
 /**
  * Utility functions to work with Hibernate. Mostly using reflection to make sure common functionality can be executed
@@ -31,10 +31,13 @@ import org.jspecify.annotations.Nullable;
  * @author Jens Schauder
  * @author Donghun Shin
  * @author Greg Turnquist
+ * @author Oscar Fanchin
  * @since 1.10.2
  * @soundtrack Benny Greb - Soulfood (Live, https://www.youtube.com/watch?v=9_ErMa_CtSw)
  */
 public abstract class HibernateUtils {
+
+	private static final HibernateQueryAdapter HIBERNATE_QUERY_ADAPTER = new HibernateQueryAdapter();
 
 	private HibernateUtils() {}
 
@@ -47,32 +50,30 @@ public abstract class HibernateUtils {
 	public @Nullable static String getHibernateQuery(Object query) {
 
 		try {
-			// Try the new Hibernate implementation first
-			if (query instanceof SqmQuery sqmQuery) {
+			if (HIBERNATE_QUERY_ADAPTER.isSqmQuery(query)) {
 
-				String hql = sqmQuery.getQueryString();
-
-				if (!hql.equals("<criteria>")) {
-					return hql;
-				}
-
-				return sqmQuery.getSqmStatement().toHqlString();
-			}
-
-			// Try the new Hibernate implementation first
-			if (query instanceof NamedSqmQueryMemento<?> sqmQuery) {
-
-				String hql = sqmQuery.getHqlString();
+				String hql = HIBERNATE_QUERY_ADAPTER.getQueryString(query);
 
 				if (!hql.equals("<criteria>")) {
 					return hql;
 				}
 
-				return sqmQuery.getSqmStatement().toHqlString();
+				return HIBERNATE_QUERY_ADAPTER.getSqmStatement(query);
 			}
 
-			if (query instanceof NamedNativeQueryMemento<?> nativeQuery) {
-				return nativeQuery.getSqlString();
+			if (HIBERNATE_QUERY_ADAPTER.isNamedSqmQuery(query)) {
+
+				String hql = HIBERNATE_QUERY_ADAPTER.getHqlString(query);
+
+				if (!hql.equals("<criteria>")) {
+					return hql;
+				}
+
+				return HIBERNATE_QUERY_ADAPTER.getSqmStatement(query);
+			}
+
+			if (HIBERNATE_QUERY_ADAPTER.isNamedNativeQuery(query)) {
+				return HIBERNATE_QUERY_ADAPTER.getSqlString(query);
 			}
 
 			// Couple of cases in which this still breaks, see HHH-15389
@@ -88,8 +89,7 @@ public abstract class HibernateUtils {
 
 	public static boolean isNativeQuery(Object query) {
 
-		// Try the new Hibernate implementation first
-		if (query instanceof SqmQuery) {
+		if (HIBERNATE_QUERY_ADAPTER.isSqmQuery(query)) {
 			return false;
 		}
 
@@ -97,16 +97,97 @@ public abstract class HibernateUtils {
 			return true;
 		}
 
-		// Try the new Hibernate implementation first
-		if (query instanceof NamedSqmQueryMemento<?>) {
+		if (HIBERNATE_QUERY_ADAPTER.isNamedSqmQuery(query)) {
 
 			return false;
 		}
 
-		if (query instanceof NamedNativeQueryMemento<?>) {
+		if (HIBERNATE_QUERY_ADAPTER.isNamedNativeQuery(query)) {
 			return true;
 		}
 
+		if (query instanceof jakarta.persistence.Query jpaQuery) {
+			try {
+				jpaQuery.unwrap(NativeQuery.class);
+				return true;
+			} catch (RuntimeException o_O) {
+				// Not a native Hibernate query.
+			}
+		}
+
 		return false;
+	}
+
+	private static final class HibernateQueryAdapter {
+
+		private static final ClassLoader CLASS_LOADER = HibernateUtils.class.getClassLoader();
+
+		private final @Nullable Class<?> sqmQuery = loadClass("org.hibernate.query.sqm.spi.SqmStatementAccess",
+				"org.hibernate.query.spi.SqmQuery");
+		private final @Nullable Class<?> namedSqmQuery = loadClass("org.hibernate.query.named.spi.NamedSqmQueryMemento",
+				"org.hibernate.query.sqm.spi.NamedSqmQueryMemento");
+		private final @Nullable Class<?> namedNativeQuery = loadClass(
+				"org.hibernate.query.named.spi.NamedNativeQueryMemento",
+				"org.hibernate.query.sql.spi.NamedNativeQueryMemento");
+
+		boolean isSqmQuery(Object query) {
+			return isInstance(sqmQuery, query);
+		}
+
+		boolean isNamedSqmQuery(Object query) {
+			return isInstance(namedSqmQuery, query);
+		}
+
+		boolean isNamedNativeQuery(Object query) {
+			return isInstance(namedNativeQuery, query);
+		}
+
+		String getQueryString(Object query) {
+			return invokeStringMethod(query, "getQueryString");
+		}
+
+		String getHqlString(Object query) {
+			return invokeStringMethod(query, "getHqlString");
+		}
+
+		String getSqlString(Object query) {
+			return invokeStringMethod(query, "getSqlString");
+		}
+
+		String getSqmStatement(Object query) {
+			return invokeStringMethod(invokeMethod(query, "getSqmStatement"), "toHqlString");
+		}
+
+		private static boolean isInstance(@Nullable Class<?> type, Object query) {
+			return type != null && type.isInstance(query);
+		}
+
+		private static String invokeStringMethod(Object target, String methodName) {
+			return (String) invokeMethod(target, methodName);
+		}
+
+		private static Object invokeMethod(Object target, String methodName) {
+
+			var method = ReflectionUtils.findMethod(target.getClass(), methodName);
+
+			if (method == null) {
+				throw new IllegalStateException("Cannot resolve method %s on %s".formatted(methodName, target.getClass()));
+			}
+
+			ReflectionUtils.makeAccessible(method);
+
+			return ReflectionUtils.invokeMethod(method, target);
+		}
+
+		private static @Nullable Class<?> loadClass(String... classNames) {
+
+			for (String className : classNames) {
+				if (ClassUtils.isPresent(className, CLASS_LOADER)) {
+					return ClassUtils.resolveClassName(className, CLASS_LOADER);
+				}
+			}
+
+			return null;
+		}
 	}
 }

--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/provider/HibernateUtils.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/provider/HibernateUtils.java
@@ -17,10 +17,8 @@ package org.springframework.data.jpa.provider;
 
 import org.hibernate.query.NativeQuery;
 import org.hibernate.query.Query;
+import org.hibernate.query.SelectionQuery;
 import org.jspecify.annotations.Nullable;
-
-import org.springframework.util.ClassUtils;
-import org.springframework.util.ReflectionUtils;
 
 /**
  * Utility functions to work with Hibernate. Mostly using reflection to make sure common functionality can be executed
@@ -37,9 +35,18 @@ import org.springframework.util.ReflectionUtils;
  */
 public abstract class HibernateUtils {
 
-	private static final HibernateQueryAdapter HIBERNATE_QUERY_ADAPTER = new HibernateQueryAdapter();
+	private static final HibernateAdapter HIBERNATE_ADAPTER = HibernateAdapter.create();
 
 	private HibernateUtils() {}
+
+	/**
+	 * Return the {@link SelectionQuery} the given query represents, or {@literal null} if it does not represent one.
+	 *
+	 * @since 4.2
+	 */
+	static @Nullable SelectionQuery<?> asSelectionQuery(jakarta.persistence.Query query) {
+		return HIBERNATE_ADAPTER.asSelectionQuery(query);
+	}
 
 	/**
 	 * Return the query string of the underlying native Hibernate query.
@@ -50,30 +57,30 @@ public abstract class HibernateUtils {
 	public @Nullable static String getHibernateQuery(Object query) {
 
 		try {
-			if (HIBERNATE_QUERY_ADAPTER.isSqmQuery(query)) {
+			if (HIBERNATE_ADAPTER.isSqmQuery(query)) {
 
-				String hql = HIBERNATE_QUERY_ADAPTER.getQueryString(query);
-
-				if (!hql.equals("<criteria>")) {
-					return hql;
-				}
-
-				return HIBERNATE_QUERY_ADAPTER.getSqmStatement(query);
-			}
-
-			if (HIBERNATE_QUERY_ADAPTER.isNamedSqmQuery(query)) {
-
-				String hql = HIBERNATE_QUERY_ADAPTER.getHqlString(query);
+				String hql = HIBERNATE_ADAPTER.getQueryString(query);
 
 				if (!hql.equals("<criteria>")) {
 					return hql;
 				}
 
-				return HIBERNATE_QUERY_ADAPTER.getSqmStatement(query);
+				return HIBERNATE_ADAPTER.getSqmStatement(query);
 			}
 
-			if (HIBERNATE_QUERY_ADAPTER.isNamedNativeQuery(query)) {
-				return HIBERNATE_QUERY_ADAPTER.getSqlString(query);
+			if (HIBERNATE_ADAPTER.isNamedSqmQuery(query)) {
+
+				String hql = HIBERNATE_ADAPTER.getHqlString(query);
+
+				if (!hql.equals("<criteria>")) {
+					return hql;
+				}
+
+				return HIBERNATE_ADAPTER.getSqmStatement(query);
+			}
+
+			if (HIBERNATE_ADAPTER.isNamedNativeQuery(query)) {
+				return HIBERNATE_ADAPTER.getSqlString(query);
 			}
 
 			// Couple of cases in which this still breaks, see HHH-15389
@@ -89,7 +96,7 @@ public abstract class HibernateUtils {
 
 	public static boolean isNativeQuery(Object query) {
 
-		if (HIBERNATE_QUERY_ADAPTER.isSqmQuery(query)) {
+		if (HIBERNATE_ADAPTER.isSqmQuery(query)) {
 			return false;
 		}
 
@@ -97,12 +104,12 @@ public abstract class HibernateUtils {
 			return true;
 		}
 
-		if (HIBERNATE_QUERY_ADAPTER.isNamedSqmQuery(query)) {
+		if (HIBERNATE_ADAPTER.isNamedSqmQuery(query)) {
 
 			return false;
 		}
 
-		if (HIBERNATE_QUERY_ADAPTER.isNamedNativeQuery(query)) {
+		if (HIBERNATE_ADAPTER.isNamedNativeQuery(query)) {
 			return true;
 		}
 
@@ -116,78 +123,5 @@ public abstract class HibernateUtils {
 		}
 
 		return false;
-	}
-
-	private static final class HibernateQueryAdapter {
-
-		private static final ClassLoader CLASS_LOADER = HibernateUtils.class.getClassLoader();
-
-		private final @Nullable Class<?> sqmQuery = loadClass("org.hibernate.query.sqm.spi.SqmStatementAccess",
-				"org.hibernate.query.spi.SqmQuery");
-		private final @Nullable Class<?> namedSqmQuery = loadClass("org.hibernate.query.named.spi.NamedSqmQueryMemento",
-				"org.hibernate.query.sqm.spi.NamedSqmQueryMemento");
-		private final @Nullable Class<?> namedNativeQuery = loadClass(
-				"org.hibernate.query.named.spi.NamedNativeQueryMemento",
-				"org.hibernate.query.sql.spi.NamedNativeQueryMemento");
-
-		boolean isSqmQuery(Object query) {
-			return isInstance(sqmQuery, query);
-		}
-
-		boolean isNamedSqmQuery(Object query) {
-			return isInstance(namedSqmQuery, query);
-		}
-
-		boolean isNamedNativeQuery(Object query) {
-			return isInstance(namedNativeQuery, query);
-		}
-
-		String getQueryString(Object query) {
-			return invokeStringMethod(query, "getQueryString");
-		}
-
-		String getHqlString(Object query) {
-			return invokeStringMethod(query, "getHqlString");
-		}
-
-		String getSqlString(Object query) {
-			return invokeStringMethod(query, "getSqlString");
-		}
-
-		String getSqmStatement(Object query) {
-			return invokeStringMethod(invokeMethod(query, "getSqmStatement"), "toHqlString");
-		}
-
-		private static boolean isInstance(@Nullable Class<?> type, Object query) {
-			return type != null && type.isInstance(query);
-		}
-
-		private static String invokeStringMethod(Object target, String methodName) {
-			return (String) invokeMethod(target, methodName);
-		}
-
-		private static Object invokeMethod(Object target, String methodName) {
-
-			var method = ReflectionUtils.findMethod(target.getClass(), methodName);
-
-			if (method == null) {
-				throw new IllegalStateException("Cannot resolve method %s on %s".formatted(methodName, target.getClass()));
-			}
-
-			ReflectionUtils.makeAccessible(method);
-
-			return ReflectionUtils.invokeMethod(method, target);
-		}
-
-		private static @Nullable Class<?> loadClass(String... classNames) {
-
-			for (String className : classNames) {
-				if (ClassUtils.isPresent(className, CLASS_LOADER)) {
-					return ClassUtils.resolveClassName(className, CLASS_LOADER);
-				}
-			}
-
-			return null;
-		}
 	}
 }

--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/provider/PersistenceProvider.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/provider/PersistenceProvider.java
@@ -133,7 +133,8 @@ public enum PersistenceProvider implements QueryExtractor, ProxyIdAccessor, Quer
 					return selectionQuery.getResultCount();
 				}
 
-				SelectionQuery<?> selectionQuery = asSelectionQuery(resultQuery);
+				// Hibernate 8 exposes selection queries through MutationOrSelectionQuery instead.
+				SelectionQuery<?> selectionQuery = HibernateUtils.asSelectionQuery(resultQuery);
 
 				if (selectionQuery != null) {
 					return selectionQuery.getResultCount();
@@ -251,9 +252,6 @@ public enum PersistenceProvider implements QueryExtractor, ProxyIdAccessor, Quer
 	};
 
 	private static final @Nullable Class<?> typedParameterValueClass;
-	private static final @Nullable Class<?> mutationOrSelectionQueryClass;
-	private static final @Nullable Method isSelectionQueryMethod;
-	private static final @Nullable Method asSelectionQueryMethod;
 
 	static {
 
@@ -264,36 +262,11 @@ public enum PersistenceProvider implements QueryExtractor, ProxyIdAccessor, Quer
 			type = null;
 		}
 		typedParameterValueClass = type;
-
-		Class<?> queryType;
-		try {
-			queryType = ClassUtils.forName("org.hibernate.query.MutationOrSelectionQuery",
-					PersistenceProvider.class.getClassLoader());
-		} catch (ClassNotFoundException e) {
-			queryType = null;
-		}
-
-		mutationOrSelectionQueryClass = queryType;
-		isSelectionQueryMethod = queryType != null ? ReflectionUtils.findMethod(queryType, "isSelectionQuery") : null;
-		asSelectionQueryMethod = queryType != null ? ReflectionUtils.findMethod(queryType, "asSelectionQuery") : null;
 	}
 
 	private static final Collection<PersistenceProvider> ALL = List.of(HIBERNATE, ECLIPSELINK, GENERIC_JPA);
 
 	private static final ConcurrentReferenceHashMap<Class<?>, PersistenceProvider> CACHE = new ConcurrentReferenceHashMap<>();
-
-	private static @Nullable SelectionQuery<?> asSelectionQuery(Query query) {
-
-		if (mutationOrSelectionQueryClass == null || isSelectionQueryMethod == null || asSelectionQueryMethod == null
-				|| !mutationOrSelectionQueryClass.isInstance(query)
-				|| !Boolean.TRUE.equals(ReflectionUtils.invokeMethod(isSelectionQueryMethod, query))) {
-			return null;
-		}
-
-		Object selectionQuery = ReflectionUtils.invokeMethod(asSelectionQueryMethod, query);
-
-		return selectionQuery instanceof SelectionQuery<?> candidate ? candidate : null;
-	}
 
 	final Iterable<String> entityManagerFactoryClassNames;
 	private final Iterable<String> metamodelClassNames;

--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/provider/PersistenceProvider.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/provider/PersistenceProvider.java
@@ -25,6 +25,7 @@ import jakarta.persistence.metamodel.IdentifiableType;
 import jakarta.persistence.metamodel.Metamodel;
 import jakarta.persistence.metamodel.SingularAttribute;
 
+import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
 import java.util.Collection;
 import java.util.Collections;
@@ -53,6 +54,7 @@ import org.springframework.transaction.support.TransactionSynchronizationManager
 import org.springframework.util.Assert;
 import org.springframework.util.ClassUtils;
 import org.springframework.util.ConcurrentReferenceHashMap;
+import org.springframework.util.ReflectionUtils;
 import org.springframework.util.StringUtils;
 
 /**
@@ -65,6 +67,7 @@ import org.springframework.util.StringUtils;
  * @author Greg Turnquist
  * @author Yuriy Tsarkov
  * @author Ariel Morelli Andres
+ * @author Oscar Fanchin
  */
 public enum PersistenceProvider implements QueryExtractor, ProxyIdAccessor, QueryComment {
 
@@ -124,9 +127,17 @@ public enum PersistenceProvider implements QueryExtractor, ProxyIdAccessor, Quer
 		@Override
 		public long getResultCount(Query resultQuery, LongSupplier countSupplier) {
 
-			if (TransactionSynchronizationManager.isActualTransactionActive()
-					&& resultQuery instanceof SelectionQuery<?> sq) {
-				return sq.getResultCount();
+			if (TransactionSynchronizationManager.isActualTransactionActive()) {
+
+				if (resultQuery instanceof SelectionQuery<?> selectionQuery) {
+					return selectionQuery.getResultCount();
+				}
+
+				SelectionQuery<?> selectionQuery = asSelectionQuery(resultQuery);
+
+				if (selectionQuery != null) {
+					return selectionQuery.getResultCount();
+				}
 			}
 
 			return super.getResultCount(resultQuery, countSupplier);
@@ -240,6 +251,9 @@ public enum PersistenceProvider implements QueryExtractor, ProxyIdAccessor, Quer
 	};
 
 	private static final @Nullable Class<?> typedParameterValueClass;
+	private static final @Nullable Class<?> mutationOrSelectionQueryClass;
+	private static final @Nullable Method isSelectionQueryMethod;
+	private static final @Nullable Method asSelectionQueryMethod;
 
 	static {
 
@@ -250,11 +264,37 @@ public enum PersistenceProvider implements QueryExtractor, ProxyIdAccessor, Quer
 			type = null;
 		}
 		typedParameterValueClass = type;
+
+		Class<?> queryType;
+		try {
+			queryType = ClassUtils.forName("org.hibernate.query.MutationOrSelectionQuery",
+					PersistenceProvider.class.getClassLoader());
+		} catch (ClassNotFoundException e) {
+			queryType = null;
+		}
+
+		mutationOrSelectionQueryClass = queryType;
+		isSelectionQueryMethod = queryType != null ? ReflectionUtils.findMethod(queryType, "isSelectionQuery") : null;
+		asSelectionQueryMethod = queryType != null ? ReflectionUtils.findMethod(queryType, "asSelectionQuery") : null;
 	}
 
 	private static final Collection<PersistenceProvider> ALL = List.of(HIBERNATE, ECLIPSELINK, GENERIC_JPA);
 
 	private static final ConcurrentReferenceHashMap<Class<?>, PersistenceProvider> CACHE = new ConcurrentReferenceHashMap<>();
+
+	private static @Nullable SelectionQuery<?> asSelectionQuery(Query query) {
+
+		if (mutationOrSelectionQueryClass == null || isSelectionQueryMethod == null || asSelectionQueryMethod == null
+				|| !mutationOrSelectionQueryClass.isInstance(query)
+				|| !Boolean.TRUE.equals(ReflectionUtils.invokeMethod(isSelectionQueryMethod, query))) {
+			return null;
+		}
+
+		Object selectionQuery = ReflectionUtils.invokeMethod(asSelectionQueryMethod, query);
+
+		return selectionQuery instanceof SelectionQuery<?> candidate ? candidate : null;
+	}
+
 	final Iterable<String> entityManagerFactoryClassNames;
 	private final Iterable<String> metamodelClassNames;
 

--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/aot/AotMetamodel.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/aot/AotMetamodel.java
@@ -293,6 +293,10 @@ class AotMetamodel implements Metamodel {
 										JdbcParameterBindings.NO_BINDINGS);
 							}
 
+							if (method.getReturnType().equals(void.class)) {
+								return null;
+							}
+
 							if (method.getReturnType().isPrimitive()) {
 								return ReflectionUtils.getPrimitiveDefault(method.getReturnType());
 							}
@@ -316,6 +320,10 @@ class AotMetamodel implements Metamodel {
 							if (method.getName().equals("buildHandler")) {
 								return new MultiTableHandlerBuildResult(EmptyMultiTableHandler.INSTANCE,
 										JdbcParameterBindings.NO_BINDINGS);
+							}
+
+							if (method.getReturnType().equals(void.class)) {
+								return null;
 							}
 
 							if (method.getReturnType().isPrimitive()) {

--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/aot/AotMetamodel.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/aot/AotMetamodel.java
@@ -64,6 +64,7 @@ import org.springframework.data.util.Lazy;
 import org.springframework.data.util.ReflectionUtils;
 import org.springframework.orm.jpa.persistenceunit.PersistenceManagedTypes;
 import org.springframework.orm.jpa.persistenceunit.SpringPersistenceUnitInfo;
+import org.springframework.util.ClassUtils;
 import org.springframework.util.CollectionUtils;
 
 /**
@@ -99,8 +100,11 @@ class AotMetamodel implements Metamodel {
 	public AotMetamodel(Collection<String> managedTypes, @Nullable URL persistenceUnitRootUrl,
 			Map<String, Object> jpaProperties) {
 
+		// managedTypes may be backed by a bootstrap-loaded JDK collection whose class loader is null.
+		// Use the application class loader so that the persistence unit can resolve managed entity classes.
+		ClassLoader classLoader = ClassUtils.getDefaultClassLoader();
 		SpringPersistenceUnitInfo persistenceUnitInfo = new SpringPersistenceUnitInfo(
-				managedTypes.getClass().getClassLoader());
+				classLoader != null ? classLoader : AotMetamodel.class.getClassLoader());
 		persistenceUnitInfo.setPersistenceUnitName("AotMetamodel");
 		persistenceUnitInfo.setPersistenceUnitRootUrl(persistenceUnitRootUrl);
 		persistenceUnitInfo.setExcludeUnlistedClasses(true);

--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/aot/AotMetamodel.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/aot/AotMetamodel.java
@@ -35,6 +35,7 @@ import org.hibernate.cfg.JdbcSettings;
 import org.hibernate.cfg.PersistenceSettings;
 import org.hibernate.cfg.QuerySettings;
 import org.hibernate.cfg.SchemaToolingSettings;
+import org.hibernate.dialect.DatabaseVersion;
 import org.hibernate.dialect.Dialect;
 import org.hibernate.dialect.pagination.LimitHandler;
 import org.hibernate.dialect.pagination.OffsetFetchLimitHandler;
@@ -47,14 +48,10 @@ import org.hibernate.jpa.boot.internal.PersistenceUnitInfoDescriptor;
 import org.hibernate.metamodel.mapping.EntityMappingType;
 import org.hibernate.metamodel.spi.RuntimeModelCreationContext;
 import org.hibernate.query.common.TemporalUnit;
-import org.hibernate.query.spi.DomainQueryExecutionContext;
-import org.hibernate.query.sqm.internal.DomainParameterXref;
 import org.hibernate.query.sqm.mutation.spi.MultiTableHandler;
 import org.hibernate.query.sqm.mutation.spi.MultiTableHandlerBuildResult;
 import org.hibernate.query.sqm.mutation.spi.SqmMultiTableInsertStrategy;
 import org.hibernate.query.sqm.mutation.spi.SqmMultiTableMutationStrategy;
-import org.hibernate.query.sqm.tree.SqmDeleteOrUpdateStatement;
-import org.hibernate.query.sqm.tree.insert.SqmInsertStatement;
 import org.hibernate.sql.ast.SqlAstTranslatorFactory;
 import org.hibernate.sql.ast.spi.StandardSqlAstTranslatorFactory;
 import org.hibernate.sql.exec.spi.JdbcParameterBindings;
@@ -75,6 +72,7 @@ import org.springframework.util.CollectionUtils;
  * @author Christoph Strobl
  * @author Mark Paluch
  * @author Oliver Drotbohm
+ * @author Oscar Fanchin
  * @since 4.0
  */
 class AotMetamodel implements Metamodel {
@@ -203,7 +201,11 @@ class AotMetamodel implements Metamodel {
 	@SuppressWarnings("deprecation")
 	static class SpringDataJpaAotDialect extends Dialect {
 
-		static SpringDataJpaAotDialect INSTANCE = new SpringDataJpaAotDialect();
+		static SpringDataJpaAotDialect INSTANCE = new SpringDataJpaAotDialect(DatabaseVersion.make(1, 0));
+
+		protected SpringDataJpaAotDialect(DatabaseVersion version) {
+			super(version);
+		}
 
 		public boolean isCurrentTimestampSelectStringCallable() {
 			return false;
@@ -241,13 +243,13 @@ class AotMetamodel implements Metamodel {
 		@Override
 		public SqmMultiTableInsertStrategy getFallbackSqmInsertStrategy(EntityMappingType entityDescriptor,
 				RuntimeModelCreationContext runtimeModelCreationContext) {
-			return new FallbackSqmMultiTableInsertStrategy();
+			return FallbackSqmMultiTableInsertStrategy.INSTANCE;
 		}
 
 		@Override
 		public SqmMultiTableMutationStrategy getFallbackSqmMutationStrategy(EntityMappingType entityDescriptor,
 				RuntimeModelCreationContext runtimeModelCreationContext) {
-			return new FallbackSqmMultiTableMutationStrategy();
+			return FallbackSqmMultiTableMutationStrategy.INSTANCE;
 		}
 
 		/**
@@ -278,27 +280,51 @@ class AotMetamodel implements Metamodel {
 		/**
 		 * Fallback {@link SqmMultiTableInsertStrategy} for AOT when no dialect-specific strategy is used.
 		 */
-		static class FallbackSqmMultiTableInsertStrategy implements SqmMultiTableInsertStrategy {
+		static class FallbackSqmMultiTableInsertStrategy {
 
-			@Override
-			public MultiTableHandlerBuildResult buildHandler(SqmInsertStatement<?> sqmInsertStatement,
-					DomainParameterXref domainParameterXref, DomainQueryExecutionContext context) {
-				return new MultiTableHandlerBuildResult(EmptyMultiTableHandler.INSTANCE, JdbcParameterBindings.NO_BINDINGS);
+			private static final SqmMultiTableInsertStrategy INSTANCE = createStrategy();
+
+			private static SqmMultiTableInsertStrategy createStrategy() {
+				return (SqmMultiTableInsertStrategy) Proxy.newProxyInstance(AotMetamodel.class.getClassLoader(),
+						new Class[] { SqmMultiTableInsertStrategy.class }, (proxy, method, args) -> {
+
+							if (method.getName().equals("buildHandler")) {
+								return new MultiTableHandlerBuildResult(EmptyMultiTableHandler.INSTANCE,
+										JdbcParameterBindings.NO_BINDINGS);
+							}
+
+							if (method.getReturnType().isPrimitive()) {
+								return ReflectionUtils.getPrimitiveDefault(method.getReturnType());
+							}
+
+							return null;
+						});
 			}
-
 		}
 
 		/**
 		 * Fallback {@link SqmMultiTableMutationStrategy} for AOT when no dialect-specific strategy is used.
 		 */
-		static class FallbackSqmMultiTableMutationStrategy implements SqmMultiTableMutationStrategy {
+		static class FallbackSqmMultiTableMutationStrategy {
 
-			@Override
-			public MultiTableHandlerBuildResult buildHandler(SqmDeleteOrUpdateStatement<?> sqmStatement,
-					DomainParameterXref domainParameterXref, DomainQueryExecutionContext context) {
-				return new MultiTableHandlerBuildResult(EmptyMultiTableHandler.INSTANCE, JdbcParameterBindings.NO_BINDINGS);
+			private static final SqmMultiTableMutationStrategy INSTANCE = createStrategy();
+
+			private static SqmMultiTableMutationStrategy createStrategy() {
+				return (SqmMultiTableMutationStrategy) Proxy.newProxyInstance(AotMetamodel.class.getClassLoader(),
+						new Class[] { SqmMultiTableMutationStrategy.class }, (proxy, method, args) -> {
+
+							if (method.getName().equals("buildHandler")) {
+								return new MultiTableHandlerBuildResult(EmptyMultiTableHandler.INSTANCE,
+										JdbcParameterBindings.NO_BINDINGS);
+							}
+
+							if (method.getReturnType().isPrimitive()) {
+								return ReflectionUtils.getPrimitiveDefault(method.getReturnType());
+							}
+
+							return null;
+						});
 			}
-
 		}
 
 	}

--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/aot/AotMetamodel.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/aot/AotMetamodel.java
@@ -91,7 +91,7 @@ class AotMetamodel implements Metamodel {
 			SchemaToolingSettings.JAKARTA_HBM2DDL_DATABASE_ACTION, "none" // has also precedence over HBM2DDL_AUTO
 	);
 	private final Lazy<EntityManagerFactory> entityManagerFactory;
-	private final Lazy<EntityManager> entityManager = Lazy.of(() -> getEntityManagerFactory().createEntityManager());
+	private final Lazy<EntityManager> entityManager = Lazy.of(() -> getEntityManagerFactory().createEntityManager(Map.of()));
 
 	public AotMetamodel(PersistenceManagedTypes managedTypes, Map<String, Object> jpaProperties) {
 		this(managedTypes.getManagedClassNames(), managedTypes.getPersistenceUnitRootUrl(), jpaProperties);

--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/aot/AotMetamodel.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/aot/AotMetamodel.java
@@ -103,6 +103,7 @@ class AotMetamodel implements Metamodel {
 				managedTypes.getClass().getClassLoader());
 		persistenceUnitInfo.setPersistenceUnitName("AotMetamodel");
 		persistenceUnitInfo.setPersistenceUnitRootUrl(persistenceUnitRootUrl);
+		persistenceUnitInfo.setExcludeUnlistedClasses(true);
 
 		this.entityManagerFactory = init(() -> {
 

--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/aot/JpaCodeBlocks.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/aot/JpaCodeBlocks.java
@@ -49,6 +49,7 @@ import org.springframework.data.jpa.repository.query.DeclaredQuery;
 import org.springframework.data.jpa.repository.query.JpaQueryMethod;
 import org.springframework.data.jpa.repository.query.ParameterBinding;
 import org.springframework.data.jpa.repository.support.JpqlQueryTemplates;
+import org.springframework.data.jpa.util.JpaPortableQueries;
 import org.springframework.data.repository.aot.generate.AotQueryMethodGenerationContext;
 import org.springframework.data.repository.aot.generate.MethodReturn;
 import org.springframework.data.support.PageableExecutionUtils;
@@ -466,8 +467,8 @@ class JpaCodeBlocks {
 					return builder.build();
 				}
 
-				builder.addStatement("$T $L = this.$L.createNamedQuery($S)", Query.class, queryVariableName,
-						context.fieldNameOf(EntityManager.class), nq.getQueryName());
+				builder.addStatement("$T $L = $T.createNamedQuery(this.$L, $S)", Query.class, queryVariableName,
+						JpaPortableQueries.class, context.fieldNameOf(EntityManager.class), nq.getQueryName());
 
 				return builder.build();
 			}
@@ -490,8 +491,9 @@ class JpaCodeBlocks {
 
 			if (StringUtils.hasText(sqlResultSetMapping)) {
 
-				builder.addStatement("$T $L = this.$L.createNativeQuery($L, $S)", Query.class, queryVariableName,
-						context.fieldNameOf(EntityManager.class), queryStringNameToUse, sqlResultSetMapping);
+				builder.addStatement("$T $L = $T.createNativeQuery(this.$L, $L, $S)", Query.class, queryVariableName,
+						JpaPortableQueries.class, context.fieldNameOf(EntityManager.class), queryStringNameToUse,
+						sqlResultSetMapping);
 
 				return builder.build();
 			}
@@ -500,19 +502,20 @@ class JpaCodeBlocks {
 
 				if (queryReturnType != null) {
 
-					builder.addStatement("$T $L = this.$L.createNativeQuery($L, $T.class)", Query.class, queryVariableName,
-							context.fieldNameOf(EntityManager.class), queryStringNameToUse, queryReturnType);
+					builder.addStatement("$T $L = $T.createNativeQuery(this.$L, $L, $T.class)", Query.class,
+							queryVariableName, JpaPortableQueries.class, context.fieldNameOf(EntityManager.class),
+							queryStringNameToUse, queryReturnType);
 				} else {
-					builder.addStatement("$T $L = this.$L.createNativeQuery($L)", Query.class, queryVariableName,
-							context.fieldNameOf(EntityManager.class), queryStringNameToUse);
+					builder.addStatement("$T $L = $T.createNativeQuery(this.$L, $L)", Query.class, queryVariableName,
+							JpaPortableQueries.class, context.fieldNameOf(EntityManager.class), queryStringNameToUse);
 				}
 
 				return builder.build();
 			}
 
 			if (sq.hasConstructorExpressionOrDefaultProjection() && !count && methodReturn.isInterfaceProjection()) {
-				builder.addStatement("$T $L = this.$L.createQuery($L)", Query.class, queryVariableName,
-						context.fieldNameOf(EntityManager.class), queryStringNameToUse);
+				builder.addStatement("$T $L = $T.createQuery(this.$L, $L)", Query.class, queryVariableName,
+						JpaPortableQueries.class, context.fieldNameOf(EntityManager.class), queryStringNameToUse);
 			} else {
 
 				String createQueryMethod = query.isNative() ? "createNativeQuery" : "createQuery";
@@ -521,8 +524,8 @@ class JpaCodeBlocks {
 					builder.addStatement("$T $L = this.$L.$L($L, $T.class)", Query.class, queryVariableName,
 							context.fieldNameOf(EntityManager.class), createQueryMethod, queryStringNameToUse, Tuple.class);
 				} else {
-					builder.addStatement("$T $L = this.$L.$L($L)", Query.class, queryVariableName,
-							context.fieldNameOf(EntityManager.class), createQueryMethod, queryStringNameToUse);
+					builder.addStatement("$T $L = $T.createQuery(this.$L, $L)", Query.class, queryVariableName,
+							JpaPortableQueries.class, context.fieldNameOf(EntityManager.class), queryStringNameToUse);
 				}
 			}
 

--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/aot/QueriesFactory.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/aot/QueriesFactory.java
@@ -28,6 +28,8 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Properties;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.BiConsumer;
 import java.util.function.Function;
 import java.util.function.UnaryOperator;
 
@@ -50,7 +52,9 @@ import org.springframework.data.repository.core.RepositoryInformation;
 import org.springframework.data.repository.core.support.PropertiesBasedNamedQueries;
 import org.springframework.data.repository.query.ReturnedType;
 import org.springframework.data.repository.query.parser.PartTree;
+import org.springframework.orm.jpa.EntityManagerFactoryInfo;
 import org.springframework.util.Assert;
+import org.springframework.util.ReflectionUtils;
 import org.springframework.util.StringUtils;
 
 /**
@@ -59,11 +63,13 @@ import org.springframework.util.StringUtils;
  *
  * @author Mark Paluch
  * @author Christoph Strobl
+ * @author Oscar Fanchin
  * @since 4.0
  */
 class QueriesFactory {
 
 	private final EntityManagerFactory entityManagerFactory;
+	private final @Nullable Hibernate8NamedQueryLookup hibernate8NamedQueryLookup;
 	private final NamedQueries namedQueries;
 	private final Metamodel metamodel;
 	private final EscapeCharacter escapeCharacter;
@@ -80,6 +86,7 @@ class QueriesFactory {
 		this.metamodel = metamodel;
 		this.namedQueries = getNamedQueries(configurationSource, classLoader);
 		this.entityManagerFactory = entityManagerFactory;
+		this.hibernate8NamedQueryLookup = Hibernate8NamedQueryLookup.create(entityManagerFactory);
 
 		Optional<Character> escapeCharacter = configurationSource.getAttribute("escapeCharacter", Character.class);
 		this.escapeCharacter = escapeCharacter.map(EscapeCharacter::of).orElse(EscapeCharacter.DEFAULT);
@@ -254,6 +261,11 @@ class QueriesFactory {
 
 		for (Class<?> candidate : candidates) {
 
+			// Hibernate 8 rejects a null result type, the untyped lookup below covers that case instead.
+			if (candidate == null && hibernate8NamedQueryLookup != null) {
+				continue;
+			}
+
 			Map<String, ? extends TypedQueryReference<?>> namedQueries = entityManagerFactory.getNamedQueries(candidate);
 
 			if (namedQueries.containsKey(queryName)) {
@@ -261,7 +273,73 @@ class QueriesFactory {
 			}
 		}
 
-		return null;
+		return hibernate8NamedQueryLookup != null ? hibernate8NamedQueryLookup.findNamedQuery(queryName) : null;
+	}
+
+	/**
+	 * Work around Hibernate 8 not exposing untyped named queries through
+	 * {@link EntityManagerFactory#getNamedQueries(Class)}: {@literal null} throws and {@link Object} returns nothing.
+	 * The chain stays reflective because Hibernate 8 relocated {@code NamedObjectRepository}. See GH-4197.
+	 */
+	private static class Hibernate8NamedQueryLookup {
+
+		private final Object namedObjectRepository;
+		private final Method forEachNamedQuery;
+
+		private Hibernate8NamedQueryLookup(Object namedObjectRepository, Method forEachNamedQuery) {
+			this.namedObjectRepository = namedObjectRepository;
+			this.forEachNamedQuery = forEachNamedQuery;
+		}
+
+		static @Nullable Hibernate8NamedQueryLookup create(EntityManagerFactory entityManagerFactory) {
+
+			Object nativeEntityManagerFactory = entityManagerFactory instanceof EntityManagerFactoryInfo info
+					? info.getNativeEntityManagerFactory()
+					: entityManagerFactory;
+			Method getQueryEngine = ReflectionUtils.findMethod(nativeEntityManagerFactory.getClass(), "getQueryEngine");
+
+			if (getQueryEngine == null) {
+				return null;
+			}
+
+			Object queryEngine = ReflectionUtils.invokeMethod(getQueryEngine, nativeEntityManagerFactory);
+
+			if (queryEngine == null) {
+				return null;
+			}
+
+			Method getNamedObjectRepository = ReflectionUtils.findMethod(queryEngine.getClass(), "getNamedObjectRepository");
+
+			if (getNamedObjectRepository == null) {
+				return null;
+			}
+
+			Object namedObjectRepository = ReflectionUtils.invokeMethod(getNamedObjectRepository, queryEngine);
+
+			if (namedObjectRepository == null) {
+				return null;
+			}
+
+			Method forEachNamedQuery = ReflectionUtils.findMethod(namedObjectRepository.getClass(), "forEachNamedQuery",
+					BiConsumer.class);
+
+			return forEachNamedQuery != null ? new Hibernate8NamedQueryLookup(namedObjectRepository, forEachNamedQuery) : null;
+		}
+
+		@Nullable TypedQueryReference<?> findNamedQuery(String queryName) {
+
+			AtomicReference<TypedQueryReference<?>> result = new AtomicReference<>();
+
+			BiConsumer<String, TypedQueryReference<?>> consumer = (name, reference) -> {
+				if (queryName.equals(name)) {
+					result.set(reference);
+				}
+			};
+
+			ReflectionUtils.invokeMethod(forEachNamedQuery, namedObjectRepository, consumer);
+
+			return result.get();
+		}
 	}
 
 	private AotQueries buildPartTreeQuery(RepositoryInformation repositoryInformation, ReturnedType returnedType,

--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/AbstractStringBasedJpaQuery.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/AbstractStringBasedJpaQuery.java
@@ -29,6 +29,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.expression.ValueEvaluationContextProvider;
 import org.springframework.data.jpa.repository.QueryRewriter;
+import org.springframework.data.jpa.util.JpaPortableQueries;
 import org.springframework.data.repository.query.QueryCreationException;
 import org.springframework.data.repository.query.ResultProcessor;
 import org.springframework.data.repository.query.ReturnedType;
@@ -207,7 +208,7 @@ abstract class AbstractStringBasedJpaQuery extends AbstractJpaQuery {
 		String queryStringToUse = potentiallyRewriteQuery(queryString, accessor.getSort(), accessor.getPageable());
 
 		Query query = getQueryMethod().isNativeQuery() //
-				? em.createNativeQuery(queryStringToUse) //
+				? JpaPortableQueries.createNativeQuery(em, queryStringToUse) //
 				: em.createQuery(queryStringToUse, Long.class);
 
 		countParameterBinder.get().bind(new QueryParameterSetter.BindableQuery(query), accessor,
@@ -241,13 +242,13 @@ abstract class AbstractStringBasedJpaQuery extends AbstractJpaQuery {
 		String queryToUse = potentiallyRewriteQuery(query.getQueryString(), sort, pageable);
 
 		if (this.query.hasConstructorExpression() || this.query.isDefaultProjection()) {
-			return em.createQuery(queryToUse);
+			return JpaPortableQueries.createQuery(em, queryToUse);
 		}
 
 		Class<?> typeToRead = getTypeToRead(returnedType);
 
 		return typeToRead == null //
-				? em.createQuery(queryToUse) //
+				? JpaPortableQueries.createQuery(em, queryToUse) //
 				: em.createQuery(queryToUse, typeToRead);
 	}
 

--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/JpaQueryExecution.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/JpaQueryExecution.java
@@ -69,6 +69,7 @@ import org.springframework.util.ReflectionUtils;
  * @author Jens Schauder
  * @author Gabriel Basilio
  * @author Greg Turnquist
+ * @author Oscar Fanchin
  */
 public abstract class JpaQueryExecution {
 
@@ -493,9 +494,12 @@ public abstract class JpaQueryExecution {
 				return query.extractOutputValue(procedure);
 			} finally {
 
-				if (procedure instanceof AutoCloseable ac) {
+				// StoredProcedureQuery extends AutoCloseable in JPA 4, but not in JPA 3.2. Keep the plain instanceof
+				// check: with JPA 4 on the compile classpath AJC rejects a pattern whose type the expression already
+				// implements ("Expression type cannot be a subtype of the Pattern type").
+				if (procedure instanceof AutoCloseable) {
 					try {
-						ac.close();
+						((AutoCloseable) procedure).close();
 					} catch (Exception ignored) {}
 				}
 			}

--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/JpaQueryLookupStrategy.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/JpaQueryLookupStrategy.java
@@ -24,6 +24,7 @@ import org.apache.commons.logging.LogFactory;
 import org.jspecify.annotations.Nullable;
 
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.jpa.util.JpaPortableQueries;
 import org.springframework.data.projection.ProjectionFactory;
 import org.springframework.data.repository.core.NamedQueries;
 import org.springframework.data.repository.core.RepositoryMetadata;
@@ -209,7 +210,7 @@ public final class JpaQueryLookupStrategy {
 			boolean namedQuery = NamedQuery.hasNamedQuery(em, queryName);
 
 			if (namedQuery) {
-				return method.getQueryExtractor().extractQueryString(em.createNamedQuery(queryName));
+				return method.getQueryExtractor().extractQueryString(JpaPortableQueries.createNamedQuery(em, queryName));
 			}
 
 			if (method.hasAnnotatedCountQueryName()) {

--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/KeysetScrollSpecification.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/KeysetScrollSpecification.java
@@ -132,12 +132,12 @@ public record KeysetScrollSpecification<T>(KeysetScrollPosition position, Sort s
 
 		@Override
 		public Predicate and(List<Predicate> intermediate) {
-			return cb.and(intermediate.toArray(new Predicate[0]));
+			return cb.and(intermediate);
 		}
 
 		@Override
 		public Predicate or(List<Predicate> intermediate) {
-			return cb.or(intermediate.toArray(new Predicate[0]));
+			return cb.or(intermediate);
 		}
 	}
 

--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/NamedQuery.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/NamedQuery.java
@@ -20,6 +20,8 @@ import jakarta.persistence.Query;
 import jakarta.persistence.Tuple;
 import jakarta.persistence.TypedQuery;
 
+import java.util.Map;
+
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.jspecify.annotations.Nullable;
@@ -34,6 +36,7 @@ import org.springframework.data.repository.query.RepositoryQuery;
 import org.springframework.data.repository.query.ResultProcessor;
 import org.springframework.data.repository.query.ReturnedType;
 import org.springframework.data.util.Lazy;
+import org.springframework.data.jpa.util.JpaPortableQueries;
 import org.springframework.util.StringUtils;
 
 /**
@@ -82,7 +85,7 @@ final class NamedQuery extends AbstractJpaQuery {
 
 		this.namedCountQueryIsPresent = hasNamedQuery(em, countQueryName);
 
-		Query namedQuery = em.createNamedQuery(queryName);
+		Query namedQuery = JpaPortableQueries.createNamedQuery(em, queryName);
 		boolean weNeedToCreateCountQuery = !namedCountQueryIsPresent && method.getParameters().hasLimitingParameters();
 		boolean cantExtractQuery = !extractor.canExtractQuery();
 
@@ -139,8 +142,8 @@ final class NamedQuery extends AbstractJpaQuery {
 		 * potential rollback of the running tx.
 		 */
 
-		try (EntityManager lookupEm = em.getEntityManagerFactory().createEntityManager()) {
-			lookupEm.createNamedQuery(queryName);
+		try (EntityManager lookupEm = em.getEntityManagerFactory().createEntityManager(Map.of())) {
+			JpaPortableQueries.createNamedQuery(lookupEm, queryName);
 			return true;
 		} catch (IllegalArgumentException e) {
 
@@ -206,7 +209,7 @@ final class NamedQuery extends AbstractJpaQuery {
 		Class<?> typeToRead = getTypeToRead(processor.getReturnedType());
 
 		Query query = typeToRead == null //
-				? em.createNamedQuery(queryName) //
+				? JpaPortableQueries.createNamedQuery(em, queryName) //
 				: em.createNamedQuery(queryName, typeToRead);
 
 		return parameterBinder.get().bindAndPrepare(query, accessor);

--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/NativeJpaQuery.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/NativeJpaQuery.java
@@ -26,6 +26,7 @@ import org.springframework.core.annotation.MergedAnnotations;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.jpa.repository.NativeQuery;
+import org.springframework.data.jpa.util.JpaPortableQueries;
 import org.springframework.data.repository.query.RepositoryQuery;
 import org.springframework.data.repository.query.ReturnedType;
 import org.springframework.util.ObjectUtils;
@@ -97,11 +98,12 @@ class NativeJpaQuery extends AbstractStringBasedJpaQuery {
 		String query = potentiallyRewriteQuery(declaredQuery.getQueryString(), sort, pageable);
 
 		if (!ObjectUtils.isEmpty(sqlResultSetMapping)) {
-			return em.createNativeQuery(query, sqlResultSetMapping);
+			return JpaPortableQueries.createNativeQuery(em, query, sqlResultSetMapping);
 		}
 
 		Class<?> type = getTypeToQueryFor(returnedType);
-		return type == null ? em.createNativeQuery(query) : em.createNativeQuery(query, type);
+		return type == null ? JpaPortableQueries.createNativeQuery(em, query)
+				: JpaPortableQueries.createNativeQuery(em, query, type);
 	}
 
 	private @Nullable Class<?> getTypeToQueryFor(ReturnedType returnedType) {

--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/PartTreeJpaQuery.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/PartTreeJpaQuery.java
@@ -58,6 +58,7 @@ import org.springframework.util.Assert;
  * @author Jens Schauder
  * @author Mark Paluch
  * @author Сергей Цыпанов
+ * @author Oscar Fanchin
  */
 public class PartTreeJpaQuery extends AbstractJpaQuery {
 
@@ -128,7 +129,10 @@ public class PartTreeJpaQuery extends AbstractJpaQuery {
 	@Override
 	@SuppressWarnings("unchecked")
 	public TypedQuery<Long> doCreateCountQuery(JpaParametersParameterAccessor accessor) {
-		return (TypedQuery<Long>) countQuery.createQuery(accessor);
+
+		Query query = countQuery.createQuery(accessor);
+
+		return query instanceof TypedQuery<?> typedQuery ? (TypedQuery<Long>) typedQuery : query.unwrap(TypedQuery.class);
 	}
 
 	@Override

--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/PartTreeJpaQuery.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/PartTreeJpaQuery.java
@@ -39,6 +39,7 @@ import org.springframework.data.jpa.repository.query.JpaQueryExecution.ScrollExe
 import org.springframework.data.jpa.repository.support.JpaEntityInformation;
 import org.springframework.data.jpa.repository.support.JpaEntityInformationSupport;
 import org.springframework.data.jpa.repository.support.JpqlQueryTemplates;
+import org.springframework.data.jpa.util.JpaPortableQueries;
 import org.springframework.data.repository.query.QueryCreationException;
 import org.springframework.data.repository.query.ResultProcessor;
 import org.springframework.data.repository.query.ReturnedType;
@@ -241,7 +242,7 @@ public class PartTreeJpaQuery extends AbstractJpaQuery {
 			}
 
 			try {
-				query = creator.useTupleQuery() ? em.createQuery(jpql, Tuple.class) : em.createQuery(jpql);
+				query = creator.useTupleQuery() ? em.createQuery(jpql, Tuple.class) : JpaPortableQueries.createQuery(em, jpql);
 			} catch (Exception e) {
 				throw new BadJpqlGrammarException(e.getMessage(), jpql, e);
 			}

--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/QueryUtils.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/QueryUtils.java
@@ -55,6 +55,7 @@ import org.springframework.data.domain.Sort;
 import org.springframework.data.domain.Sort.Order;
 import org.springframework.data.jpa.domain.JpaSort.JpaOrder;
 import org.springframework.data.jpa.provider.PersistenceProvider;
+import org.springframework.data.jpa.util.JpaPortableQueries;
 import org.springframework.data.util.Streamable;
 import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
@@ -542,13 +543,14 @@ public abstract class QueryUtils {
 		Iterator<T> iterator = entities.iterator();
 
 		if (!iterator.hasNext()) {
-			return entityManager.createQuery(queryString);
+			return JpaPortableQueries.createQuery(entityManager, queryString);
 		}
 
 		if (persistenceProvider == PersistenceProvider.HIBERNATE) {
 
 			String alias = detectAlias(queryString);
-			Query query = entityManager.createQuery("%s where %s IN (?1)".formatted(queryString, alias));
+			Query query = JpaPortableQueries.createQuery(entityManager,
+					"%s where %s IN (?1)".formatted(queryString, alias));
 			query.setParameter(1, entities instanceof Collection<T> ? entities : Streamable.of(entities).toList());
 
 			return query;
@@ -577,7 +579,7 @@ public abstract class QueryUtils {
 			}
 		}
 
-		Query query = entityManager.createQuery(builder.toString());
+		Query query = JpaPortableQueries.createQuery(entityManager, builder.toString());
 
 		iterator = entities.iterator();
 		i = 0;

--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/SimpleJpaQuery.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/SimpleJpaQuery.java
@@ -18,8 +18,11 @@ package org.springframework.data.jpa.repository.query;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.Query;
 
+import java.util.Map;
+
 import org.jspecify.annotations.Nullable;
 
+import org.springframework.data.jpa.util.JpaPortableQueries;
 import org.springframework.data.repository.query.QueryCreationException;
 import org.springframework.data.repository.query.RepositoryQuery;
 
@@ -69,8 +72,8 @@ class SimpleJpaQuery extends AbstractStringBasedJpaQuery {
 		}
 
 		String queryString = query.getQueryString();
-		try (EntityManager validatingEm = getEntityManager().getEntityManagerFactory().createEntityManager()) {
-			validatingEm.createQuery(queryString);
+		try (EntityManager validatingEm = getEntityManager().getEntityManagerFactory().createEntityManager(Map.of())) {
+			JpaPortableQueries.createQuery(validatingEm, queryString);
 		} catch (RuntimeException e) {
 
 			// Needed as there's ambiguities in how an invalid query string shall be expressed by the persistence provider

--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/support/SimpleJpaRepository.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/support/SimpleJpaRepository.java
@@ -68,6 +68,7 @@ import org.springframework.data.jpa.repository.support.FetchableFluentQueryBySpe
 import org.springframework.data.jpa.repository.support.FluentQuerySupport.ScrollQueryFactory;
 import org.springframework.data.jpa.repository.support.QueryHints.NoHints;
 import org.springframework.data.jpa.support.PageableUtils;
+import org.springframework.data.jpa.util.JpaPortableQueries;
 import org.springframework.data.projection.ProjectionFactory;
 import org.springframework.data.projection.SpelAwareProxyProjectionFactory;
 import org.springframework.data.repository.query.FluentQuery;
@@ -265,7 +266,7 @@ public class SimpleJpaRepository<T, ID> implements JpaRepositoryImplementation<T
 			String queryString = String.format(DELETE_ALL_QUERY_BY_ID_STRING, entityInformation.getEntityName(),
 					entityInformation.getRequiredIdAttribute().getName());
 
-			Query query = entityManager.createQuery(queryString);
+			Query query = JpaPortableQueries.createQuery(entityManager, queryString);
 
 			/*
 			 * Some JPA providers require {@code ids} to be a {@link Collection} so we must convert if it's not already.
@@ -317,7 +318,7 @@ public class SimpleJpaRepository<T, ID> implements JpaRepositoryImplementation<T
 	@Transactional
 	public void deleteAllInBatch() {
 
-		Query query = entityManager.createQuery(deleteAllQueryString.get());
+		Query query = JpaPortableQueries.createQuery(entityManager, deleteAllQueryString.get());
 
 		applyQueryHints(query);
 
@@ -496,7 +497,7 @@ public class SimpleJpaRepository<T, ID> implements JpaRepositoryImplementation<T
 
 		applySpecificationToCriteria(spec, getDomainClass(), cq);
 
-		TypedQuery<Integer> query = applyRepositoryMethodMetadata(this.entityManager.createQuery(cq));
+		TypedQuery<Integer> query = applyRepositoryMethodMetadata(JpaPortableQueries.createQuery(this.entityManager, cq));
 		return ExistsUtil.exists(query.setMaxResults(1).getResultList().size());
 	}
 
@@ -600,7 +601,7 @@ public class SimpleJpaRepository<T, ID> implements JpaRepositoryImplementation<T
 
 		applySpecificationToCriteria(spec, example.getProbeType(), cq);
 
-		TypedQuery<Integer> query = applyRepositoryMethodMetadata(this.entityManager.createQuery(cq));
+		TypedQuery<Integer> query = applyRepositoryMethodMetadata(JpaPortableQueries.createQuery(this.entityManager, cq));
 		return ExistsUtil.exists(query.setMaxResults(1).getResultList().size());
 	}
 
@@ -867,7 +868,7 @@ public class SimpleJpaRepository<T, ID> implements JpaRepositoryImplementation<T
 			query.orderBy(toOrders(sort, root, builder));
 		}
 
-		return applyRepositoryMethodMetadata(entityManager.createQuery(query));
+		return applyRepositoryMethodMetadata(JpaPortableQueries.createQuery(entityManager, query));
 	}
 
 	/**
@@ -885,7 +886,7 @@ public class SimpleJpaRepository<T, ID> implements JpaRepositoryImplementation<T
 
 		applySpecificationToCriteria(spec, domainClass, query);
 
-		return applyRepositoryMethodMetadata(entityManager.createQuery(query));
+		return applyRepositoryMethodMetadata(JpaPortableQueries.createQuery(entityManager, query));
 	}
 
 	/**
@@ -903,7 +904,7 @@ public class SimpleJpaRepository<T, ID> implements JpaRepositoryImplementation<T
 
 		applySpecificationToCriteria(spec, domainClass, query);
 
-		return applyRepositoryMethodMetadata(entityManager.createQuery(query));
+		return applyRepositoryMethodMetadata(JpaPortableQueries.createQuery(entityManager, query));
 	}
 
 	/**
@@ -941,7 +942,7 @@ public class SimpleJpaRepository<T, ID> implements JpaRepositoryImplementation<T
 		// Remove all Orders the Specifications might have applied
 		query.orderBy(Collections.emptyList());
 
-		return applyRepositoryMethodMetadataForCount(entityManager.createQuery(query));
+		return applyRepositoryMethodMetadataForCount(JpaPortableQueries.createQuery(entityManager, query));
 	}
 
 	/**

--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/support/SpringDataJpaQuery.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/support/SpringDataJpaQuery.java
@@ -31,6 +31,8 @@ import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAUtil;
 import org.jspecify.annotations.Nullable;
 
+import org.springframework.data.jpa.util.JpaPortableQueries;
+
 /**
  * Customized String-Query implementation that specifically routes tuple query creation to
  * {@code EntityManager#createQuery(queryString, Tuple.class)}.
@@ -56,7 +58,7 @@ class SpringDataJpaQuery<T> extends JPAQuery<T> {
 
 		Query query = getMetadata().getProjection() instanceof JakartaTuple
 				? entityManager.createQuery(queryString, Tuple.class)
-				: entityManager.createQuery(queryString);
+				: JpaPortableQueries.createQuery(entityManager, queryString);
 
 		JPAUtil.setConstants(query, serializer.getConstants(), getMetadata().getParams());
 		if (modifiers != null && modifiers.isRestricting()) {

--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/util/JpaPortableQueries.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/util/JpaPortableQueries.java
@@ -1,0 +1,178 @@
+/*
+ * Copyright 2026-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.jpa.util;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.Query;
+import jakarta.persistence.TypedQuery;
+import jakarta.persistence.criteria.CriteriaDelete;
+import jakarta.persistence.criteria.CriteriaQuery;
+import jakarta.persistence.criteria.CriteriaSelect;
+import jakarta.persistence.criteria.CriteriaUpdate;
+
+import java.lang.reflect.Method;
+
+import org.springframework.util.Assert;
+import org.springframework.util.ReflectionUtils;
+
+/**
+ * Creates {@link Query queries} from an {@link EntityManager} in a way that stays binary-compatible across Jakarta
+ * Persistence API generations.
+ * <p>
+ * Jakarta Persistence 4 changes the return type of the untyped query factory methods, so code compiled against 3.2
+ * fails with a {@link NoSuchMethodError} when running against 4. Only that case pays for reflection. See GH-4197.
+ *
+ * @author Oscar Fanchin
+ * @since 4.2
+ */
+public abstract class JpaPortableQueries {
+
+	private static final Method CREATE_QUERY = resolveMethod("createQuery", String.class);
+	private static final Method CREATE_NAMED_QUERY = resolveMethod("createNamedQuery", String.class);
+	private static final Method CREATE_NATIVE_QUERY = resolveMethod("createNativeQuery", String.class);
+	private static final Method CREATE_NATIVE_QUERY_WITH_TYPE = resolveMethod("createNativeQuery", String.class,
+			Class.class);
+	private static final Method CREATE_NATIVE_QUERY_WITH_MAPPING = resolveMethod("createNativeQuery", String.class,
+			String.class);
+	private static final Method CREATE_UPDATE_QUERY = resolveCriteriaQueryMethod(CriteriaUpdate.class);
+	private static final Method CREATE_DELETE_QUERY = resolveCriteriaQueryMethod(CriteriaDelete.class);
+
+	// Method references are resolved on first execution, so the direct calls below are never linked under JPA 4.
+	private static final boolean JPA_32 = CREATE_QUERY.getReturnType() == Query.class;
+
+	private JpaPortableQueries() {}
+
+	/**
+	 * Create an untyped query using the runtime Jakarta Persistence API.
+	 */
+	public static Query createQuery(EntityManager entityManager, String queryString) {
+
+		Assert.notNull(entityManager, "EntityManager must not be null");
+
+		return JPA_32 //
+				? entityManager.createQuery(queryString) //
+				: (Query) ReflectionUtils.invokeMethod(CREATE_QUERY, entityManager, queryString);
+	}
+
+	/**
+	 * Create an untyped named query using the runtime Jakarta Persistence API.
+	 */
+	public static Query createNamedQuery(EntityManager entityManager, String queryName) {
+
+		Assert.notNull(entityManager, "EntityManager must not be null");
+
+		return JPA_32 //
+				? entityManager.createNamedQuery(queryName) //
+				: (Query) ReflectionUtils.invokeMethod(CREATE_NAMED_QUERY, entityManager, queryName);
+	}
+
+	/**
+	 * Create an untyped native query using the runtime Jakarta Persistence API.
+	 */
+	public static Query createNativeQuery(EntityManager entityManager, String queryString) {
+
+		Assert.notNull(entityManager, "EntityManager must not be null");
+
+		return JPA_32 //
+				? entityManager.createNativeQuery(queryString) //
+				: (Query) ReflectionUtils.invokeMethod(CREATE_NATIVE_QUERY, entityManager, queryString);
+	}
+
+	/**
+	 * Create a native query for the given result type using the runtime Jakarta Persistence API.
+	 */
+	public static Query createNativeQuery(EntityManager entityManager, String queryString, Class<?> resultClass) {
+
+		Assert.notNull(entityManager, "EntityManager must not be null");
+
+		return JPA_32 //
+				? entityManager.createNativeQuery(queryString, resultClass) //
+				: (Query) ReflectionUtils.invokeMethod(CREATE_NATIVE_QUERY_WITH_TYPE, entityManager, queryString,
+						resultClass);
+	}
+
+	/**
+	 * Create a native query for the given SQL result set mapping using the runtime Jakarta Persistence API.
+	 */
+	public static Query createNativeQuery(EntityManager entityManager, String queryString, String resultSetMapping) {
+
+		Assert.notNull(entityManager, "EntityManager must not be null");
+
+		return JPA_32 //
+				? entityManager.createNativeQuery(queryString, resultSetMapping) //
+				: (Query) ReflectionUtils.invokeMethod(CREATE_NATIVE_QUERY_WITH_MAPPING, entityManager, queryString,
+						resultSetMapping);
+	}
+
+	/**
+	 * Create a typed query through the {@link CriteriaSelect} overload common to Jakarta Persistence API generations.
+	 */
+	public static <T> TypedQuery<T> createQuery(EntityManager entityManager, CriteriaQuery<T> criteriaQuery) {
+
+		Assert.notNull(entityManager, "EntityManager must not be null");
+		Assert.notNull(criteriaQuery, "CriteriaQuery must not be null");
+
+		return entityManager.createQuery((CriteriaSelect<T>) criteriaQuery);
+	}
+
+	/**
+	 * Create an update query using the runtime Jakarta Persistence API.
+	 */
+	public static Query createQuery(EntityManager entityManager, CriteriaUpdate<?> criteriaUpdate) {
+
+		Assert.notNull(entityManager, "EntityManager must not be null");
+		Assert.notNull(criteriaUpdate, "CriteriaUpdate must not be null");
+
+		return JPA_32 //
+				? entityManager.createQuery(criteriaUpdate) //
+				: (Query) ReflectionUtils.invokeMethod(CREATE_UPDATE_QUERY, entityManager, criteriaUpdate);
+	}
+
+	/**
+	 * Create a delete query using the runtime Jakarta Persistence API.
+	 */
+	public static Query createQuery(EntityManager entityManager, CriteriaDelete<?> criteriaDelete) {
+
+		Assert.notNull(entityManager, "EntityManager must not be null");
+		Assert.notNull(criteriaDelete, "CriteriaDelete must not be null");
+
+		return JPA_32 //
+				? entityManager.createQuery(criteriaDelete) //
+				: (Query) ReflectionUtils.invokeMethod(CREATE_DELETE_QUERY, entityManager, criteriaDelete);
+	}
+
+	private static Method resolveMethod(String methodName, Class<?>... parameterTypes) {
+
+		Method method = ReflectionUtils.findMethod(EntityManager.class, methodName, parameterTypes);
+
+		Assert.state(method != null, () -> "Cannot resolve EntityManager.%s".formatted(methodName));
+
+		return method;
+	}
+
+	private static Method resolveCriteriaQueryMethod(Class<?> criteriaType) {
+
+		for (Method method : EntityManager.class.getMethods()) {
+			if (method.getName().equals("createQuery") && method.getParameterCount() == 1
+					&& method.getParameterTypes()[0].isAssignableFrom(criteriaType)
+					&& Query.class.isAssignableFrom(method.getReturnType())) {
+				return method;
+			}
+		}
+
+		throw new IllegalStateException("Cannot resolve EntityManager.createQuery(%s)".formatted(criteriaType.getSimpleName()));
+	}
+}

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/convert/QueryByExamplePredicateBuilderUnitTests.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/convert/QueryByExamplePredicateBuilderUnitTests.java
@@ -36,6 +36,7 @@ import jakarta.persistence.metamodel.Type;
 
 import java.lang.reflect.Member;
 import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Set;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -131,8 +132,8 @@ class QueryByExamplePredicateBuilderUnitTests {
 
 		doReturn(expressionMock).when(cb).literal(any(Boolean.class));
 		doReturn(truePredicate).when(cb).isTrue(eq(expressionMock));
-		doReturn(andPredicate).when(cb).and(ArgumentMatchers.<Predicate[]> any());
-		doReturn(orPredicate).when(cb).or(ArgumentMatchers.<Predicate[]> any());
+		doReturn(andPredicate).when(cb).and(ArgumentMatchers.<List<Predicate>> any());
+		doReturn(orPredicate).when(cb).or(ArgumentMatchers.<List<Predicate>> any());
 	}
 
 	@Test // DATAJPA-218
@@ -177,7 +178,7 @@ class QueryByExamplePredicateBuilderUnitTests {
 		p.firstname = "foo";
 		p.age = 2L;
 
-		when(cb.and(any(Predicate[].class))).thenReturn(andPredicate);
+		when(cb.and(anyList())).thenReturn(andPredicate);
 
 		assertThat(QueryByExamplePredicateBuilder.getPredicate(root, cb, of(p), EscapeCharacter.DEFAULT))
 				.isEqualTo(andPredicate);
@@ -195,12 +196,12 @@ class QueryByExamplePredicateBuilderUnitTests {
 
 		Example<Person> example = of(person, ExampleMatcher.matchingAny());
 
-		when(cb.or(any(Predicate[].class))).thenReturn(orPredicate);
+		when(cb.or(anyList())).thenReturn(orPredicate);
 
 		assertThat(QueryByExamplePredicateBuilder.getPredicate(root, cb, example, EscapeCharacter.DEFAULT))
 				.isEqualTo(orPredicate);
 
-		verify(cb).or(ArgumentMatchers.any(Predicate[].class));
+		verify(cb).or(anyList());
 	}
 
 	@Test // DATAJPA-1372

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/criteria/ExpressionsTests.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/criteria/ExpressionsTests.java
@@ -38,6 +38,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.core.TypedPropertyPath;
 import org.springframework.data.jpa.domain.sample.Role;
 import org.springframework.data.jpa.domain.sample.User;
+import org.springframework.data.jpa.util.JpaPortableQueries;
 import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 
 /**
@@ -154,7 +155,7 @@ class ExpressionsTests {
 
 		QueryExpression<T, S> qe = new QueryExpression<>(from, callable.apply(from));
 
-		entityManager.createQuery(query); // validate the query
+		JpaPortableQueries.createQuery(entityManager, query); // validate the query
 		return qe;
 
 	}

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/infrastructure/MetamodelIntegrationTests.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/infrastructure/MetamodelIntegrationTests.java
@@ -38,6 +38,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import org.springframework.data.jpa.domain.sample.User;
+import org.springframework.data.jpa.util.JpaPortableQueries;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.transaction.annotation.Transactional;
@@ -77,7 +78,7 @@ abstract class MetamodelIntegrationTests {
 	@Test
 	void canAccessParametersByIndexForNativeQueries() {
 
-		Query query = em.createNativeQuery("SELECT u from User u where u.lastname = ?1");
+		Query query = JpaPortableQueries.createNativeQuery(em, "SELECT u from User u where u.lastname = ?1");
 
 		assertThat(query.getParameter(1)).isNotNull();
 	}

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/CrudMethodMetadataUnitTests.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/CrudMethodMetadataUnitTests.java
@@ -16,6 +16,7 @@
 package org.springframework.data.jpa.repository;
 
 import static org.mockito.Mockito.*;
+import static org.springframework.data.jpa.support.EntityManagerTestUtils.*;
 
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.EntityManagerFactory;
@@ -47,6 +48,7 @@ import org.springframework.data.jpa.repository.support.JpaRepositoryFactory;
  *
  * @author Oliver Gierke
  * @author Thomas Darimont
+ * @author Oscar Fanchin
  */
 @ExtendWith(MockitoExtension.class)
 @MockitoSettings(strictness = Strictness.LENIENT)
@@ -58,13 +60,15 @@ class CrudMethodMetadataUnitTests {
 	@Mock CriteriaQuery<Role> criteriaQuery;
 	@Mock JpaEntityInformation<Role, Integer> information;
 	@Mock TypedQuery<Role> typedQuery;
-	@Mock jakarta.persistence.Query query;
+	jakarta.persistence.Query query;
 	@Mock Metamodel metamodel;
 
 	private RoleRepository repository;
 
 	@BeforeEach
 	void setUp() {
+
+		query = mockQuery();
 
 		when(information.getJavaType()).thenReturn(Role.class);
 
@@ -113,7 +117,7 @@ class CrudMethodMetadataUnitTests {
 	void appliesLockModeAndQueryHintsToQuerydslQuery() {
 
 		when(em.getDelegate()).thenReturn(mock(EntityManager.class));
-		when(em.createQuery(anyString())).thenReturn(query);
+		doReturn(query).when(em).createQuery(anyString());
 
 		repository.findOne(QRole.role.name.eq("role"));
 

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/CrudMethodMetadataUnitTests.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/CrudMethodMetadataUnitTests.java
@@ -75,7 +75,7 @@ class CrudMethodMetadataUnitTests {
 		when(em.getMetamodel()).thenReturn(metamodel);
 		when(em.getDelegate()).thenReturn(em);
 		when(em.getEntityManagerFactory()).thenReturn(emf);
-		when(emf.createEntityManager()).thenReturn(em);
+		when(emf.createEntityManager(Map.of())).thenReturn(em);
 
 		JpaRepositoryFactory factory = new JpaRepositoryFactory(em) {
 			@Override
@@ -93,7 +93,7 @@ class CrudMethodMetadataUnitTests {
 
 		when(em.getCriteriaBuilder()).thenReturn(builder);
 		when(builder.createQuery(Role.class)).thenReturn(criteriaQuery);
-		when(em.createQuery(criteriaQuery)).thenReturn(typedQuery);
+		whenCreateQuery(em, criteriaQuery).thenReturn(typedQuery);
 		when(typedQuery.setLockMode(any(LockModeType.class))).thenReturn(typedQuery);
 
 		repository.findAll();
@@ -117,7 +117,7 @@ class CrudMethodMetadataUnitTests {
 	void appliesLockModeAndQueryHintsToQuerydslQuery() {
 
 		when(em.getDelegate()).thenReturn(mock(EntityManager.class));
-		doReturn(query).when(em).createQuery(anyString());
+		whenCreateQuery(em, anyString()).thenReturn(query);
 
 		repository.findOne(QRole.role.name.eq("role"));
 

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/EclipseLinkNamespaceUserRepositoryTests.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/EclipseLinkNamespaceUserRepositoryTests.java
@@ -23,6 +23,7 @@ import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.data.jpa.repository.sample.UserRepository;
+import org.springframework.data.jpa.util.JpaPortableQueries;
 import org.springframework.test.context.ContextConfiguration;
 
 /**
@@ -63,7 +64,8 @@ class EclipseLinkNamespaceUserRepositoryTests extends NamespaceUserRepositoryTes
 	@Test // DATAJPA-1172
 	void queryProvidesCorrectNumberOfParametersForNativeQuery() {
 
-		Query query = em.createNativeQuery("select 1 from User where firstname=? and lastname=?");
+		Query query = JpaPortableQueries.createNativeQuery(em,
+				"select 1 from User where firstname=? and lastname=?");
 		assertThat(query.getParameters()).describedAs(
 				"Due to a bug eclipse has size 0; If this is no longer the case the special code path triggered in NamedOrIndexedQueryParameterSetter.registerExcessParameters can be removed")
 				.isEmpty();

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/SimpleJpaParameterBindingTests.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/SimpleJpaParameterBindingTests.java
@@ -34,6 +34,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import org.springframework.data.jpa.domain.sample.User;
+import org.springframework.data.jpa.util.JpaPortableQueries;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.transaction.annotation.Transactional;
@@ -67,7 +68,7 @@ class SimpleJpaParameterBindingTests {
 		ParameterExpression<String[]> parameter = builder.parameter(String[].class);
 		criteria.where(root.get("firstname").in(parameter));
 
-		TypedQuery<User> query = em.createQuery(criteria);
+		TypedQuery<User> query = JpaPortableQueries.createQuery(em, criteria);
 		query.setParameter(parameter, new String[] { "Dave", "Carter" });
 
 		List<User> result = query.getResultList();
@@ -89,7 +90,7 @@ class SimpleJpaParameterBindingTests {
 		ParameterExpression<Collection> parameter = builder.parameter(Collection.class);
 		criteria.where(root.get("firstname").in(parameter));
 
-		TypedQuery<User> query = em.createQuery(criteria);
+		TypedQuery<User> query = JpaPortableQueries.createQuery(em, criteria);
 
 		query.setParameter(parameter, Arrays.asList("Dave"));
 

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/UserRepositoryTests.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/UserRepositoryTests.java
@@ -81,6 +81,7 @@ import org.springframework.data.jpa.repository.sample.UserRepository;
 import org.springframework.data.jpa.repository.sample.UserRepository.NameOnly;
 import org.springframework.data.jpa.repository.sample.Users;
 import org.springframework.data.jpa.util.DisabledOnHibernate;
+import org.springframework.data.jpa.util.JpaPortableQueries;
 import org.springframework.data.util.Streamable;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
@@ -150,7 +151,7 @@ class UserRepositoryTests {
 	@Test
 	void testCreation() {
 
-		Query countQuery = em.createQuery("select count(u) from User u");
+		Query countQuery = JpaPortableQueries.createQuery(em, "select count(u) from User u");
 		Long before = (Long) countQuery.getSingleResult();
 
 		flushTestUsers();
@@ -3307,7 +3308,8 @@ class UserRepositoryTests {
 	@Test // DATAJPA-1172
 	void queryProvidesCorrectNumberOfParametersForNativeQuery() {
 
-		Query query = em.createNativeQuery("select 1 from User where firstname=? and lastname=?");
+		Query query = JpaPortableQueries.createNativeQuery(em,
+				"select 1 from User where firstname=? and lastname=?");
 		assertThat(query.getParameters()).hasSize(2);
 	}
 
@@ -3624,7 +3626,8 @@ class UserRepositoryTests {
 
 		/*
 		TODO: Hibernate-generated HQL for the CriteriaBuilder-based API. Yields only one result in contrast to the CriteriaBuilder one.
-		Query query = em.createQuery("select alias_544097980 from org.springframework.data.jpa.domain.sample.User alias_544097980 left join alias_544097980.attributes alias_975381534 where alias_975381534 in (?1)")
+		Query query = JpaPortableQueries.createQuery(em,
+				"select alias_544097980 from org.springframework.data.jpa.domain.sample.User alias_544097980 left join alias_544097980.attributes alias_975381534 where alias_975381534 in (?1)")
 				.setParameter(1, asList("cOOl", "hIP"));
 
 		List resultList = query.getResultList();

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/UserRepositoryTests.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/UserRepositoryTests.java
@@ -110,6 +110,7 @@ import org.springframework.transaction.annotation.Transactional;
  * @author Krzysztof Krason
  * @author Yanming Zhou
  * @author Ilya Bakaev
+ * @author Oscar Fanchin
  */
 @ExtendWith(SpringExtension.class)
 @ContextConfiguration("classpath:application-context.xml")
@@ -817,6 +818,8 @@ class UserRepositoryTests {
 	}
 
 	@Test
+	// Hibernate 7 permissively flattens the selected collection-valued path.
+	@DisabledOnHibernate(value = "8", disabledReason = "Hibernate 8 no longer flattens collection-valued paths")
 	void executesAnnotatedCollectionMethodCorrectly() {
 
 		flushTestUsers();
@@ -824,6 +827,18 @@ class UserRepositoryTests {
 		repository.save(firstUser);
 
 		List<User> result = repository.findColleaguesFor(firstUser);
+		assertThat(result).containsOnly(thirdUser);
+	}
+
+	@Test
+	@DisabledOnHibernate(value = "7", disabledReason = "Hibernate 7 permits the original collection-valued query")
+	void executesAnnotatedCollectionMethodCorrectlyH8() {
+
+		flushTestUsers();
+		firstUser.addColleague(thirdUser);
+		repository.save(firstUser);
+
+		List<User> result = repository.findColleaguesForH8(firstUser);
 		assertThat(result).containsOnly(thirdUser);
 	}
 

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/aot/AotMetamodelUnitTests.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/aot/AotMetamodelUnitTests.java
@@ -43,6 +43,7 @@ import org.springframework.orm.jpa.persistenceunit.SpringPersistenceUnitInfo;
  *
  * @author Mark Paluch
  * @author Christoph Strobl
+ * @author Oscar Fanchin
  */
 class AotMetamodelUnitTests {
 
@@ -93,6 +94,7 @@ class AotMetamodelUnitTests {
 		SpringPersistenceUnitInfo persistenceUnitInfo = new SpringPersistenceUnitInfo(this.getClass().getClassLoader());
 		persistenceUnitInfo.setPersistenceUnitName("AotMetamodel");
 		persistenceUnitInfo.addManagedClassName(EntityEntity.class.getName());
+		persistenceUnitInfo.setExcludeUnlistedClasses(true);
 		PersistenceUnitInfoDescriptor persistenceUnit = new PersistenceUnitInfoDescriptor(
 				persistenceUnitInfo.asStandardPersistenceUnitInfo());
 

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/aot/JpaRepositoryContributorIntegrationTests.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/aot/JpaRepositoryContributorIntegrationTests.java
@@ -41,6 +41,7 @@ import org.springframework.data.jpa.domain.sample.Role;
 import org.springframework.data.jpa.domain.sample.SpecialUser;
 import org.springframework.data.jpa.domain.sample.User;
 import org.springframework.data.jpa.util.DisabledOnHibernate;
+import org.springframework.data.jpa.util.JpaPortableQueries;
 import org.springframework.data.util.Streamable;
 import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 import org.springframework.transaction.annotation.Transactional;
@@ -71,8 +72,8 @@ class JpaRepositoryContributorIntegrationTests {
 	@BeforeEach
 	void beforeEach() {
 
-		em.createQuery("DELETE FROM %s".formatted(User.class.getName())).executeUpdate();
-		em.createQuery("DELETE FROM %s".formatted(Role.class.getName())).executeUpdate();
+		JpaPortableQueries.createQuery(em, "DELETE FROM %s".formatted(User.class.getName())).executeUpdate();
+		JpaPortableQueries.createQuery(em, "DELETE FROM %s".formatted(Role.class.getName())).executeUpdate();
 
 		smuggler = em.merge(new Role("Smuggler"));
 		jedi = em.merge(new Role("Jedi"));
@@ -554,8 +555,8 @@ class JpaRepositoryContributorIntegrationTests {
 
 		assertThat(result).isNotNull().extracting(User::getEmailAddress).isEqualTo("yoda@jedi.org");
 
-		Object yodaShouldBeGone = em
-				.createQuery("SELECT u FROM %s u WHERE u.emailAddress = 'yoda@jedi.org'".formatted(User.class.getName()))
+		Object yodaShouldBeGone = JpaPortableQueries
+				.createQuery(em, "SELECT u FROM %s u WHERE u.emailAddress = 'yoda@jedi.org'".formatted(User.class.getName()))
 				.getSingleResultOrNull();
 		assertThat(yodaShouldBeGone).isNull();
 	}
@@ -566,8 +567,8 @@ class JpaRepositoryContributorIntegrationTests {
 		User user = fragment.deleteByEmailAddressAndIdIsNotNull("yoda@jedi.org");
 		assertThat(user).isNotNull().extracting(User::getEmailAddress).isEqualTo("yoda@jedi.org");
 
-		Object yodaShouldBeGone = em
-				.createQuery("SELECT u FROM %s u WHERE u.emailAddress = 'yoda@jedi.org'".formatted(User.class.getName()))
+		Object yodaShouldBeGone = JpaPortableQueries
+				.createQuery(em, "SELECT u FROM %s u WHERE u.emailAddress = 'yoda@jedi.org'".formatted(User.class.getName()))
 				.getSingleResultOrNull();
 		assertThat(yodaShouldBeGone).isNull();
 	}
@@ -579,8 +580,8 @@ class JpaRepositoryContributorIntegrationTests {
 
 		assertThat(count).isEqualTo(1);
 
-		Object yodaShouldBeGone = em
-				.createQuery("SELECT u FROM %s u WHERE u.emailAddress = 'yoda@jedi.org'".formatted(User.class.getName()))
+		Object yodaShouldBeGone = JpaPortableQueries
+				.createQuery(em, "SELECT u FROM %s u WHERE u.emailAddress = 'yoda@jedi.org'".formatted(User.class.getName()))
 				.getSingleResultOrNull();
 		assertThat(yodaShouldBeGone).isNull();
 	}
@@ -608,8 +609,8 @@ class JpaRepositoryContributorIntegrationTests {
 
 		assertThat(affected).isEqualTo(7);
 
-		Object yodaShouldBeGone = em
-				.createQuery("SELECT u FROM %s u WHERE u.lastname = 'n/a'".formatted(User.class.getName()))
+		Object yodaShouldBeGone = JpaPortableQueries
+				.createQuery(em, "SELECT u FROM %s u WHERE u.lastname = 'n/a'".formatted(User.class.getName()))
 				.getSingleResultOrNull();
 		assertThat(yodaShouldBeGone).isNull();
 	}

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/aot/JpaRepositoryContributorIntegrationTests.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/aot/JpaRepositoryContributorIntegrationTests.java
@@ -40,6 +40,7 @@ import org.springframework.data.domain.Sort;
 import org.springframework.data.jpa.domain.sample.Role;
 import org.springframework.data.jpa.domain.sample.SpecialUser;
 import org.springframework.data.jpa.domain.sample.User;
+import org.springframework.data.jpa.util.DisabledOnHibernate;
 import org.springframework.data.util.Streamable;
 import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 import org.springframework.transaction.annotation.Transactional;
@@ -49,6 +50,7 @@ import org.springframework.transaction.annotation.Transactional;
  *
  * @author Christoph Strobl
  * @author Mark Paluch
+ * @author Oscar Fanchin
  */
 @SpringJUnitConfig(classes = JpaRepositoryContributorIntegrationTests.JpaRepositoryContributorConfiguration.class)
 @Transactional
@@ -657,9 +659,17 @@ class JpaRepositoryContributorIntegrationTests {
 	}
 
 	@Test // GH-3830
+	@DisabledOnHibernate(value = "8", disabledReason = "Hibernate 8 normalizes enum query hint values to uppercase")
 	void shouldApplyQueryHints() {
 		assertThatIllegalArgumentException().isThrownBy(() -> fragment.findHintedByLastname("Skywalker"))
 				.withMessageContaining("No enum constant jakarta.persistence.CacheStoreMode.foo");
+	}
+
+	@Test // GH-3830, GH-4197
+	@DisabledOnHibernate(value = "7", disabledReason = "Hibernate 7 retains the original enum query hint value")
+	void shouldApplyQueryHintsOnHibernate8() {
+		assertThatIllegalArgumentException().isThrownBy(() -> fragment.findHintedByLastname("Skywalker"))
+				.withMessageContaining("No enum constant jakarta.persistence.CacheStoreMode.FOO");
 	}
 
 	@Test // GH-3830, GH-4097

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/cdi/QualifiedEntityManagerProducer.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/cdi/QualifiedEntityManagerProducer.java
@@ -20,6 +20,8 @@ import jakarta.enterprise.inject.Produces;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.EntityManagerFactory;
 
+import java.util.Map;
+
 /**
  * @author Oliver Gierke
  * @author Mark Paluch
@@ -29,7 +31,7 @@ class QualifiedEntityManagerProducer {
 	@Produces
 	@PersonDB
 	public EntityManager createPersonDBEntityManager(EntityManagerFactory entityManagerFactory) {
-		return entityManagerFactory.createEntityManager();
+		return entityManagerFactory.createEntityManager(Map.of());
 	}
 
 	public void closePersonDB(@Disposes @PersonDB EntityManager entityManager) {
@@ -39,7 +41,7 @@ class QualifiedEntityManagerProducer {
 	@Produces
 	@UserDB
 	public EntityManager createUserDBEntityManager(EntityManagerFactory entityManagerFactory) {
-		return entityManagerFactory.createEntityManager();
+		return entityManagerFactory.createEntityManager(Map.of());
 	}
 
 	public void closeUserDB(@Disposes @UserDB EntityManager entityManager) {

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/cdi/UnqualifiedEntityManagerProducer.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/cdi/UnqualifiedEntityManagerProducer.java
@@ -20,11 +20,13 @@ import jakarta.enterprise.inject.Produces;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.EntityManagerFactory;
 
+import java.util.Map;
+
 class UnqualifiedEntityManagerProducer {
 
 	@Produces
 	public EntityManager createEntityManager(EntityManagerFactory entityManagerFactory) {
-		return entityManagerFactory.createEntityManager();
+		return entityManagerFactory.createEntityManager(Map.of());
 	}
 
 	public void close(@Disposes EntityManager entityManager) {

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/procedures/PostgresStoredProcedureIntegrationTests.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/procedures/PostgresStoredProcedureIntegrationTests.java
@@ -62,6 +62,7 @@ import org.testcontainers.postgresql.PostgreSQLContainer;
  * @author Yanming Zhou
  * @author Thorben Janssen
  * @author Mark Paluch
+ * @author Oscar Fanchin
  */
 @Transactional
 @ExtendWith(SpringExtension.class)
@@ -110,8 +111,8 @@ class PostgresStoredProcedureIntegrationTests {
 				new Employee(4, "Gabriel"));
 	}
 
-	@DisabledOnHibernate(value = "7",
-			disabledReason = "class org.hibernate.metamodel.model.domain.internal.EntityTypeImpl cannot be cast to class org.hibernate.query.OutputableType (org.hibernate.metamodel.model.domain.internal.EntityTypeImpl and org.hibernate.query.OutputableType are in unnamed module of loader 'app')")
+	@DisabledOnHibernate(value = { "7", "8" },
+			disabledReason = "Hibernate cannot register an entity type as a REF_CURSOR output type")
 	@Test // 2256
 	void testSingleEntityFromResultSet() {
 

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/projections/ProjectionsIntegrationTests.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/projections/ProjectionsIntegrationTests.java
@@ -56,6 +56,7 @@ import org.springframework.transaction.annotation.Transactional;
  * Integration tests for the behavior of projections.
  *
  * @author Jens Schauder
+ * @author Oscar Fanchin
  */
 @Transactional
 @ExtendWith(SpringExtension.class)
@@ -230,6 +231,7 @@ class ProjectionsIntegrationTests {
 			Properties properties = new Properties();
 			properties.setProperty("hibernate.hbm2ddl.auto", "create");
 			properties.setProperty("hibernate.dialect", "org.hibernate.dialect.HSQLDialect");
+			properties.setProperty("hibernate.xml_mapping_enabled", "false");
 			factoryBean.setJpaProperties(properties);
 
 			return factoryBean;

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/AbstractJpaQueryTests.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/AbstractJpaQueryTests.java
@@ -20,6 +20,7 @@ import static org.assertj.core.api.Assumptions.*;
 import static org.mockito.Mockito.*;
 import static org.springframework.data.jpa.support.EntityManagerTestUtils.*;
 
+import jakarta.persistence.AttributeNode;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.LockModeType;
 import jakarta.persistence.PersistenceContext;
@@ -40,6 +41,7 @@ import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.EntityGraph.EntityGraphType;
 import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.QueryHints;
+import org.springframework.data.jpa.util.DisabledOnHibernate;
 import org.springframework.data.projection.SpelAwareProxyProjectionFactory;
 import org.springframework.data.repository.Repository;
 import org.springframework.data.repository.core.support.DefaultRepositoryMetadata;
@@ -55,6 +57,7 @@ import org.springframework.transaction.annotation.Transactional;
  * @author Mark Paluch
  * @author Krzysztof Krason
  * @author Julia Lee
+ * @author Oscar Fanchin
  */
 @ExtendWith(SpringExtension.class)
 @ContextConfiguration("classpath:hibernate-infrastructure.xml")
@@ -119,6 +122,8 @@ class AbstractJpaQueryTests {
 
 	@Test // DATAJPA-466
 	@Transactional
+	// Hibernate 8 passes an equivalent EntityGraph instance instead of retaining identity.
+	@DisabledOnHibernate(value = "8", disabledReason = "Hibernate 8 no longer retains EntityGraph identity")
 	void shouldAddEntityGraphHintForFetch() throws Exception {
 
 		assumeThat(currentEntityManagerIsAJpa21EntityManager(em)).isTrue();
@@ -134,6 +139,31 @@ class AbstractJpaQueryTests {
 
 	@Test // DATAJPA-466
 	@Transactional
+	@DisabledOnHibernate(value = "7", disabledReason = "Hibernate 7 retains EntityGraph identity")
+	void shouldAddEntityGraphHintForFetchH8() throws Exception {
+
+		assumeThat(currentEntityManagerIsAJpa21EntityManager(em)).isTrue();
+
+		JpaQueryMethod queryMethod = getMethod("findAll");
+		jakarta.persistence.EntityGraph<?> entityGraph = em.getEntityGraph("User.overview");
+
+		AbstractJpaQuery jpaQuery = new DummyJpaQuery(queryMethod, em);
+		Query result = jpaQuery.createQuery(new JpaParametersParameterAccessor(queryMethod.getParameters(), new Object[0]));
+
+		ArgumentCaptor<Object> captor = ArgumentCaptor.forClass(Object.class);
+		verify(result).setHint(eq("jakarta.persistence.fetchgraph"), captor.capture());
+
+		assertThat(captor.getValue()).isInstanceOf(jakarta.persistence.EntityGraph.class);
+		jakarta.persistence.EntityGraph<?> actual = (jakarta.persistence.EntityGraph<?>) captor.getValue();
+
+		assertThat(actual.getName()).isEqualTo(entityGraph.getName());
+		assertThat(actual.getAttributeNodes()).extracting(AttributeNode::getAttributeName).containsExactly("roles");
+	}
+
+	@Test // DATAJPA-466
+	@Transactional
+	// Hibernate 8 passes an equivalent EntityGraph instance instead of retaining identity.
+	@DisabledOnHibernate(value = "8", disabledReason = "Hibernate 8 no longer retains EntityGraph identity")
 	void shouldAddEntityGraphHintForLoad() throws Exception {
 
 		assumeThat(currentEntityManagerIsAJpa21EntityManager(em)).isTrue();
@@ -146,6 +176,31 @@ class AbstractJpaQueryTests {
 				.createQuery(new JpaParametersParameterAccessor(queryMethod.getParameters(), new Object[] { 1 }));
 
 		verify(result).setHint("jakarta.persistence.loadgraph", entityGraph);
+	}
+
+	@Test // DATAJPA-466
+	@Transactional
+	@DisabledOnHibernate(value = "7", disabledReason = "Hibernate 7 retains EntityGraph identity")
+	void shouldAddEntityGraphHintForLoadH8() throws Exception {
+
+		assumeThat(currentEntityManagerIsAJpa21EntityManager(em)).isTrue();
+
+		JpaQueryMethod queryMethod = getMethod("getById", Integer.class);
+		jakarta.persistence.EntityGraph<?> entityGraph = em.getEntityGraph("User.detail");
+
+		AbstractJpaQuery jpaQuery = new DummyJpaQuery(queryMethod, em);
+		Query result = jpaQuery
+				.createQuery(new JpaParametersParameterAccessor(queryMethod.getParameters(), new Object[] { 1 }));
+
+		ArgumentCaptor<Object> captor = ArgumentCaptor.forClass(Object.class);
+		verify(result).setHint(eq("jakarta.persistence.loadgraph"), captor.capture());
+
+		assertThat(captor.getValue()).isInstanceOf(jakarta.persistence.EntityGraph.class);
+		jakarta.persistence.EntityGraph<?> actual = (jakarta.persistence.EntityGraph<?>) captor.getValue();
+
+		assertThat(actual.getName()).isEqualTo(entityGraph.getName());
+		assertThat(actual.getAttributeNodes()).extracting(AttributeNode::getAttributeName)
+				.containsExactlyInAnyOrder("manager", "roles", "colleagues");
 	}
 
 	@Test // GH-3137

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/AbstractStringBasedJpaQueryIntegrationTests.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/AbstractStringBasedJpaQueryIntegrationTests.java
@@ -16,6 +16,7 @@
 package org.springframework.data.jpa.repository.query;
 
 import static org.mockito.Mockito.*;
+import static org.springframework.data.jpa.support.EntityManagerTestUtils.*;
 
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
@@ -74,7 +75,7 @@ class AbstractStringBasedJpaQueryIntegrationTests {
 		jpaQuery.createJpaQuery(method.getRequiredDeclaredQuery(), Sort.unsorted(), null,
 				method.getResultProcessor().getReturnedType());
 
-		verify(mock, times(1)).createQuery(anyString());
+		verifyCreateQuery(verify(mock, times(1)), anyString());
 		verify(mock, times(0)).createQuery(anyString(), eq(Tuple.class));
 	}
 

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/HqlOrderExpressionVisitorUnitTests.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/HqlOrderExpressionVisitorUnitTests.java
@@ -27,8 +27,6 @@ import jakarta.persistence.criteria.Selection;
 
 import java.util.Locale;
 
-import org.hibernate.query.sqm.tree.SqmRenderContext;
-import org.hibernate.query.sqm.tree.select.SqmSelectStatement;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
@@ -37,12 +35,15 @@ import org.springframework.data.jpa.domain.sample.User;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.ClassUtils;
+import org.springframework.util.ReflectionUtils;
 
 /**
  * Verify that {@link JpaSort#unsafe(String...)} works properly with Hibernate via {@link HqlOrderExpressionVisitor}.
  *
  * @author Greg Turnquist
  * @author Mark Paluch
+ * @author Oscar Fanchin
  */
 @ExtendWith(SpringExtension.class)
 @ContextConfiguration("classpath:application-context.xml")
@@ -337,15 +338,32 @@ class HqlOrderExpressionVisitorUnitTests {
 		return query.select(from).orderBy(em.getCriteriaBuilder().asc(expression, Nulls.NONE));
 	}
 
-	@SuppressWarnings("rawtypes")
 	String renderQuery(JpaSort sort, String alias) {
 
 		CriteriaQuery<User> q = createQuery(sort, alias);
-		SqmSelectStatement s = (SqmSelectStatement) q;
-
 		StringBuilder builder = new StringBuilder();
-		s.appendHqlString(builder, SqmRenderContext.simpleContext());
+		Class<?> renderContextType = loadClass("org.hibernate.query.sqm.tree.spi.SqmRenderContext",
+				"org.hibernate.query.sqm.tree.SqmRenderContext");
+		Object renderContext = ReflectionUtils.invokeMethod(
+				ReflectionUtils.findMethod(renderContextType, "simpleContext"), null);
+
+		ReflectionUtils.invokeMethod(
+				ReflectionUtils.findMethod(q.getClass(), "appendHqlString", StringBuilder.class, renderContextType), q,
+				builder, renderContext);
 
 		return builder.toString();
+	}
+
+	private static Class<?> loadClass(String... classNames) {
+
+		ClassLoader classLoader = HqlOrderExpressionVisitorUnitTests.class.getClassLoader();
+
+		for (String className : classNames) {
+			if (ClassUtils.isPresent(className, classLoader)) {
+				return ClassUtils.resolveClassName(className, classLoader);
+			}
+		}
+
+		throw new IllegalStateException("Cannot resolve Hibernate SQM render context");
 	}
 }

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/Jpa21UtilsTests.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/Jpa21UtilsTests.java
@@ -27,7 +27,6 @@ import jakarta.persistence.Subgraph;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.Iterator;
 import java.util.List;
 
 import org.assertj.core.api.AbstractAssert;
@@ -51,6 +50,7 @@ import org.springframework.util.ObjectUtils;
  * @author Jens Schauder
  * @author Krzysztof Krason
  * @author Christoph Strobl
+ * @author Oscar Fanchin
  */
 @ExtendWith(SpringExtension.class)
 @ContextConfiguration("classpath:application-context.xml")
@@ -317,7 +317,8 @@ class Jpa21UtilsTests {
 
 		private List<String> extractSubgraphsAttributeNames() {
 
-			Iterator<Subgraph> iterator = attributeNode.getSubgraphs().values().iterator();
+			// JPA 3.2 and 4.0 expose different generic signatures for subgraphs.
+			var iterator = attributeNode.getSubgraphs().values().iterator();
 
 			if (!iterator.hasNext()) {
 				return Collections.emptyList();

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/JpaQueryCreatorTests.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/JpaQueryCreatorTests.java
@@ -54,6 +54,7 @@ import org.springframework.data.jpa.domain.sample.EmbeddedIdExampleEmployeePK;
 import org.springframework.data.jpa.domain.sample.ReferencingEmbeddedIdExampleEmployee;
 import org.springframework.data.jpa.repository.support.JpqlQueryTemplates;
 import org.springframework.data.jpa.util.TestMetaModel;
+import org.springframework.data.jpa.util.JpaPortableQueries;
 import org.springframework.data.projection.ProjectionFactory;
 import org.springframework.data.projection.SpelAwareProxyProjectionFactory;
 import org.springframework.data.repository.query.ParameterAccessor;
@@ -955,7 +956,7 @@ class JpaQueryCreatorTests {
 			if (builder instanceof DefaultCreatorBuilder dcb) {
 				entityManager.createQuery(this.jpql.get(), dcb.returnedType.getReturnedType());
 			} else {
-				entityManager.createQuery(this.jpql.get());
+				JpaPortableQueries.createQuery(entityManager, this.jpql.get());
 			}
 			return this;
 		}

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/JpaQueryLookupStrategyUnitTests.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/JpaQueryLookupStrategyUnitTests.java
@@ -17,6 +17,7 @@ package org.springframework.data.jpa.repository.query;
 
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.Mockito.*;
+import static org.springframework.data.jpa.support.EntityManagerTestUtils.*;
 
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.EntityManagerFactory;
@@ -24,6 +25,7 @@ import jakarta.persistence.metamodel.Metamodel;
 
 import java.lang.reflect.Method;
 import java.util.List;
+import java.util.Map;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
@@ -82,7 +84,7 @@ class JpaQueryLookupStrategyUnitTests {
 
 		when(em.getMetamodel()).thenReturn(metamodel);
 		when(em.getEntityManagerFactory()).thenReturn(emf);
-		when(emf.createEntityManager()).thenReturn(em);
+		when(emf.createEntityManager(Map.of())).thenReturn(em);
 		when(em.getDelegate()).thenReturn(em);
 		queryMethodFactory = new DefaultJpaQueryMethodFactory(extractor);
 	}
@@ -161,7 +163,7 @@ class JpaQueryLookupStrategyUnitTests {
 		Method method = UserRepository.class.getMethod("annotatedQueryNameOnly", String.class, String.class, String.class);
 		RepositoryMetadata metadata = new DefaultRepositoryMetadata(UserRepository.class);
 
-		when(em.createNamedQuery("missing-query")).thenThrow(new IllegalArgumentException());
+		whenCreateNamedQuery(em, "missing-query").thenThrow(new IllegalArgumentException());
 
 		assertThatExceptionOfType(QueryCreationException.class)
 				.isThrownBy(() -> strategy.resolveQuery(method, metadata, projectionFactory, namedQueries))
@@ -177,7 +179,7 @@ class JpaQueryLookupStrategyUnitTests {
 				Pageable.class);
 		RepositoryMetadata metadata = new DefaultRepositoryMetadata(UserRepository.class);
 
-		when(em.createNamedQuery("foo.count")).thenThrow(new IllegalArgumentException());
+		whenCreateNamedQuery(em, "foo.count").thenThrow(new IllegalArgumentException());
 
 		assertThatExceptionOfType(QueryCreationException.class)
 				.isThrownBy(() -> strategy.resolveQuery(method, metadata, projectionFactory, namedQueries))
@@ -205,7 +207,7 @@ class JpaQueryLookupStrategyUnitTests {
 		Method method = UserRepository.class.getMethod("findByNamedQuery", String.class, Pageable.class);
 		RepositoryMetadata metadata = new DefaultRepositoryMetadata(UserRepository.class);
 
-		when(em.createNamedQuery("foo.count")).thenThrow(new IllegalArgumentException());
+		whenCreateNamedQuery(em, "foo.count").thenThrow(new IllegalArgumentException());
 
 		assertThatExceptionOfType(QueryCreationException.class)
 				.isThrownBy(() -> strategy.resolveQuery(method, metadata, projectionFactory, namedQueries))

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/NamedQueryUnitTests.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/NamedQueryUnitTests.java
@@ -17,6 +17,7 @@ package org.springframework.data.jpa.repository.query;
 
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.Mockito.*;
+import static org.springframework.data.jpa.support.EntityManagerTestUtils.*;
 
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.EntityManagerFactory;
@@ -24,6 +25,7 @@ import jakarta.persistence.TypedQuery;
 import jakarta.persistence.metamodel.Metamodel;
 
 import java.lang.reflect.Method;
+import java.util.Map;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -82,7 +84,7 @@ class NamedQueryUnitTests {
 		when(em.getMetamodel()).thenReturn(metamodel);
 		when(em.getEntityManagerFactory()).thenReturn(emf);
 		when(em.getDelegate()).thenReturn(em);
-		when(emf.createEntityManager()).thenReturn(em);
+		when(emf.createEntityManager(Map.of())).thenReturn(em);
 	}
 
 	@Test
@@ -91,7 +93,8 @@ class NamedQueryUnitTests {
 		when(extractor.canExtractQuery()).thenReturn(false);
 		JpaQueryMethod queryMethod = new JpaQueryMethod(method, metadata, projectionFactory, extractor);
 
-		when(em.createNamedQuery(queryMethod.getNamedCountQueryName())).thenThrow(new IllegalArgumentException());
+		whenCreateNamedQuery(em, queryMethod.getNamedCountQueryName())
+				.thenThrow(new IllegalArgumentException());
 		assertThatExceptionOfType(QueryCreationException.class)
 				.isThrownBy(() -> NamedQuery.lookupFrom(queryMethod, em, CONFIG));
 	}

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/QueryUtilsIntegrationTests.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/QueryUtilsIntegrationTests.java
@@ -301,7 +301,7 @@ class QueryUtilsIntegrationTests {
 
 		doInMerchantContext((emf) -> {
 
-			CriteriaBuilder builder = emf.createEntityManager().getCriteriaBuilder();
+			CriteriaBuilder builder = emf.createEntityManager(emptyMap()).getCriteriaBuilder();
 			CriteriaQuery<Merchant> query = builder.createQuery(Merchant.class);
 			Root<Merchant> root = query.from(Merchant.class);
 

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/QueryUtilsIntegrationTests.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/QueryUtilsIntegrationTests.java
@@ -27,6 +27,7 @@ import jakarta.persistence.OneToMany;
 import jakarta.persistence.OneToOne;
 import jakarta.persistence.Persistence;
 import jakarta.persistence.PersistenceContext;
+import jakarta.persistence.Query;
 import jakarta.persistence.criteria.CriteriaBuilder;
 import jakarta.persistence.criteria.CriteriaQuery;
 import jakarta.persistence.criteria.From;
@@ -45,7 +46,6 @@ import java.util.Set;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
-import org.hibernate.query.sqm.internal.SqmQueryImpl;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mockito;
@@ -62,6 +62,7 @@ import org.springframework.data.jpa.domain.sample.ReferencingEmbeddedIdExampleEm
 import org.springframework.data.jpa.domain.sample.ReferencingIdClassExampleEmployee;
 import org.springframework.data.jpa.domain.sample.User;
 import org.springframework.data.jpa.infrastructure.HibernateTestUtils;
+import org.springframework.data.jpa.provider.HibernateUtils;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.transaction.annotation.Transactional;
@@ -76,6 +77,7 @@ import org.springframework.transaction.annotation.Transactional;
  * @author Diego Krupitza
  * @author Krzysztof Krason
  * @author Jakub Soltys
+ * @author Oscar Fanchin
  */
 @ExtendWith(SpringExtension.class)
 @ContextConfiguration("classpath:hibernate-infrastructure.xml")
@@ -449,10 +451,10 @@ class QueryUtilsIntegrationTests {
 	void applyAndBindOptimizesIn() {
 
 		em.getCriteriaBuilder();
-		SqmQueryImpl<?> query = (SqmQueryImpl) QueryUtils
+		Query query = (Query) QueryUtils
 				.applyAndBind("DELETE FROM User u", List.of(new User(), new User()), em.unwrap(null));
 
-		assertThat(query.getQueryString()).isEqualTo("DELETE FROM User u where u IN (?1)");
+		assertThat(HibernateUtils.getHibernateQuery(query)).isEqualTo("DELETE FROM User u where u IN (?1)");
 	}
 
 	@Test // GH-3983, GH-2870
@@ -460,11 +462,11 @@ class QueryUtilsIntegrationTests {
 	void applyAndBindExpandsToPositionalPlaceholders() {
 
 		em.getCriteriaBuilder();
-		SqmQueryImpl<?> query = (SqmQueryImpl) QueryUtils
+		Query query = (Query) QueryUtils
 				.applyAndBind("DELETE FROM User u", List.of(new User(), new User()), em.unwrap(null),
 						org.springframework.data.jpa.provider.PersistenceProvider.ECLIPSELINK);
 
-		assertThat(query.getQueryString()).isEqualTo("DELETE FROM User u where u = ?1 or u = ?2");
+		assertThat(HibernateUtils.getHibernateQuery(query)).isEqualTo("DELETE FROM User u where u = ?1 or u = ?2");
 	}
 
 	int getNumberOfJoinsAfterCreatingAPath() {

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/SimpleJpaQueryUnitTests.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/SimpleJpaQueryUnitTests.java
@@ -17,6 +17,7 @@ package org.springframework.data.jpa.repository.query;
 
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.Mockito.*;
+import static org.springframework.data.jpa.support.EntityManagerTestUtils.mockQuery;
 
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.EntityManagerFactory;
@@ -75,6 +76,7 @@ import org.springframework.data.repository.query.ValueExpressionDelegate;
  * @author Erik Pellizzon
  * @author Christoph Strobl
  * @author Danny van den Elshout
+ * @author Oscar Fanchin
  */
 @ExtendWith(MockitoExtension.class)
 @MockitoSettings(strictness = Strictness.LENIENT)
@@ -90,8 +92,9 @@ class SimpleJpaQueryUnitTests {
 	@Mock EntityManager em;
 	@Mock EntityManagerFactory emf;
 	@Mock QueryExtractor extractor;
-	@Mock jakarta.persistence.Query query;
+	jakarta.persistence.Query query;
 	@Mock TypedQuery<Long> typedQuery;
+	@Mock TypedQuery<User> userQuery;
 	RepositoryMetadata metadata;
 	@Mock ParameterBinder binder;
 	@Mock Metamodel metamodel;
@@ -101,8 +104,9 @@ class SimpleJpaQueryUnitTests {
 	@BeforeEach
 	void setUp() throws SecurityException, NoSuchMethodException {
 
+		query = mockQuery();
 		when(em.getMetamodel()).thenReturn(metamodel);
-		when(em.createQuery(anyString())).thenReturn(query);
+		doReturn(query).when(em).createQuery(anyString());
 		when(em.createQuery(anyString(), eq(Long.class))).thenReturn(typedQuery);
 		when(em.getEntityManagerFactory()).thenReturn(emf);
 		when(em.getDelegate()).thenReturn(em);
@@ -132,7 +136,7 @@ class SimpleJpaQueryUnitTests {
 	@Test // DATAJPA-77
 	void doesNotApplyPaginationToCountQuery() throws Exception {
 
-		when(em.createQuery(Mockito.anyString())).thenReturn(query);
+		doReturn(query).when(em).createQuery(Mockito.anyString());
 
 		Method method = UserRepository.class.getMethod("findAllPaged", Pageable.class);
 		JpaQueryMethod queryMethod = new JpaQueryMethod(method, metadata, factory, extractor);
@@ -156,7 +160,7 @@ class SimpleJpaQueryUnitTests {
 
 		assertThat(jpaQuery).isInstanceOf(NativeJpaQuery.class);
 
-		when(em.createNativeQuery(anyString(), eq(User.class))).thenReturn(query);
+		when(em.createNativeQuery(anyString(), eq(User.class))).thenReturn(userQuery);
 
 		jpaQuery.createQuery(new JpaParametersParameterAccessor(queryMethod.getParameters(), new Object[] { "Matthews" }));
 
@@ -173,7 +177,7 @@ class SimpleJpaQueryUnitTests {
 
 		assertThat(jpaQuery).isInstanceOf(NativeJpaQuery.class);
 
-		when(em.createNativeQuery(anyString(), eq(User.class))).thenReturn(query);
+		when(em.createNativeQuery(anyString(), eq(User.class))).thenReturn(userQuery);
 
 		jpaQuery.createQuery(new JpaParametersParameterAccessor(queryMethod.getParameters(), new Object[] { "Matthews" }));
 
@@ -218,7 +222,7 @@ class SimpleJpaQueryUnitTests {
 	@Test // DATAJPA-757
 	void createsNativeCountQuery() throws Exception {
 
-		when(em.createNativeQuery(anyString())).thenReturn(query);
+		doReturn(query).when(em).createNativeQuery(anyString());
 
 		AbstractJpaQuery jpaQuery = createJpaQuery(
 				UserRepository.class.getMethod("findUsersInNativeQueryWithPagination", Pageable.class));
@@ -232,7 +236,7 @@ class SimpleJpaQueryUnitTests {
 	@Test // GH-3293
 	void allowsCountQueryUsingParametersNotInOriginalQuery() throws Exception {
 
-		when(em.createNativeQuery(anyString())).thenReturn(query);
+		doReturn(query).when(em).createNativeQuery(anyString());
 
 		AbstractJpaQuery jpaQuery = createJpaQuery(
 				SampleRepository.class.getMethod("findAllWithBindingsOnlyInCountQuery", String.class, Pageable.class),
@@ -336,7 +340,7 @@ class SimpleJpaQueryUnitTests {
 	@Test // DATAJPA-1163
 	void resolvesExpressionInCountQuery() throws Exception {
 
-		when(em.createQuery(Mockito.anyString())).thenReturn(query);
+		doReturn(query).when(em).createQuery(Mockito.anyString());
 
 		Method method = SampleRepository.class.getMethod("findAllWithExpressionInCountQuery", Pageable.class);
 		JpaQueryMethod queryMethod = new JpaQueryMethod(method, metadata, factory, extractor);

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/SimpleJpaQueryUnitTests.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/SimpleJpaQueryUnitTests.java
@@ -17,7 +17,7 @@ package org.springframework.data.jpa.repository.query;
 
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.Mockito.*;
-import static org.springframework.data.jpa.support.EntityManagerTestUtils.mockQuery;
+import static org.springframework.data.jpa.support.EntityManagerTestUtils.*;
 
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.EntityManagerFactory;
@@ -29,6 +29,7 @@ import jakarta.persistence.metamodel.Metamodel;
 import java.lang.reflect.Method;
 import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
@@ -106,11 +107,11 @@ class SimpleJpaQueryUnitTests {
 
 		query = mockQuery();
 		when(em.getMetamodel()).thenReturn(metamodel);
-		doReturn(query).when(em).createQuery(anyString());
+		whenCreateQuery(em, anyString()).thenReturn(query);
 		when(em.createQuery(anyString(), eq(Long.class))).thenReturn(typedQuery);
 		when(em.getEntityManagerFactory()).thenReturn(emf);
 		when(em.getDelegate()).thenReturn(em);
-		when(emf.createEntityManager()).thenReturn(em);
+		when(emf.createEntityManager(Map.of())).thenReturn(em);
 
 		metadata = AbstractRepositoryMetadata.getMetadata(SampleRepository.class);
 
@@ -136,7 +137,7 @@ class SimpleJpaQueryUnitTests {
 	@Test // DATAJPA-77
 	void doesNotApplyPaginationToCountQuery() throws Exception {
 
-		doReturn(query).when(em).createQuery(Mockito.anyString());
+		whenCreateQuery(em, Mockito.anyString()).thenReturn(query);
 
 		Method method = UserRepository.class.getMethod("findAllPaged", Pageable.class);
 		JpaQueryMethod queryMethod = new JpaQueryMethod(method, metadata, factory, extractor);
@@ -160,11 +161,11 @@ class SimpleJpaQueryUnitTests {
 
 		assertThat(jpaQuery).isInstanceOf(NativeJpaQuery.class);
 
-		when(em.createNativeQuery(anyString(), eq(User.class))).thenReturn(userQuery);
+		whenCreateNativeQuery(em, anyString(), eq(User.class)).thenReturn(userQuery);
 
 		jpaQuery.createQuery(new JpaParametersParameterAccessor(queryMethod.getParameters(), new Object[] { "Matthews" }));
 
-		verify(em).createNativeQuery("SELECT u FROM User u WHERE u.lastname = ?1", User.class);
+		verifyCreateNativeQuery(verify(em), "SELECT u FROM User u WHERE u.lastname = ?1", User.class);
 	}
 
 	@Test // GH-3155
@@ -177,18 +178,18 @@ class SimpleJpaQueryUnitTests {
 
 		assertThat(jpaQuery).isInstanceOf(NativeJpaQuery.class);
 
-		when(em.createNativeQuery(anyString(), eq(User.class))).thenReturn(userQuery);
+		whenCreateNativeQuery(em, anyString(), eq(User.class)).thenReturn(userQuery);
 
 		jpaQuery.createQuery(new JpaParametersParameterAccessor(queryMethod.getParameters(), new Object[] { "Matthews" }));
 
-		verify(em).createNativeQuery("SELECT u FROM User u WHERE u.lastname = ?1", User.class);
+		verifyCreateNativeQuery(verify(em), "SELECT u FROM User u WHERE u.lastname = ?1", User.class);
 	}
 
 	@Test // DATAJPA-352
 	void doesNotValidateCountQueryIfNotPagingMethod() throws Exception {
 
 		Method method = SampleRepository.class.getMethod("findByAnnotatedQuery");
-		when(em.createQuery(Mockito.contains("count"))).thenThrow(IllegalArgumentException.class);
+		whenCreateQuery(em, Mockito.contains("count")).thenThrow(IllegalArgumentException.class);
 
 		createJpaQuery(method);
 	}
@@ -198,7 +199,7 @@ class SimpleJpaQueryUnitTests {
 
 		Method method = SampleRepository.class.getMethod("pageByAnnotatedQuery", Pageable.class);
 
-		when(em.createQuery(Mockito.contains("count"))).thenThrow(IllegalArgumentException.class);
+		whenCreateQuery(em, Mockito.contains("count")).thenThrow(IllegalArgumentException.class);
 
 		assertThatExceptionOfType(QueryCreationException.class) //
 				.isThrownBy(() -> createJpaQuery(method)) //
@@ -222,7 +223,7 @@ class SimpleJpaQueryUnitTests {
 	@Test // DATAJPA-757
 	void createsNativeCountQuery() throws Exception {
 
-		doReturn(query).when(em).createNativeQuery(anyString());
+		whenCreateNativeQuery(em, anyString()).thenReturn(query);
 
 		AbstractJpaQuery jpaQuery = createJpaQuery(
 				UserRepository.class.getMethod("findUsersInNativeQueryWithPagination", Pageable.class));
@@ -230,13 +231,13 @@ class SimpleJpaQueryUnitTests {
 		jpaQuery.doCreateCountQuery(new JpaParametersParameterAccessor(jpaQuery.getQueryMethod().getParameters(),
 				new Object[] { PageRequest.of(0, 10) }));
 
-		verify(em).createNativeQuery(anyString());
+		verifyCreateNativeQuery(verify(em), anyString());
 	}
 
 	@Test // GH-3293
 	void allowsCountQueryUsingParametersNotInOriginalQuery() throws Exception {
 
-		doReturn(query).when(em).createNativeQuery(anyString());
+		whenCreateNativeQuery(em, anyString()).thenReturn(query);
 
 		AbstractJpaQuery jpaQuery = createJpaQuery(
 				SampleRepository.class.getMethod("findAllWithBindingsOnlyInCountQuery", String.class, Pageable.class),
@@ -261,7 +262,7 @@ class SimpleJpaQueryUnitTests {
 		verify(em, times(0)).createQuery(anyString(), eq(Tuple.class));
 
 		// Two times, first one is from the query validation
-		verify(em, times(2)).createQuery(anyString());
+		verifyCreateQuery(verify(em, times(2)), anyString());
 	}
 
 	@Test // GH-3895
@@ -340,7 +341,7 @@ class SimpleJpaQueryUnitTests {
 	@Test // DATAJPA-1163
 	void resolvesExpressionInCountQuery() throws Exception {
 
-		doReturn(query).when(em).createQuery(Mockito.anyString());
+		whenCreateQuery(em, Mockito.anyString()).thenReturn(query);
 
 		Method method = SampleRepository.class.getMethod("findAllWithExpressionInCountQuery", Pageable.class);
 		JpaQueryMethod queryMethod = new JpaQueryMethod(method, metadata, factory, extractor);
@@ -351,7 +352,7 @@ class SimpleJpaQueryUnitTests {
 		jpaQuery.createCountQuery(
 				new JpaParametersParameterAccessor(queryMethod.getParameters(), new Object[] { PageRequest.of(1, 10) }));
 
-		verify(em).createQuery(eq("select u from User u"));
+		verifyCreateQuery(verify(em), "select u from User u");
 		verify(em).createQuery(eq("select count(u.id) from User u"), eq(Long.class));
 	}
 

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/sample/UserRepository.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/sample/UserRepository.java
@@ -73,6 +73,7 @@ import com.querydsl.core.types.Predicate;
  * @author Diego Krupitza
  * @author Geoffrey Deremetz
  * @author Yanming Zhou
+ * @author Oscar Fanchin
  */
 public interface UserRepository extends JpaRepository<User, Integer>, JpaSpecificationExecutor<User>,
 		UserRepositoryCustom, ListQuerydslPredicateExecutor<User> {
@@ -252,6 +253,12 @@ public interface UserRepository extends JpaRepository<User, Integer>, JpaSpecifi
 
 	@Query("select u.colleagues from User u where u = ?1")
 	List<User> findColleaguesFor(User user);
+
+	// Counterpart of findColleaguesFor(…) above: Hibernate 8 no longer flattens the collection-valued path into
+	// individual elements. Join the association explicitly to preserve the expected List<User> result shape.
+	// See Jakarta Persistence specification, section 4.9.
+	@Query("select colleague from User u join u.colleagues colleague where u = ?1")
+	List<User> findColleaguesForH8(User user);
 
 	// DATAJPA-188
 	List<User> findByCreatedAtBefore(Date date);

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/support/DefaultJpaContextIntegrationTests.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/support/DefaultJpaContextIntegrationTests.java
@@ -22,6 +22,7 @@ import jakarta.persistence.EntityManagerFactory;
 
 import java.util.Arrays;
 import java.util.HashSet;
+import java.util.Map;
 
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -88,8 +89,8 @@ class DefaultJpaContextIntegrationTests {
 	@BeforeEach
 	void createEntityManagers() {
 
-		this.firstEm = firstEmf.createEntityManager();
-		this.secondEm = secondEmf.createEntityManager();
+		this.firstEm = firstEmf.createEntityManager(Map.of());
+		this.secondEm = secondEmf.createEntityManager(Map.of());
 
 		this.jpaContext = new DefaultJpaContext(new HashSet<>(Arrays.asList(firstEm, secondEm)));
 	}

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/support/JpaMetamodelEntityInformationIntegrationTests.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/support/JpaMetamodelEntityInformationIntegrationTests.java
@@ -23,6 +23,7 @@ import jakarta.persistence.*;
 import java.io.Serializable;
 import java.sql.Timestamp;
 import java.util.Date;
+import java.util.Map;
 import java.util.UUID;
 
 import org.junit.jupiter.api.Disabled;
@@ -151,7 +152,7 @@ public abstract class JpaMetamodelEntityInformationIntegrationTests {
 	void findsIdClassOnMappedSuperclass() {
 
 		EntityManagerFactory emf = Persistence.createEntityManagerFactory(getMetadadataPersistenceUnitName());
-		EntityManager em = emf.createEntityManager();
+		EntityManager em = emf.createEntityManager(Map.of());
 
 		EntityInformation<Sample, BaseIdClass> information = new JpaMetamodelEntityInformation<>(Sample.class,
 				em.getMetamodel(), em.getEntityManagerFactory().getPersistenceUnitUtil());
@@ -262,7 +263,7 @@ public abstract class JpaMetamodelEntityInformationIntegrationTests {
 	void correctlyDeterminesIdValueForNestedIdClassesWithNonPrimitiveNonManagedType() {
 
 		EntityManagerFactory emf = Persistence.createEntityManagerFactory(getMetadadataPersistenceUnitName());
-		EntityManager em = emf.createEntityManager();
+		EntityManager em = emf.createEntityManager(Map.of());
 
 		JpaEntityInformation<EntityWithNestedIdClass, ?> information = getEntityInformation(EntityWithNestedIdClass.class,
 				em);
@@ -305,7 +306,7 @@ public abstract class JpaMetamodelEntityInformationIntegrationTests {
 	void prefersPrivateGetterOverFieldAccess() {
 
 		EntityManagerFactory emf = Persistence.createEntityManagerFactory(getMetadadataPersistenceUnitName());
-		EntityManager em = emf.createEntityManager();
+		EntityManager em = emf.createEntityManager(Map.of());
 
 		JpaEntityInformation<EntityWithPrivateIdGetter, ?> information = getEntityInformation(
 				EntityWithPrivateIdGetter.class, em);

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/support/JpaRepositoryFactoryUnitTests.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/support/JpaRepositoryFactoryUnitTests.java
@@ -28,6 +28,7 @@ import jakarta.persistence.metamodel.Metamodel;
 
 import java.io.IOException;
 import java.io.Serializable;
+import java.util.Map;
 import java.util.Optional;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -77,7 +78,7 @@ class JpaRepositoryFactoryUnitTests {
 		when(entityManager.getMetamodel()).thenReturn(metamodel);
 		when(entityManager.getEntityManagerFactory()).thenReturn(emf);
 		when(entityManager.getDelegate()).thenReturn(entityManager);
-		when(emf.createEntityManager()).thenReturn(entityManager);
+		when(emf.createEntityManager(Map.of())).thenReturn(entityManager);
 		when(emf.getPersistenceUnitUtil()).thenReturn(persistenceUnitUtil);
 
 		// Setup standard factory configuration

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/support/QuerydslRepositorySupportTests.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/support/QuerydslRepositorySupportTests.java
@@ -33,6 +33,7 @@ import org.springframework.data.domain.Sort;
 import org.springframework.data.jpa.domain.JpaSort;
 import org.springframework.data.jpa.domain.sample.QUser;
 import org.springframework.data.jpa.domain.sample.User;
+import org.springframework.data.jpa.util.DisabledOnHibernate;
 import org.springframework.data.support.PageableExecutionUtils;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
@@ -46,7 +47,9 @@ import org.springframework.transaction.annotation.Transactional;
  * @author Jens Schauder
  * @author Krzysztof Krason
  * @author Mark Paluch
+ * @author Oscar Fanchin
  */
+@DisabledOnHibernate(value = "8", disabledReason = "Querydsl 5.1 is not binary-compatible with Jakarta Persistence 4.0")
 @ExtendWith(SpringExtension.class)
 @ContextConfiguration("classpath:hibernate-infrastructure.xml")
 @Transactional

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/support/SimpleJpaRepositoryUnitTests.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/support/SimpleJpaRepositoryUnitTests.java
@@ -18,6 +18,7 @@ package org.springframework.data.jpa.repository.support;
 import static java.util.Collections.*;
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.Mockito.*;
+import static org.springframework.data.jpa.support.EntityManagerTestUtils.*;
 
 import jakarta.persistence.EntityGraph;
 import jakarta.persistence.EntityManager;
@@ -95,8 +96,8 @@ class SimpleJpaRepositoryUnitTests {
 		when(builder.createQuery(User.class)).thenReturn(criteriaQuery);
 		when(builder.createQuery(Long.class)).thenReturn(countCriteriaQuery);
 
-		when(em.createQuery(criteriaQuery)).thenReturn(query);
-		when(em.createQuery(countCriteriaQuery)).thenReturn(countQuery);
+		whenCreateQuery(em, criteriaQuery).thenReturn(query);
+		whenCreateQuery(em, countCriteriaQuery).thenReturn(countQuery);
 
 		MutableQueryHints hints = new MutableQueryHints();
 		when(metadata.getQueryHints()).thenReturn(hints);

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/support/TestcontainerConfigSupport.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/support/TestcontainerConfigSupport.java
@@ -42,6 +42,7 @@ import org.testcontainers.containers.JdbcDatabaseContainer;
  * Support class for integration testing with Testcontainers
  *
  * @author Mark Paluch
+ * @author Oscar Fanchin
  */
 public class TestcontainerConfigSupport {
 
@@ -79,7 +80,7 @@ public class TestcontainerConfigSupport {
 		Properties properties = new Properties();
 		properties.setProperty("hibernate.hbm2ddl.auto", getSchemaAction());
 		properties.setProperty("hibernate.dialect", dialect.getCanonicalName());
-
+		properties.setProperty("hibernate.xml_mapping_enabled", Boolean.FALSE.toString());
 		factoryBean.setJpaProperties(properties);
 
 		return factoryBean;

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/support/EntityManagerTestUtils.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/support/EntityManagerTestUtils.java
@@ -17,18 +17,35 @@ package org.springframework.data.jpa.support;
 
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.Query;
+import jakarta.persistence.TypedQuery;
+import jakarta.persistence.criteria.CriteriaQuery;
+import jakarta.persistence.criteria.CriteriaSelect;
+
+import java.lang.reflect.Method;
 
 import org.mockito.Mockito;
+import org.mockito.stubbing.OngoingStubbing;
+import org.mockito.verification.VerificationMode;
+
 import org.springframework.util.Assert;
 import org.springframework.util.ReflectionUtils;
 
 /**
  * Utility class with {@link EntityManager} related helper methods.
+ * <p>
+ * The query factory methods are resolved here rather than through the production adapter on purpose: stubbing and
+ * verifying through the very code under test would make a defect in it undetectable.
  *
  * @author Thomas Darimont
  * @author Oscar Fanchin
  */
 public abstract class EntityManagerTestUtils {
+
+	private static final Method CREATE_QUERY = resolveMethod("createQuery", String.class);
+	private static final Method CREATE_NAMED_QUERY = resolveMethod("createNamedQuery", String.class);
+	private static final Method CREATE_NATIVE_QUERY = resolveMethod("createNativeQuery", String.class);
+	private static final Method CREATE_NATIVE_QUERY_WITH_TYPE = resolveMethod("createNativeQuery", String.class,
+			Class.class);
 
 	private EntityManagerTestUtils() {}
 
@@ -43,19 +60,91 @@ public abstract class EntityManagerTestUtils {
 
 	/**
 	 * Creates a query mock matching the return type of {@link EntityManager#createQuery(String)}.
-	 * <p>
-	 * Jakarta Persistence 4 changes the return type from {@link Query} to {@code StatementOrTypedQuery}. Resolving the
-	 * method at runtime keeps these test sources compilable against both API generations.
 	 *
 	 * @return a query mock compatible with the Jakarta Persistence API on the classpath.
 	 */
 	@SuppressWarnings("unchecked")
 	public static Query mockQuery() {
+		return Mockito.mock((Class<? extends Query>) CREATE_QUERY.getReturnType());
+	}
 
-		var createQuery = ReflectionUtils.findMethod(EntityManager.class, "createQuery", String.class);
+	/**
+	 * Stub {@link EntityManager#createQuery(String)} on the given mock.
+	 */
+	public static OngoingStubbing<Query> whenCreateQuery(EntityManager entityManager, String queryString) {
+		return Mockito.when(invoke(CREATE_QUERY, entityManager, queryString));
+	}
 
-		Assert.state(createQuery != null, "Cannot resolve EntityManager.createQuery(String)");
+	/**
+	 * Stub {@code EntityManager#createQuery(CriteriaSelect)} on the given mock.
+	 * <p>
+	 * The cast pins the overload production code uses: it is the one whose signature is unchanged across Jakarta
+	 * Persistence 3.2 and 4, whereas {@code createQuery(CriteriaQuery)} exists only in 3.2.
+	 */
+	public static <T> OngoingStubbing<TypedQuery<T>> whenCreateQuery(EntityManager entityManager,
+			CriteriaQuery<T> criteriaQuery) {
+		return Mockito.when(entityManager.createQuery((CriteriaSelect<T>) criteriaQuery));
+	}
 
-		return Mockito.mock((Class<? extends Query>) createQuery.getReturnType());
+	/**
+	 * Stub {@link EntityManager#createNamedQuery(String)} on the given mock.
+	 */
+	public static OngoingStubbing<Query> whenCreateNamedQuery(EntityManager entityManager, String queryName) {
+		return Mockito.when(invoke(CREATE_NAMED_QUERY, entityManager, queryName));
+	}
+
+	/**
+	 * Stub {@link EntityManager#createNativeQuery(String)} on the given mock.
+	 */
+	public static OngoingStubbing<Query> whenCreateNativeQuery(EntityManager entityManager, String queryString) {
+		return Mockito.when(invoke(CREATE_NATIVE_QUERY, entityManager, queryString));
+	}
+
+	/**
+	 * Stub {@link EntityManager#createNativeQuery(String, Class)} on the given mock.
+	 */
+	public static OngoingStubbing<Query> whenCreateNativeQuery(EntityManager entityManager, String queryString,
+			Class<?> resultClass) {
+		return Mockito.when(invoke(CREATE_NATIVE_QUERY_WITH_TYPE, entityManager, queryString, resultClass));
+	}
+
+	/**
+	 * Invoke {@link EntityManager#createQuery(String)} on an entity manager already put into verification mode.
+	 * <p>
+	 * {@code Mockito.verify(…)} stays at the call site on purpose: arguments are evaluated before the call, so an
+	 * argument matcher passed to this method would be registered before verification starts and Mockito would reject it
+	 * as misplaced.
+	 */
+	public static void verifyCreateQuery(EntityManager verifiedEntityManager, String queryString) {
+		invoke(CREATE_QUERY, verifiedEntityManager, queryString);
+	}
+
+	/**
+	 * Invoke {@link EntityManager#createNativeQuery(String)} on an entity manager already put into verification mode.
+	 */
+	public static void verifyCreateNativeQuery(EntityManager verifiedEntityManager, String queryString) {
+		invoke(CREATE_NATIVE_QUERY, verifiedEntityManager, queryString);
+	}
+
+	/**
+	 * Invoke {@link EntityManager#createNativeQuery(String, Class)} on an entity manager already put into verification
+	 * mode.
+	 */
+	public static void verifyCreateNativeQuery(EntityManager verifiedEntityManager, String queryString,
+			Class<?> resultClass) {
+		invoke(CREATE_NATIVE_QUERY_WITH_TYPE, verifiedEntityManager, queryString, resultClass);
+	}
+
+	private static Query invoke(Method method, EntityManager entityManager, Object... arguments) {
+		return (Query) ReflectionUtils.invokeMethod(method, entityManager, arguments);
+	}
+
+	private static Method resolveMethod(String methodName, Class<?>... parameterTypes) {
+
+		Method method = ReflectionUtils.findMethod(EntityManager.class, methodName, parameterTypes);
+
+		Assert.state(method != null, () -> "Cannot resolve EntityManager.%s".formatted(methodName));
+
+		return method;
 	}
 }

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/support/EntityManagerTestUtils.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/support/EntityManagerTestUtils.java
@@ -16,13 +16,17 @@
 package org.springframework.data.jpa.support;
 
 import jakarta.persistence.EntityManager;
+import jakarta.persistence.Query;
 
+import org.mockito.Mockito;
+import org.springframework.util.Assert;
 import org.springframework.util.ReflectionUtils;
 
 /**
  * Utility class with {@link EntityManager} related helper methods.
  *
  * @author Thomas Darimont
+ * @author Oscar Fanchin
  */
 public abstract class EntityManagerTestUtils {
 
@@ -35,5 +39,23 @@ public abstract class EntityManagerTestUtils {
 
 	public static boolean currentEntityManagerIsHibernateEntityManager(EntityManager em) {
 		return em.getDelegate().getClass().getName().toLowerCase().contains("hibernate");
+	}
+
+	/**
+	 * Creates a query mock matching the return type of {@link EntityManager#createQuery(String)}.
+	 * <p>
+	 * Jakarta Persistence 4 changes the return type from {@link Query} to {@code StatementOrTypedQuery}. Resolving the
+	 * method at runtime keeps these test sources compilable against both API generations.
+	 *
+	 * @return a query mock compatible with the Jakarta Persistence API on the classpath.
+	 */
+	@SuppressWarnings("unchecked")
+	public static Query mockQuery() {
+
+		var createQuery = ReflectionUtils.findMethod(EntityManager.class, "createQuery", String.class);
+
+		Assert.state(createQuery != null, "Cannot resolve EntityManager.createQuery(String)");
+
+		return Mockito.mock((Class<? extends Query>) createQuery.getReturnType());
 	}
 }

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/util/DisabledOnHibernate.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/util/DisabledOnHibernate.java
@@ -24,10 +24,11 @@ import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * {@code @DisabledOnHibernate} is used to signal that the annotated test class or test method is only <em>disabled</em>
- * if the given Hibernate {@linkplain #value version} is being used.
+ * if any of the given Hibernate {@linkplain #value versions} is being used.
  *
  * @author Greg Turnquist
  * @author Mark Paluch
+ * @author Oscar Fanchin
  * @since 3.2
  */
 @Target({ ElementType.TYPE, ElementType.METHOD, ElementType.ANNOTATION_TYPE })
@@ -36,12 +37,12 @@ import org.junit.jupiter.api.extension.ExtendWith;
 public @interface DisabledOnHibernate {
 
 	/**
-	 * The version of Hibernate to disable the test or container case on. The version specifier can hold individual
+	 * The versions of Hibernate to disable the test or container case on. Each version specifier can hold individual
 	 * version components matching effectively the version in a prefix-manner. The more specific you want to match, the
-	 * more version components you can specify, such as {@code  6.2.1} to match a specific service release or {@code 6} to
+	 * more version components you can specify, such as {@code 6.2.1} to match a specific service release or {@code 6} to
 	 * match a full major version.
 	 */
-	String value();
+	String[] value();
 
 	/**
 	 * Custom reason to provide if the test or container is disabled.

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/util/DisabledOnHibernateCondition.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/util/DisabledOnHibernateCondition.java
@@ -16,6 +16,7 @@
 package org.springframework.data.jpa.util;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -25,6 +26,7 @@ import org.junit.jupiter.api.extension.ExecutionCondition;
 /**
  * {@link ExecutionCondition} for {@link DisabledOnHibernate @DisabledOnHibernate}.
  *
+ * @author Oscar Fanchin
  * @see DisabledOnHibernate
  */
 class DisabledOnHibernateCondition extends BooleanExecutionCondition<DisabledOnHibernate> {
@@ -43,10 +45,11 @@ class DisabledOnHibernateCondition extends BooleanExecutionCondition<DisabledOnH
 	@Override
 	boolean isEnabled(DisabledOnHibernate annotation) {
 
-		VersionMatcher disabled = VersionMatcher.parse(annotation.value());
 		VersionMatcher hibernate = VersionMatcher.parse(org.hibernate.Version.getVersionString());
 
-		return !disabled.matches(hibernate);
+		return Arrays.stream(annotation.value()) //
+				.map(VersionMatcher::parse) //
+				.noneMatch(disabled -> disabled.matches(hibernate));
 	}
 
 	static class VersionMatcher {

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/util/DisabledOnHibernateConditionTests.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/util/DisabledOnHibernateConditionTests.java
@@ -16,6 +16,7 @@
 package org.springframework.data.jpa.util;
 
 import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
 import static org.springframework.data.jpa.util.DisabledOnHibernateCondition.*;
 
 import org.junit.jupiter.api.Test;
@@ -24,6 +25,7 @@ import org.junit.jupiter.api.Test;
  * Unit tests for {@link DisabledOnHibernate}.
  *
  * @author Mark Paluch
+ * @author Oscar Fanchin
  */
 class DisabledOnHibernateConditionTests {
 
@@ -52,5 +54,14 @@ class DisabledOnHibernateConditionTests {
 		VersionMatcher lib = VersionMatcher.parse("1.2");
 
 		assertThat(spec.matches(lib)).isFalse();
+	}
+
+	@Test
+	void shouldDisableOnAnyConfiguredVersion() {
+
+		DisabledOnHibernate annotation = mock(DisabledOnHibernate.class);
+		when(annotation.value()).thenReturn(new String[] { "7", "8" });
+
+		assertThat(new DisabledOnHibernateCondition().isEnabled(annotation)).isFalse();
 	}
 }

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/util/TestMetaModel.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/util/TestMetaModel.java
@@ -33,6 +33,7 @@ import org.springframework.orm.jpa.persistenceunit.SpringPersistenceUnitInfo;
 
 /**
  * @author Christoph Strobl
+ * @author Oscar Fanchin
  */
 public class TestMetaModel implements Metamodel {
 
@@ -99,9 +100,14 @@ public class TestMetaModel implements Metamodel {
 		persistenceUnitInfo.setPersistenceUnitName(persistenceUnit);
 		this.managedTypes.stream().map(Class::getName).forEach(persistenceUnitInfo::addManagedClassName);
 		persistenceUnitInfo.setPersistenceProviderClassName(HibernatePersistenceProvider.class.getName());
+		persistenceUnitInfo.setExcludeUnlistedClasses(true);
+
+		Map<String, Object> properties = Map.of( //
+				"hibernate.dialect", "org.hibernate.dialect.H2Dialect", //
+				"hibernate.xml_mapping_enabled", false);
 
 		return new EntityManagerFactoryBuilderImpl(
 				new PersistenceUnitInfoDescriptor(persistenceUnitInfo.asStandardPersistenceUnitInfo()) {},
-				Map.of("hibernate.dialect", "org.hibernate.dialect.H2Dialect")).build();
+				properties).build();
 	}
 }

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/util/TestMetaModel.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/util/TestMetaModel.java
@@ -41,7 +41,7 @@ public class TestMetaModel implements Metamodel {
 	private final Set<Class<?>> managedTypes;
 	private final Lazy<EntityManagerFactory> entityManagerFactory = Lazy.of(this::init);
 	private final Lazy<Metamodel> metamodel = Lazy.of(() -> entityManagerFactory.get().getMetamodel());
-	private final Lazy<EntityManager> entityManager = Lazy.of(() -> entityManagerFactory.get().createEntityManager());
+	private final Lazy<EntityManager> entityManager = Lazy.of(() -> entityManagerFactory.get().createEntityManager(Map.of()));
 
 	private TestMetaModel(Set<Class<?>> managedTypes) {
 		this("dynamic-tests", managedTypes);


### PR DESCRIPTION
Handling interoperability between generations turned into two distinct problems.

Hibernate's changes to SPIs and classes are handled by two reflective adapters, one per Hibernate
generation. The binary incompatibility between the Jakarta Persistence 3.2 and 4.0 signatures is
handled by a bridge. On 3.2, which is the baseline, the calls go through directly; on 4.0 they rely
on reflection.

Hibernate 8.x is used through opt-in profiles and the snapshot repository is declared inside them,
so the default build resolves nothing from it.

I tried to make the way I worked visible in the commits: cross-version compilation first, then the
build and the tests obtained by recompiling, with the behaviour changes documented as they came up.

The point is where this ends up: a build made only against Jakarta Persistence 3.2 and Hibernate 7
runs under both profiles, without recompiling.

Three of these changes are deliberately standalone, so any one of them can be dropped without
affecting the others: the temporary artifact versions, the AOT generation change, and the workaround
for Hibernate 8 named queries. I tried it, and they come out easily.

Rationale in [#4197](https://github.com/spring-projects/spring-data-jpa/issues/4197).

- [X] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [X] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [X] You submit test cases (unit or integration tests) that back your changes.
- [X] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
