### PR TITLE
Support the ID and VERSION functions in JPQL and EQL

### DIFF
--- a/spring-data-jpa/src/main/antlr4/org/springframework/data/jpa/repository/query/Eql.g4
+++ b/spring-data-jpa/src/main/antlr4/org/springframework/data/jpa/repository/query/Eql.g4
@@ -24,6 +24,7 @@ grammar Eql;
  * @author Greg Turnquist
  * @author Christoph Strobl
  * @author Jewoo Shin
+ * @author Wantaek Choi
  * @since 3.2
  */
 }
@@ -317,6 +318,7 @@ scalar_expression
     | boolean_expression
     | case_expression
     | entity_type_expression
+    | entity_id_or_version_function
     ;
 
 conditional_expression
@@ -414,6 +416,7 @@ comparison_expression
     | datetime_expression comparison_operator (datetime_expression | all_or_any_expression)     #DatetimeComparison
     | entity_expression op=(EQUAL | NOT_EQUAL) (entity_expression | all_or_any_expression)      #EntityComparison
     | arithmetic_expression comparison_operator (arithmetic_expression | all_or_any_expression) #ArithmeticComparison
+    | entity_id_or_version_function op=(EQUAL | NOT_EQUAL) input_parameter                      #EntityIdOrVersionComparison
     | entity_type_expression op=(EQUAL | NOT_EQUAL) entity_type_expression                      #EntityTypeComparison
     | string_expression REGEXP string_literal                                                   #RegexpComparison
     ;
@@ -574,6 +577,19 @@ string_cast_function
     : CAST '(' scalar_expression (AS)? STRING ')'
     ;
 
+entity_id_or_version_function
+    : id_function
+    | version_function
+    ;
+
+id_function
+    : ID '(' (general_identification_variable | single_valued_object_path_expression) ')'
+    ;
+
+version_function
+    : VERSION '(' (general_identification_variable | single_valued_object_path_expression) ')'
+    ;
+
 function_invocation
     : (FUNCTION|identification_variable) '(' function_name (',' function_arg)* ')'
     ;
@@ -669,7 +685,9 @@ identification_variable
     | SIGN
     | TIME
     | TYPE
-    | VALUE)
+    | VALUE
+    | ID
+    | VERSION)
     | type_literal
     ;
 
@@ -828,6 +846,7 @@ reserved_word
        |FETCH
        |FLOOR
        |FUNCTION
+       |ID
        |IN
        |INDEX
        |INNER
@@ -875,7 +894,8 @@ reserved_word
        |TYPE
        |UPDATE
        |UPPER
-       |VALUE)
+       |VALUE
+       |VERSION)
        ;
 /*
     Lexer rules
@@ -959,6 +979,7 @@ FROM                        : F R O M;
 FUNCTION                    : F U N C T I O N;
 GROUP                       : G R O U P;
 HAVING                      : H A V I N G;
+ID                          : I D;
 IN                          : I N;
 INDEX                       : I N D E X;
 INNER                       : I N N E R;
@@ -1017,6 +1038,7 @@ UNION                       : U N I O N;
 UPDATE                      : U P D A T E;
 UPPER                       : U P P E R;
 VALUE                       : V A L U E;
+VERSION                     : V E R S I O N;
 WHEN                        : W H E N;
 WHERE                       : W H E R E;
 

--- a/spring-data-jpa/src/main/antlr4/org/springframework/data/jpa/repository/query/Jpql.g4
+++ b/spring-data-jpa/src/main/antlr4/org/springframework/data/jpa/repository/query/Jpql.g4
@@ -25,6 +25,7 @@ grammar Jpql;
  * @author Greg Turnquist
  * @author Christoph Strobl
  * @author Jewoo Shin
+ * @author Wantaek Choi
  * @since 3.1
  */
 }
@@ -317,6 +318,7 @@ scalar_expression
     | boolean_expression
     | case_expression
     | entity_type_expression
