### PR TITLE
Allow CAST as a state field name in EQL

### DIFF
--- a/spring-data-jpa/src/main/antlr4/org/springframework/data/jpa/repository/query/Eql.g4
+++ b/spring-data-jpa/src/main/antlr4/org/springframework/data/jpa/repository/query/Eql.g4
@@ -24,6 +24,7 @@ grammar Eql;
  * @author Greg Turnquist
  * @author Christoph Strobl
  * @author Jewoo Shin
+ * @author Wantaek Choi
  * @since 3.2
  */
 }
@@ -804,6 +805,7 @@ reserved_word
        |BOTH
        |BY
        |CASE
+       |CAST
        |CEILING
        |COALESCE
        |CONCAT

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/JpqlQueryRendererTckTests.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/JpqlQueryRendererTckTests.java
@@ -28,6 +28,7 @@ import org.junit.jupiter.params.provider.ValueSource;
  *
  * @author Mark Paluch
  * @author Jewoo Shin
+ * @author Wantaek Choi
  */
 abstract class JpqlQueryRendererTckTests {
 
@@ -1479,6 +1480,12 @@ abstract class JpqlQueryRendererTckTests {
 
 		String source = "select new com.company.%s.thing.stuff.ClassName(e.id) from Experience e".formatted(reservedWord);
 		assertQuery(source);
+	}
+
+	@Test
+	void castShouldBeAValidStateField() {
+
+		assertQuery("select m.cast from Movie m where m.cast is not null");
 	}
 
 	@Test // GH-3496


### PR DESCRIPTION
`Eql.g4` declares a `CAST` token for the cast function rules but leaves it out of `reserved_word`, so an entity attribute named `cast` cannot be parsed. `select m.cast from Movie m where m.cast is not null` fails with a `BadJpqlGrammarException` (`At 1:9 and token 'cast', no viable alternative`), while JPQL and HQL parse the same query. Applications running on EclipseLink are affected because `DefaultQueryEnhancerSelector` picks the EQL parser when Hibernate is absent.

`Jpql.g4` gained the `reserved_word` entry in b0a29229c along with the reworked cast function rules. `Eql.g4` received the rules but not the `reserved_word` entry, and it has never had one. `CAST` is the only token that one grammar lists there and the other does not; the remaining entries are identical in both.

This PR adds `CAST` to the EQL `reserved_word` rule and covers the shape in the shared renderer TCK, so JPQL, EQL, and HQL all assert it.

Verified with `./mvnw -pl spring-data-jpa -Dtest='*QueryRenderer*,*Eql*,*Jpql*,*Hql*' test`. Removing the grammar line again leaves the new test as the only failure.

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
