### PR TITLE
Introduce configurable FK-column optimization for derived to-one predicates

### DIFF
--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/ExpressionFactorySupport.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/ExpressionFactorySupport.java
@@ -60,6 +60,41 @@ class ExpressionFactorySupport {
 	}
 
 	/**
+	 * Whether an explicit join is rendered when a derived query predicate navigates an owning-side to-one association to
+	 * reach a plain leaf property (e.g. {@code find…ByAbonentCode} mapping to {@code Contract.abonent.code}).
+	 * <p>
+	 * When {@code false}, the implicit dotted path is rendered instead of an explicit {@code JOIN}. The persistence
+	 * provider may then collapse the predicate onto the foreign-key column (e.g. {@code WHERE contracts.abonent = ?}),
+	 * which matches the behaviour before Spring Data JPA 4.0 and avoids a redundant join.
+	 * <p>
+	 * Defaults to {@code true} to preserve the behaviour introduced with
+	 * <a href="https://github.com/spring-projects/spring-data-jpa/issues/3349">#3349</a> and
+	 * <a href="https://github.com/spring-projects/spring-data-jpa/issues/3588">#3588</a>.
+	 */
+	private static boolean joinOnToOneAssociation = true;
+
+	/**
+	 * Check whether an explicit join is rendered for derived query predicates that traverse an owning-side to-one
+	 * association to reach a plain leaf property.
+	 *
+	 * @return {@literal true} to keep explicit joins (default), {@literal false} to render the implicit dotted path.
+	 */
+	public static boolean isJoinOnToOneAssociation() {
+		return joinOnToOneAssociation;
+	}
+
+	/**
+	 * Configure whether an explicit join is rendered for derived query predicates that traverse an owning-side to-one
+	 * association to reach a plain leaf property.
+	 *
+	 * @param enabled {@literal true} to keep explicit joins (default), {@literal false} to render the implicit dotted
+	 *          path and let the persistence provider collapse the predicate onto the foreign-key column.
+	 */
+	public static void setJoinOnToOneAssociation(boolean enabled) {
+		joinOnToOneAssociation = enabled;
+	}
+
+	/**
 	 * Checks if this attribute requires an outer join. This is the case e.g. if it hadn't already been fetched with an
 	 * inner join and if it's an optional association, and if previous paths has already required outer joins. It also
 	 * ensures outer joins are used even when Hibernate defaults to inner joins (HHH-12712 and HHH-12999).
@@ -118,6 +153,38 @@ class ExpressionFactorySupport {
 
 		Bindable<?> bindable = resolver.resolveNext(property);
 		return bindable instanceof SingularAttribute<?, ?> sa && sa.isId();
+	}
+
+	/**
+	 * Checks if the given property path refers to an owning-side to-one association
+	 * ({@code @ManyToOne} or an owning {@code @OneToOne}).
+	 * <p>
+	 * The inverse side of a {@code @OneToOne} association is excluded as it requires an explicit join to be rendered
+	 * correctly (see HHH-12712). Collections are excluded as well.
+	 *
+	 * @param resolver the {@link ModelPathResolver resolver}.
+	 * @param property the property path.
+	 * @return {@literal true} if the property resolves to an owning-side to-one association.
+	 */
+	public boolean isToOneAssociation(ModelPathResolver resolver, PropertyPath property) {
+
+		Bindable<?> bindable = resolver.resolve(property);
+
+		if (!(bindable instanceof Attribute<?, ?> attribute)) {
+			return false;
+		}
+
+		if (attribute.isCollection()) {
+			return false;
+		}
+
+		Attribute.PersistentAttributeType type = attribute.getPersistentAttributeType();
+
+		if (type != MANY_TO_ONE && type != ONE_TO_ONE) {
+			return false;
+		}
+
+		return !(ONE_TO_ONE == type && StringUtils.hasText(getAnnotationProperty(attribute, "mappedBy", "")));
 	}
 
 	@SuppressWarnings("unchecked")