+    | entity_id_or_version_function
     ;
 
 conditional_expression
@@ -414,6 +416,7 @@ comparison_expression
     | datetime_expression comparison_operator (datetime_expression | all_or_any_expression)     #DatetimeComparison
     | entity_expression op=(EQUAL | NOT_EQUAL) (entity_expression | all_or_any_expression)      #EntityComparison
     | arithmetic_expression comparison_operator (arithmetic_expression | all_or_any_expression) #ArithmeticComparison
+    | entity_id_or_version_function op=(EQUAL | NOT_EQUAL) input_parameter                      #EntityIdOrVersionComparison
     | entity_type_expression op=(EQUAL | NOT_EQUAL) entity_type_expression                      #EntityTypeComparison
     | string_expression REGEXP string_literal                                                   #RegexpComparison
     ;
@@ -574,6 +577,19 @@ string_cast_function
     : CAST '(' scalar_expression (AS)? STRING ')'
     ;
 
+entity_id_or_version_function
+    : id_function
+    | version_function
+    ;
+
+id_function
+    : ID '(' (general_identification_variable | single_valued_object_path_expression) ')'
+    ;
+
+version_function
+    : VERSION '(' (general_identification_variable | single_valued_object_path_expression) ')'
+    ;
+
 function_invocation
     : FUNCTION '(' function_name (',' function_arg)* ')'
     ;
@@ -662,7 +678,9 @@ identification_variable
     | SIGN
     | TIME
     | TYPE
-    | VALUE)
+    | VALUE
+    | ID
+    | VERSION)
     | type_literal
     ;
 
@@ -830,6 +848,7 @@ reserved_word
        |FETCH
        |FLOOR
        |FUNCTION
+       |ID
        |IN
        |INDEX
        |INNER
@@ -877,7 +896,8 @@ reserved_word
        |TYPE
        |UPDATE
        |UPPER
-       |VALUE)
+       |VALUE
+       |VERSION)
        ;
 /*
     Lexer rules
@@ -961,6 +981,7 @@ FROM                        : F R O M;
 FUNCTION                    : F U N C T I O N;
 GROUP                       : G R O U P;
 HAVING                      : H A V I N G;
+ID                          : I D;
 IN                          : I N;
 INDEX                       : I N D E X;
 INNER                       : I N N E R;
@@ -1019,6 +1040,7 @@ UNION                       : U N I O N;
 UPDATE                      : U P D A T E;
 UPPER                       : U P P E R;
 VALUE                       : V A L U E;
+VERSION                     : V E R S I O N;
 WHEN                        : W H E N;
 WHERE                       : W H E R E;
 

--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/EqlQueryRenderer.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/EqlQueryRenderer.java
@@ -37,6 +37,7 @@ import org.springframework.util.CollectionUtils;
  * @author Mark Paluch
  * @author TaeHyun Kang
  * @author Jewoo Shin
+ * @author Wantaek Choi
  * @since 3.2
  */
 @SuppressWarnings({ "ConstantConditions", "DuplicatedCode" })
@@ -722,6 +723,32 @@ class EqlQueryRenderer extends EqlBaseVisitor<QueryTokenStream> {
 		}
 
 		return QueryTokenStream.ofFunction(ctx.TYPE(), builder);
+	}
+
+	@Override
+	public QueryTokenStream visitId_function(EqlParser.Id_functionContext ctx) {
+		return QueryTokenStream.ofFunction(ctx.ID(), renderIdOrVersionArgument(ctx.general_identification_variable(),
+				ctx.single_valued_object_path_expression()));
+	}
+
+	@Override
+	public QueryTokenStream visitVersion_function(EqlParser.Version_functionContext ctx) {
+		return QueryTokenStream.ofFunction(ctx.VERSION(), renderIdOrVersionArgument(ctx.general_identification_variable(),
+				ctx.single_valued_object_path_expression()));
+	}
+
+	private QueryTokenStream renderIdOrVersionArgument(EqlParser.General_identification_variableContext variable,
+			EqlParser.Single_valued_object_path_expressionContext path) {
+
+		QueryRendererBuilder builder = QueryRenderer.builder();
+
+		if (variable != null) {
+			builder.append(visit(variable));
+		} else if (path != null) {
+			builder.append(visit(path));
+		}
+
+		return builder;
 	}
 
 	@Override