--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/JpqlUtils.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/JpqlUtils.java
@@ -79,6 +79,16 @@ class JpqlUtils {
 				return new JpqlQueryBuilder.PathAndOrigin(property, source, false);
 			}
 
+			// GH-4332: when configured, avoid rendering an explicit join for an owning-side to-one association that is
+			// only traversed to reach a plain leaf property (e.g. find…ByAbonentCode maps to Contract.abonent.code).
+			// Rendering the implicit dotted path lets the persistence provider collapse the predicate onto the
+			// foreign-key column (WHERE contracts.abonent = ?), which is the behaviour before 4.0. The nested to-one
+			// path is preserved whenever a parent join is already required (e.g. HHH-12712 / HHH-12999).
+			if (!isJoinOnToOneAssociation() && !isForSelection && !hasRequiredOuterJoin && !isLeafProperty
+					&& !isRelationshipId && isToOneAssociation(resolver, property)) {
+				return new JpqlQueryBuilder.PathAndOrigin(property, source, false);
+			}
+
 			// get or create the join
 			JpqlQueryBuilder.Join joinSource = requiresOuterJoin ? JpqlQueryBuilder.leftJoin(source, segment)
 					: JpqlQueryBuilder.innerJoin(source, segment);

--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/PartTreeJpaQuery.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/PartTreeJpaQuery.java
@@ -64,6 +64,15 @@ public class PartTreeJpaQuery extends AbstractJpaQuery {
 	private static final Logger log = LoggerFactory.getLogger(PartTreeJpaQuery.class);
 	private final JpqlQueryTemplates templates = JpqlQueryTemplates.UPPER;
 
+	/**
+	 * Property controlling whether an explicit join is rendered when a derived query predicate navigates an
+	 * owning-side to-one association to reach a plain leaf property. When set to {@literal true} the implicit dotted
+	 * path is rendered instead, which lets the persistence provider collapse the predicate onto the foreign-key column
+	 * (behaviour before Spring Data JPA 4.0). Configured through {@code EntityManagerFactory} properties, e.g.
+	 * {@code spring.data.jpa.derived-query.prefer-fk-column=true}. Defaults to {@literal false} (explicit joins).
+	 */
+	static final String JOIN_ON_TO_ONE_ASSOCIATION_PROPERTY = "spring.data.jpa.derived-query.prefer-fk-column";
+
 	private final PartTree tree;
 	private final JpaParameters parameters;
 
@@ -99,6 +108,8 @@ public class PartTreeJpaQuery extends AbstractJpaQuery {
 		this.escape = escape;
 		this.parameters = method.getParameters();
 		this.persistenceProvider = PersistenceProvider.fromEntityManager(em);
+
+		updateJoinOnToOneAssociation(em);
 
 		Class<?> domainClass = method.getEntityInformation().getJavaType();
 		this.entityInformation = Lazy.of(() -> JpaEntityInformationSupport.getEntityInformation(domainClass, em));
@@ -143,6 +154,21 @@ public class PartTreeJpaQuery extends AbstractJpaQuery {
 		}
 
 		return super.getExecution(accessor);
+	}
+
+	/**
+	 * Applies the {@value #JOIN_ON_TO_ONE_ASSOCIATION_PROPERTY} {@code EntityManagerFactory} property to the global
+	 * expression-factory configuration. The setting is intentionally global as it affects the whole persistence unit.
+	 *
+	 * @param em must not be {@literal null}.
+	 */
+	private static void updateJoinOnToOneAssociation(EntityManager em) {
+
+		Object value = em.getEntityManagerFactory().getProperties().get(JOIN_ON_TO_ONE_ASSOCIATION_PROPERTY);
+
+		if (value instanceof String stringValue) {
+			ExpressionFactorySupport.setJoinOnToOneAssociation(!Boolean.parseBoolean(stringValue.trim()));
+		}
 	}
 
 	private static void validate(PartTree tree, JpaParameters parameters) {

--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/QueryUtils.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/QueryUtils.java
@@ -856,6 +856,22 @@ public abstract class QueryUtils {
 				return trailingPath;
 			}
 
+			// GH-4332: when configured, avoid rendering an explicit join for an owning-side to-one association that is
+			// only traversed to reach a plain leaf property (e.g. find…ByAbonentCode maps to Contract.abonent.code).
+			// Traversing the path implicitly lets the persistence provider collapse the predicate onto the
+			// foreign-key column, which is the behaviour before 4.0. Nested to-one paths that already require a parent
+			// join (e.g. HHH-12712 / HHH-12999) are left untouched.
+			if (!isJoinOnToOneAssociation() && !isForSelection && !hasRequiredOuterJoin && !isLeafProperty
+					&& !isRelationshipId && isToOneAssociation(resolver, property)) {
+				Path<T> trailingPath = from.get(segment);
+				PropertyPath current = property;
+				while (current.hasNext()) {
+					current = current.next();
+					trailingPath = trailingPath.get(current.getSegment());
+				}
+				return trailingPath;
+			}
+
 			// get or create the join
 			JoinType joinType = requiresOuterJoin ? JoinType.LEFT : JoinType.INNER;
 			Join<?, ?> join = getOrCreateJoin(from, segment, joinType);

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/JpaQueryCreatorTests.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/JpaQueryCreatorTests.java
@@ -698,6 +698,56 @@ class JpaQueryCreatorTests {
 				.validateQuery();
 	}
 
+	@Test // GH-4332
+	void createsExplicitJoinForToOneLeafByDefault() {
+
+		queryCreator(ORDER_WITH_RELATIONS) //
+				.forTree(OrderWithRelations.class, "findByCustomerNameIs") //
+				.withParameters("spring") //
+				.as(QueryCreatorTester::create) //
+				.expectJpql("SELECT o FROM %s o LEFT JOIN o.customer c WHERE c.name = ?1",
+						DefaultJpaEntityMetadata.unqualify(OrderWithRelations.class)) //
+				.validateQuery();
+	}
+
+	@Test // GH-4332
+	void rendersImplicitPathForToOneLeafWhenConfigured() {
+
+		boolean previous = ExpressionFactorySupport.isJoinOnToOneAssociation();
+		try {
+			ExpressionFactorySupport.setJoinOnToOneAssociation(false);
+
+			queryCreator(ORDER_WITH_RELATIONS) //
+					.forTree(OrderWithRelations.class, "findByCustomerNameIs") //
+					.withParameters("spring") //
+					.as(QueryCreatorTester::create) //
+					.expectJpql("SELECT o FROM %s o WHERE o.customer.name = ?1",
+							DefaultJpaEntityMetadata.unqualify(OrderWithRelations.class)) //
+					.validateQuery();
+		} finally {
+			ExpressionFactorySupport.setJoinOnToOneAssociation(previous);
+		}
+	}
+
+	@Test // GH-4332
+	void keepsImplicitPathForToOneId() {
+
+		boolean previous = ExpressionFactorySupport.isJoinOnToOneAssociation();
+		try {
+			ExpressionFactorySupport.setJoinOnToOneAssociation(false);
+
+			queryCreator(ORDER_WITH_RELATIONS) //
+					.forTree(OrderWithRelations.class, "findByCustomerId") //
+					.withParameters(1L) //
+					.as(QueryCreatorTester::create) //
+					.expectJpql("SELECT o FROM %s o WHERE o.customer.id = ?1",
+							DefaultJpaEntityMetadata.unqualify(OrderWithRelations.class)) //
+					.validateQuery();
+		} finally {
+			ExpressionFactorySupport.setJoinOnToOneAssociation(previous);
+		}
+	}
+
 	@Test // GH-3588
 	void dtoProjection() {
 


### PR DESCRIPTION
# Add configurable FK-column optimization for derived queries traversing to-one associations

Closes #4332

## Problem

A derived query such as `findByAbonentCode()` on `Contract` with

```java
@ManyToOne(fetch = FetchType.EAGER)
@JoinColumn(name = "abonent", referencedColumnName = "code")
Abonent abonent;
```

is rendered since Spring Data JPA 3.2.1 as:

```sql
select ... from contracts c
left join abonents a on a.code = c.abonent
where a.code = ?
```

The FK column `contracts.abonent` physically stores the `code` value (declared via
`referencedColumnName = "code"`), so the join is redundant. Before 3.2.1 (i.e. up to
Spring Data JPA 3.2.0) the predicate was collapsed onto the FK column:

```sql
select ... from contracts c where c.abonent = ?
```

The join is emitted explicitly in JPQL by the `JpqlQueryBuilder`-based engine
(`JpqlExpressionFactory` in `JpqlUtils`) and the Criteria-based `FromExpressionFactory`
in `QueryUtils`. An explicit join is intentional in some cases (composite/`@MapsId`, see
#3349 / #3588), so the optimisation is introduced as a configurable, default-off option.

## Change

Add a global, JPA-property-driven toggle:

- `spring.data.jpa.derived-query.prefer-fk-column=false` (default) — keep current behaviour
  (explicit `JOIN`), preserving #3349 / #3588.
- `spring.data.jpa.derived-query.prefer-fk-column=true` — render the implicit dotted path
  (`o.abonent.code`) for a predicate that traverses an **owning-side to-one** association to
  reach a **plain leaf** property. The persistence provider then collapses it to the
  foreign-key column (`WHERE c.abonent = ?`), restoring the pre-3.2.1 SQL.

### Files touched

- `ExpressionFactorySupport`
  - static `joinOnToOneAssociation` flag (default `true`) with
    `isJoinOnToOneAssociation()` / `setJoinOnToOneAssociation(boolean)`;
  - `isToOneAssociation(resolver, property)` — detects owning-side `@ManyToOne` / `@OneToOne`
    (excludes inverse one-to-one mapped-by and collections).
- `JpqlUtils.JpqlExpressionFactory.toExpressionRecursively` — emits the implicit dotted
  path instead of an explicit join, guarded by `!isForSelection && !hasRequiredOuterJoin
  && !isLeafProperty && !isRelationshipId && isToOneAssociation(...)` when enabled.
- `QueryUtils.FromExpressionFactory.toExpressionRecursively` — the Criteria equivalent,
  traversing the path from the `From` instead of creating a join.
- `PartTreeJpaQuery` — reads
  `em.getEntityManagerFactory().getProperties().get("spring.data.jpa.derived-query.prefer-fk-column")`
  and applies it to the global flag (in Spring Boot set via
  `spring.jpa.properties.spring.data.jpa.derived-query.prefer-fk-column=true`).
- `JpaQueryCreatorTests` — three tests:
  `createsExplicitJoinForToOneLeafByDefault`,
  `rendersImplicitPathForToOneLeafWhenConfigured`,
  `keepsImplicitPathForToOneId`.

## Semantics / safety

- Only predicate leaf navigation (`!isForSelection`, `!hasRequiredOuterJoin`) is affected;
  selection/ordering and paths requiring a parent outer join (HHH-12712 / HHH-12999) are
  untouched.
- Collections and inverse `@OneToOne` (mappedBy) are never collapsed.
- Relationship-id paths (`o.customer.id`) were already collapsed (#3349) and remain so.
- The toggle is global and default-off, so no existing behaviour changes unless the
  property is enabled.

## Testing

- `JpaQueryCreatorTests` (80 tests, incl. 3 new) — green.
- `QueryUtilsUnitTests`, `JpqlQueryBuilderUnitTests` — green.
- `QueryUtilsIntegrationTests` (24) — green.
- End-to-end on H2 with the modified build and
  `spring.jpa.properties.spring.data.jpa.derived-query.prefer-fk-column=true`:

  ```sql
  -- bevor
  from contracts c left join abonents a on a.code = c.abonent where a.code = ?
  -- nach
  from contracts c where c.abonent = ?
  ```