--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/JpqlQueryRenderer.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/JpqlQueryRenderer.java
@@ -37,6 +37,7 @@ import org.springframework.util.CollectionUtils;
  * @author Mark Paluch
  * @author TaeHyun Kang
  * @author Jewoo Shin
+ * @author Wantaek Choi
  * @since 3.1
  */
 @SuppressWarnings({ "ConstantConditions", "DuplicatedCode" })
@@ -724,6 +725,32 @@ class JpqlQueryRenderer extends JpqlBaseVisitor<QueryTokenStream> {
 		}
 
 		return QueryTokenStream.ofFunction(ctx.TYPE(), builder);
+	}
+
+	@Override
+	public QueryTokenStream visitId_function(JpqlParser.Id_functionContext ctx) {
+		return QueryTokenStream.ofFunction(ctx.ID(), renderIdOrVersionArgument(ctx.general_identification_variable(),
+				ctx.single_valued_object_path_expression()));
+	}
+
+	@Override
+	public QueryTokenStream visitVersion_function(JpqlParser.Version_functionContext ctx) {
+		return QueryTokenStream.ofFunction(ctx.VERSION(), renderIdOrVersionArgument(ctx.general_identification_variable(),
+				ctx.single_valued_object_path_expression()));
+	}
+
+	private QueryTokenStream renderIdOrVersionArgument(JpqlParser.General_identification_variableContext variable,
+			JpqlParser.Single_valued_object_path_expressionContext path) {
+
+		QueryRendererBuilder builder = QueryRenderer.builder();
+
+		if (variable != null) {
+			builder.append(visit(variable));
+		} else if (path != null) {
+			builder.append(visit(path));
+		}
+
+		return builder;
 	}
 
 	@Override

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/JpqlQueryRendererTckTests.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/JpqlQueryRendererTckTests.java
@@ -28,6 +28,7 @@ import org.junit.jupiter.params.provider.ValueSource;
  *
  * @author Mark Paluch
  * @author Jewoo Shin
+ * @author Wantaek Choi
  */
 abstract class JpqlQueryRendererTckTests {
 
@@ -1479,6 +1480,23 @@ abstract class JpqlQueryRendererTckTests {
 
 		String source = "select new com.company.%s.thing.stuff.ClassName(e.id) from Experience e".formatted(reservedWord);
 		assertQuery(source);
+	}
+
+	@Test
+	void idAndVersionFunctionsShouldWork() {
+
+		assertQuery("select id(e) from Employee e");
+		assertQuery("select version(e) from Employee e");
+		assertQuery("select id(e.dept) from Employee e");
+		assertQuery("select e from Employee e where id(e) = :id");
+	}
+
+	@Test
+	void idAndVersionShouldRemainUsableAsNames() {
+
+		assertQuery("select e.id, e.version from Employee e where e.id = :id");
+		assertQuery("select v from Version v");
+		assertQuery("select new com.company.id.thing.ClassName(e.a) from Experience e");
 	}
 
 	@Test // GH-3496


### PR DESCRIPTION
`select id(e) from Employee e` fails to parse as JPQL and as EQL.

Jakarta Persistence 3.2 section 4.7.11 defines `ID(x)` and `VERSION(x)`. `Hql.g4` has both functions; `Jpql.g4` and `Eql.g4` have neither.

This adds the productions the way the specification BNF writes them and renders both functions in the JPQL and EQL renderers.

New tokens would stop `id` and `version` from working as names, so both stay usable as identifiers. `idAndVersionAsIdentifiers` covers that.

Reverting the grammar change makes `idAndVersionFunctions` fail.

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
