### PR TITLE
Reduce HQL parser cold-start allocation

### DIFF
--- a/spring-data-jpa/src/jmh/java/org/springframework/data/jpa/repository/query/HqlParserColdStartBenchmarks.java
+++ b/spring-data-jpa/src/jmh/java/org/springframework/data/jpa/repository/query/HqlParserColdStartBenchmarks.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2026-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.jpa.repository.query;
+
+import java.util.concurrent.TimeUnit;
+
+import org.junit.platform.commons.annotation.Testable;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Timeout;
+import org.openjdk.jmh.annotations.Warmup;
+
+/**
+ * @author Arai
+ */
+@Testable
+@Fork(10)
+@Warmup(iterations = 0)
+@Measurement(iterations = 1, batchSize = 1)
+@BenchmarkMode(Mode.SingleShotTime)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@Timeout(time = 5)
+public class HqlParserColdStartBenchmarks {
+
+	private static final String QUERY = """
+			select new com.example.InvoiceSummary(
+				i.id,
+				coalesce(sum(case when line.kind = 'SALE' then line.amount else 0 end), 0),
+				coalesce(sum(case when line.kind = 'REFUND' then line.amount else 0 end), 0),
+				case when exists (select 1 from Payment payment where payment.invoice = i and payment.state = 'PAID')
+					then true else false end,
+				lower(coalesce(customer.name, customer.companyName, '')),
+				function('jsonb_extract_path_text', i.metadata, 'source'))
+			from Invoice i
+			join i.customer customer
+			left join i.lines line
+			where (:tenantId is null or i.tenantId = :tenantId)
+				and (:search is null
+					or lower(coalesce(i.number, '')) like lower(concat('%', :search, '%'))
+					or lower(coalesce(customer.name, customer.companyName, '')) like lower(concat('%', :search, '%'))
+					or lower(function('jsonb_extract_path_text', i.metadata, 'reference')) like lower(concat('%', :search, '%')))
+				and (:states is null or i.state in :states)
+				and i.createdAt between :from and :to
+				and not exists (select 1 from Cancellation cancellation where cancellation.invoice = i)
+			group by i.id, customer.name, customer.companyName, i.metadata
+			having coalesce(sum(case when line.kind = 'SALE' then line.amount else 0 end), 0) >= :minimum
+			order by lower(coalesce(customer.name, customer.companyName, '')), i.id
+			""";
+
+	@Benchmark
+	public Object parse() {
+		return JpaQueryEnhancer.forHql(QUERY);
+	}
+}

--- a/spring-data-jpa/src/jmh/java/org/springframework/data/jpa/repository/query/HqlParserColdStartBenchmarks.java
+++ b/spring-data-jpa/src/jmh/java/org/springframework/data/jpa/repository/query/HqlParserColdStartBenchmarks.java
@@ -29,6 +29,7 @@ import org.openjdk.jmh.annotations.Warmup;
 
 /**
  * @author Arai
+ * @author Greg Taube
  */
 @Testable
 @Fork(10)
@@ -65,7 +66,17 @@ public class HqlParserColdStartBenchmarks {
 			""";
 
 	@Benchmark
-	public Object parse() {
+	public Object parseHql() {
 		return JpaQueryEnhancer.forHql(QUERY);
+	}
+
+	@Benchmark
+	public Object parseEql() {
+		return JpaQueryEnhancer.forEql(QUERY);
+	}
+
+	@Benchmark
+	public Object parseJpql() {
+		return JpaQueryEnhancer.forJpql(QUERY);
 	}
 }

--- a/spring-data-jpa/src/main/antlr4/org/springframework/data/jpa/repository/query/Hql.g4
+++ b/spring-data-jpa/src/main/antlr4/org/springframework/data/jpa/repository/query/Hql.g4
@@ -581,7 +581,11 @@ primaryExpression
     | entityVersionReference                                        # EntityVersionExpression
     | entityNaturalIdReference                                      # EntityNaturalIdExpression
     | syntacticDomainPath pathContinuation?                         # SyntacticPathExpression
-    | function                                                      # FunctionExpression
+    | function (
+        pathContinuation
+        | slicedPathAccessFragment pathContinuation?
+        | indexedPathAccessFragment pathContinuation?
+      )?                                                            # FunctionExpression
     | generalPathFragment                                           # GeneralPathExpression
     ;
 
@@ -680,10 +684,6 @@ syntacticDomainPath
     | mapKeyNavigablePath
     | simplePath indexedPathAccessFragment
     | simplePath slicedPathAccessFragment
-    | toOneFkReference
-    | function pathContinuation
-    | function indexedPathAccessFragment pathContinuation?
-    | function slicedPathAccessFragment
     ;
 
 /**
@@ -759,6 +759,7 @@ function
     | columnFunction                             # ColumnFunctionInvocation
     | jsonFunction                               # JsonFunctionInvocation
     | xmlFunction                                # XmlFunctionInvocation
+    | toOneFkReference                           # ToOneFkReferenceInvocation
     | genericFunction                            # GenericFunctionInvocation
     ;
 
@@ -1428,20 +1429,22 @@ xmltableDefaultClause
 // Predicates
 // https://docs.jboss.org/hibernate/orm/6.1/userguide/html_single/Hibernate_User_Guide.html#hql-conditional-expressions
 predicate
-    : '(' predicate ')'                     # GroupedPredicate
-    | expression IS NOT? (NULL|EMPTY|TRUE|FALSE) # IsBooleanPredicate
-    | expression IS NOT? DISTINCT FROM expression # IsDistinctFromPredicate
-    | expression NOT? MEMBER OF? path       # MemberOfPredicate
-    | inExpression                          # InPredicate
-    | betweenExpression                     # BetweenPredicate
-    | expression NOT? (CONTAINS|INCLUDES|INTERSECTS) expression   # ContainsPredicate
-    | relationalExpression                  # RelationalPredicate
-    | stringPatternMatching                 # LikePredicate
-    | existsExpression                      # ExistsPredicate
-    | NOT predicate                         # NotPredicate
-    | predicate AND predicate               # AndPredicate
-    | predicate OR predicate                # OrPredicate
-    | expression                            # ExpressionPredicate
+    : '(' predicate ')'                                             # GroupedPredicate
+    | expression IS NOT? (NULL|EMPTY|TRUE|FALSE)                    # IsBooleanPredicate
+    | expression NOT? MEMBER OF? path                               # MemberOfPredicate
+    | expression NOT? IN inList                                     # InPredicate
+    | expression NOT? BETWEEN expression AND expression             # BetweenPredicate
+    | expression NOT? (LIKE | ILIKE) REGEXP? expression (ESCAPE (STRING_LITERAL | JAVA_STRING_LITERAL | parameter))? # LikePredicate
+    | expression (
+        NOT? (CONTAINS|INCLUDES|INTERSECTS)
+        | IS NOT? DISTINCT FROM
+        | op=('=' | '>' | '>=' | '<' | '<=' | '<>' | '!=' | '^=')
+      ) expression                                                  # BinaryExpressionPredicate
+    | EXISTS ((ELEMENTS | INDICES) '(' simplePath ')' | expression) # ExistsPredicate
+    | NOT predicate                                                 # NotPredicate
+    | predicate AND predicate                                       # AndPredicate
+    | predicate OR predicate                                        # OrPredicate
+    | expression                                                    # ExpressionPredicate
     ;
 
 expressionOrPredicate
@@ -1474,41 +1477,15 @@ indicesKeysQuantifier
     | KEYS
     ;
 
-// https://docs.jboss.org/hibernate/orm/6.1/userguide/html_single/Hibernate_User_Guide.html#hql-relational-comparisons
-// NOTE: The TIP shows that "!=" is also supported. Hibernate's source code shows that "^=" is another NOT_EQUALS option as well.
-relationalExpression
-    : expression op=('=' | '>' | '>=' | '<' | '<=' | '<>' | '!=' | '^=' ) expression
-    ;
-
-// https://docs.jboss.org/hibernate/orm/6.1/userguide/html_single/Hibernate_User_Guide.html#hql-between-predicate
-betweenExpression
-    : expression NOT? BETWEEN expression AND expression
-    ;
-
-// https://docs.jboss.org/hibernate/orm/6.1/userguide/html_single/Hibernate_User_Guide.html#hql-like-predicate
-stringPatternMatching
-    : expression NOT? (LIKE | ILIKE) REGEXP? expression (ESCAPE (STRING_LITERAL | JAVA_STRING_LITERAL |parameter))?
-    ;
-
 // https://docs.jboss.org/hibernate/orm/6.1/userguide/html_single/Hibernate_User_Guide.html#hql-elements-indices
 // TBD
 
 // https://docs.jboss.org/hibernate/orm/6.1/userguide/html_single/Hibernate_User_Guide.html#hql-in-predicate
-inExpression
-    : expression NOT? IN inList
-    ;
-
 inList
     : (ELEMENTS | INDICES) '(' simplePath ')'
     | '(' subquery ')'
     | parameter
     | '(' (expressionOrPredicate (',' expressionOrPredicate)*)? ')'
-    ;
-
-// https://docs.jboss.org/hibernate/orm/6.1/userguide/html_single/Hibernate_User_Guide.html#hql-exists-predicate
-existsExpression
-    : EXISTS (ELEMENTS | INDICES) '(' simplePath ')'
-    | EXISTS expression
     ;
 
 // Projection

--- a/spring-data-jpa/src/main/antlr4/org/springframework/data/jpa/repository/query/Hql.g4
+++ b/spring-data-jpa/src/main/antlr4/org/springframework/data/jpa/repository/query/Hql.g4
@@ -1432,15 +1432,15 @@ predicate
     : '(' predicate ')'                                             # GroupedPredicate
     | expression IS NOT? (NULL|EMPTY|TRUE|FALSE)                    # IsBooleanPredicate
     | expression NOT? MEMBER OF? path                               # MemberOfPredicate
-    | expression NOT? IN inList                                     # InPredicate
-    | expression NOT? BETWEEN expression AND expression             # BetweenPredicate
-    | expression NOT? (LIKE | ILIKE) REGEXP? expression (ESCAPE (STRING_LITERAL | JAVA_STRING_LITERAL | parameter))? # LikePredicate
+    | inExpression                                                  # InPredicate
+    | betweenExpression                                             # BetweenPredicate
     | expression (
         NOT? (CONTAINS|INCLUDES|INTERSECTS)
         | IS NOT? DISTINCT FROM
         | op=('=' | '>' | '>=' | '<' | '<=' | '<>' | '!=' | '^=')
       ) expression                                                  # BinaryExpressionPredicate
-    | EXISTS ((ELEMENTS | INDICES) '(' simplePath ')' | expression) # ExistsPredicate
+    | stringPatternMatching                                         # LikePredicate
+    | existsExpression                                              # ExistsPredicate
     | NOT predicate                                                 # NotPredicate
     | predicate AND predicate                                       # AndPredicate
     | predicate OR predicate                                        # OrPredicate
@@ -1477,15 +1477,35 @@ indicesKeysQuantifier
     | KEYS
     ;
 
+// https://docs.jboss.org/hibernate/orm/6.1/userguide/html_single/Hibernate_User_Guide.html#hql-between-predicate
+betweenExpression
+    : expression NOT? BETWEEN expression AND expression
+    ;
+
+// https://docs.jboss.org/hibernate/orm/6.1/userguide/html_single/Hibernate_User_Guide.html#hql-like-predicate
+stringPatternMatching
+    : expression NOT? (LIKE | ILIKE) REGEXP? expression (ESCAPE (STRING_LITERAL | JAVA_STRING_LITERAL |parameter))?
+    ;
+
 // https://docs.jboss.org/hibernate/orm/6.1/userguide/html_single/Hibernate_User_Guide.html#hql-elements-indices
 // TBD
 
 // https://docs.jboss.org/hibernate/orm/6.1/userguide/html_single/Hibernate_User_Guide.html#hql-in-predicate
+inExpression
+    : expression NOT? IN inList
+    ;
+
 inList
     : (ELEMENTS | INDICES) '(' simplePath ')'
     | '(' subquery ')'
     | parameter
     | '(' (expressionOrPredicate (',' expressionOrPredicate)*)? ')'
+    ;
+
+// https://docs.jboss.org/hibernate/orm/6.1/userguide/html_single/Hibernate_User_Guide.html#hql-exists-predicate
+existsExpression
+    : EXISTS (ELEMENTS | INDICES) '(' simplePath ')'
+    | EXISTS expression
     ;
 
 // Projection

--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/HqlOrderExpressionVisitor.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/HqlOrderExpressionVisitor.java
@@ -60,6 +60,7 @@ import org.springframework.util.StringUtils;
  *
  * @author Greg Turnquist
  * @author Mark Paluch
+ * @author Arai
  * @since 4.0
  */
 @SuppressWarnings({ "unchecked", "rawtypes", "ConstantValue", "NullAway" })
@@ -142,7 +143,11 @@ class HqlOrderExpressionVisitor extends HqlBaseVisitor<Expression<?>> {
 	}
 
 	@Override
-	public Expression<?> visitRelationalExpression(HqlParser.RelationalExpressionContext ctx) {
+	public Expression<?> visitBinaryExpressionPredicate(HqlParser.BinaryExpressionPredicateContext ctx) {
+
+		if (ctx.op == null) {
+			throw new UnsupportedOperationException(String.format(UNSUPPORTED_TEMPLATE, renderContext(ctx).trim()));
+		}
 
 		Expression<Comparable> left = visitRequired(ctx.expression(0));
 		Expression<Comparable> right = visitRequired(ctx.expression(1));
@@ -160,7 +165,7 @@ class HqlOrderExpressionVisitor extends HqlBaseVisitor<Expression<?>> {
 	}
 
 	@Override
-	public Expression<?> visitBetweenExpression(HqlParser.BetweenExpressionContext ctx) {
+	public Expression<?> visitBetweenPredicate(HqlParser.BetweenPredicateContext ctx) {
 
 		Expression<Comparable> condition = visitRequired(ctx.expression(0));
 		Expression<Comparable> lower = visitRequired(ctx.expression(1));
@@ -215,7 +220,7 @@ class HqlOrderExpressionVisitor extends HqlBaseVisitor<Expression<?>> {
 	}
 
 	@Override
-	public Expression<?> visitStringPatternMatching(HqlParser.StringPatternMatchingContext ctx) {
+	public Expression<?> visitLikePredicate(HqlParser.LikePredicateContext ctx) {
 
 		Expression<String> condition = visitRequired(ctx.expression(0));
 		Expression<String> match = visitRequired(ctx.expression(1));
@@ -290,7 +295,7 @@ class HqlOrderExpressionVisitor extends HqlBaseVisitor<Expression<?>> {
 	}
 
 	@Override
-	public Expression<?> visitInExpression(HqlParser.InExpressionContext ctx) {
+	public Expression<?> visitInPredicate(HqlParser.InPredicateContext ctx) {
 
 		if (ctx.inList().simplePath() != null) {
 			throw new UnsupportedOperationException(

--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/HqlOrderExpressionVisitor.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/HqlOrderExpressionVisitor.java
@@ -165,7 +165,7 @@ class HqlOrderExpressionVisitor extends HqlBaseVisitor<Expression<?>> {
 	}
 
 	@Override
-	public Expression<?> visitBetweenPredicate(HqlParser.BetweenPredicateContext ctx) {
+	public Expression<?> visitBetweenExpression(HqlParser.BetweenExpressionContext ctx) {
 
 		Expression<Comparable> condition = visitRequired(ctx.expression(0));
 		Expression<Comparable> lower = visitRequired(ctx.expression(1));
@@ -220,7 +220,7 @@ class HqlOrderExpressionVisitor extends HqlBaseVisitor<Expression<?>> {
 	}
 
 	@Override
-	public Expression<?> visitLikePredicate(HqlParser.LikePredicateContext ctx) {
+	public Expression<?> visitStringPatternMatching(HqlParser.StringPatternMatchingContext ctx) {
 
 		Expression<String> condition = visitRequired(ctx.expression(0));
 		Expression<String> match = visitRequired(ctx.expression(1));
@@ -295,7 +295,7 @@ class HqlOrderExpressionVisitor extends HqlBaseVisitor<Expression<?>> {
 	}
 
 	@Override
-	public Expression<?> visitInPredicate(HqlParser.InPredicateContext ctx) {
+	public Expression<?> visitInExpression(HqlParser.InExpressionContext ctx) {
 
 		if (ctx.inList().simplePath() != null) {
 			throw new UnsupportedOperationException(

--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/HqlQueryRenderer.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/HqlQueryRenderer.java
@@ -38,6 +38,7 @@ import org.springframework.util.CollectionUtils;
  * @author Mark Paluch
  * @author TaeHyun Kang
  * @author Jewoo Shin
+ * @author Arai
  * @since 3.1
  */
 @SuppressWarnings({ "ConstantConditions", "DuplicatedCode", "UnreachableCode" })
@@ -714,6 +715,28 @@ class HqlQueryRenderer extends HqlBaseVisitor<QueryTokenStream> {
 	}
 
 	@Override
+	public QueryTokenStream visitFunctionExpression(HqlParser.FunctionExpressionContext ctx) {
+
+		QueryRendererBuilder builder = QueryRenderer.builder();
+
+		builder.appendInline(visit(ctx.function()));
+
+		if (ctx.indexedPathAccessFragment() != null) {
+			builder.appendInline(visit(ctx.indexedPathAccessFragment()));
+		}
+
+		if (ctx.slicedPathAccessFragment() != null) {
+			builder.appendInline(visit(ctx.slicedPathAccessFragment()));
+		}
+
+		if (ctx.pathContinuation() != null) {
+			builder.appendInline(visit(ctx.pathContinuation()));
+		}
+
+		return builder;
+	}
+
+	@Override
 	public QueryTokenStream visitPathContinuation(HqlParser.PathContinuationContext ctx) {
 
 		QueryRendererBuilder builder = QueryRenderer.builder();
@@ -792,31 +815,6 @@ class HqlQueryRenderer extends HqlBaseVisitor<QueryTokenStream> {
 
 		if (ctx.mapKeyNavigablePath() != null) {
 			return visit(ctx.mapKeyNavigablePath());
-		}
-
-		if (ctx.toOneFkReference() != null) {
-			return visit(ctx.toOneFkReference());
-		}
-
-		if (ctx.function() != null) {
-
-			QueryRendererBuilder builder = QueryRenderer.builder();
-
-			builder.append(visit(ctx.function()));
-
-			if (ctx.indexedPathAccessFragment() != null) {
-				builder.append(visit(ctx.indexedPathAccessFragment()));
-			}
-
-			if (ctx.slicedPathAccessFragment() != null) {
-				builder.append(visit(ctx.slicedPathAccessFragment()));
-			}
-
-			if (ctx.pathContinuation() != null) {
-				builder.append(visit(ctx.pathContinuation()));
-			}
-
-			return builder;
 		}
 
 		if (ctx.indexedPathAccessFragment() != null) {
@@ -2045,7 +2043,7 @@ class HqlQueryRenderer extends HqlBaseVisitor<QueryTokenStream> {
 	}
 
 	@Override
-	public QueryTokenStream visitExistsExpression(HqlParser.ExistsExpressionContext ctx) {
+	public QueryTokenStream visitExistsPredicate(HqlParser.ExistsPredicateContext ctx) {
 
 		QueryRendererBuilder builder = QueryRenderer.builder();
 

--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/HqlQueryRenderer.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/HqlQueryRenderer.java
@@ -2043,7 +2043,7 @@ class HqlQueryRenderer extends HqlBaseVisitor<QueryTokenStream> {
 	}
 
 	@Override
-	public QueryTokenStream visitExistsPredicate(HqlParser.ExistsPredicateContext ctx) {
+	public QueryTokenStream visitExistsExpression(HqlParser.ExistsExpressionContext ctx) {
 
 		QueryRendererBuilder builder = QueryRenderer.builder();
 

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/HqlOrderExpressionVisitorUnitTests.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/HqlOrderExpressionVisitorUnitTests.java
@@ -43,6 +43,7 @@ import org.springframework.transaction.annotation.Transactional;
  *
  * @author Greg Turnquist
  * @author Mark Paluch
+ * @author Greg Taube
  */
 @ExtendWith(SpringExtension.class)
 @ContextConfiguration("classpath:application-context.xml")
@@ -264,6 +265,12 @@ class HqlOrderExpressionVisitorUnitTests {
 
 		assertThatExceptionOfType(UnsupportedOperationException.class).isThrownBy(
 				() -> renderOrderBy(JpaSort.unsafe("case when firstname in (:parameter) then 1 else 0 end"), "var_1"));
+
+		assertThatExceptionOfType(UnsupportedOperationException.class).isThrownBy(() -> renderOrderBy(
+				JpaSort.unsafe("case when firstname is distinct from lastname then 1 else 0 end"), "var_1"));
+
+		assertThatExceptionOfType(UnsupportedOperationException.class).isThrownBy(() -> renderOrderBy(
+				JpaSort.unsafe("case when firstname contains lastname then 1 else 0 end"), "var_1"));
 	}
 
 	@Test // GH-3172

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/HqlQueryRendererTests.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/HqlQueryRendererTests.java
@@ -36,6 +36,7 @@ import org.junit.jupiter.params.provider.ValueSource;
  * @author Yannick Brandt
  * @author Oscar Fanchin
  * @author Jewoo Shin
+ * @author Arai
  * @since 3.1
  */
 class HqlQueryRendererTests extends JpqlQueryRendererTckTests {
@@ -216,6 +217,20 @@ class HqlQueryRendererTests extends JpqlQueryRendererTckTests {
 		assertQuery("""
 				SELECT some_function().foo
 				FROM Employee e
+				""");
+	}
+
+	@Test // GH-4326
+	void complexFunctionPredicates() {
+
+		assertQuery("""
+				SELECT lower(coalesce(e.name, '')), function('json_value', e.metadata).value
+				FROM Employee e
+				WHERE lower(coalesce(e.name, '')) LIKE lower(concat('%', :search, '%'))
+					AND e.createdAt BETWEEN :from AND :to
+					AND e.state IN :states
+					AND e.total IS DISTINCT FROM :total
+					AND e.tags CONTAINS :tag
 				""");
 	}
 

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/HqlQueryRendererTests.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/HqlQueryRendererTests.java
@@ -37,6 +37,7 @@ import org.junit.jupiter.params.provider.ValueSource;
  * @author Oscar Fanchin
  * @author Jewoo Shin
  * @author Arai
+ * @author Greg Taube
  * @since 3.1
  */
 class HqlQueryRendererTests extends JpqlQueryRendererTckTests {
@@ -232,6 +233,15 @@ class HqlQueryRendererTests extends JpqlQueryRendererTckTests {
 					AND e.total IS DISTINCT FROM :total
 					AND e.tags CONTAINS :tag
 				""");
+	}
+
+	@ParameterizedTest // GH-4326
+	@ValueSource(strings = { "=", ">", ">=", "<", "<=", "<>", "!=", "^=", "IS DISTINCT FROM",
+			"IS NOT DISTINCT FROM", "CONTAINS", "NOT CONTAINS", "INCLUDES", "NOT INCLUDES", "INTERSECTS",
+			"NOT INTERSECTS" })
+	void binaryPredicates(String operator) {
+
+		assertQuery("SELECT e FROM Employee e WHERE e.first %s e.second".formatted(operator));
 	}
 
 	@ParameterizedTest // GH-3689

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/JpaQueryEnhancerUnitTests.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/JpaQueryEnhancerUnitTests.java
@@ -17,18 +17,37 @@ package org.springframework.data.jpa.repository.query;
 
 import static org.assertj.core.api.Assertions.*;
 
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 import java.util.stream.Stream;
 
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
 
 /**
  * Unit tests for {@link JpaQueryEnhancer}.
  *
  * @author Mark Paluch
+ * @author Greg Taube
  */
 class JpaQueryEnhancerUnitTests {
+
+	@ParameterizedTest // GH-4326
+	@ValueSource(strings = { "SELECT some_function().foo FROM Employee e",
+			"SELECT e FROM Employee e WHERE FOO(x).bar RESPECT NULLS",
+			"SELECT e FROM Employee e WHERE FOO(x).bar IGNORE NULLS" })
+	void shouldParseFunctionPathsUsingSllPrediction(String query) {
+
+		AtomicInteger parserCreations = new AtomicInteger();
+
+		JpaQueryEnhancer.parse(query, HqlLexer::new, tokenStream -> {
+			parserCreations.incrementAndGet();
+			return new HqlParser(tokenStream);
+		}, HqlParser::start);
+
+		assertThat(parserCreations).hasValue(1);
+	}
 
 	@ParameterizedTest // GH-3997
 	@MethodSource("queryEnhancers")


### PR DESCRIPTION
Supersedes #4327, originally submitted by @araiprof. The original commit and authorship are preserved in this branch; this follow-up narrows the production change and adds comparative controls and regression coverage.

Closes #4326.

The generated HQL parser spends a disproportionate amount of its first parse in ANTLR adaptive prediction. Two grammar decisions have overlapping expression prefixes: function-backed paths and binary predicates. Left-factoring those alternatives reduces the cold ATN/DFA work without changing the accepted query forms.

The patch deliberately drops the original PR's IN, BETWEEN, LIKE, and EXISTS refactors. A 10-fork ablation showed that function-path plus binary-predicate factoring retains effectively the entire improvement with less parser-tree and visitor churn:

| Variant | Cold parse | Allocation |
| --- | ---: | ---: |
| Current `main` | 405.980 ± 26.846 ms/op | 544.984 MB/op |
| Function paths only | 336.987 ± 61.112 ms/op | 233.410 MB/op |
| Function paths + binary predicates (this PR) | 191.533 ± 12.861 ms/op | 177.225 MB/op |
| Full original patch | 197.995 ± 13.436 ms/op | 176.731 MB/op |

JMH 1.37, JDK 26.0.2.1, 10 fresh forks, no warmup, one `SingleShotTime` invocation per fork, `-prof gc`; errors are 99.9% confidence intervals. A final run of the submitted code measured 179.589 ± 6.957 ms/op and 177.204 MB/op.

EQL and JPQL measurements using the same query are included as controls. The final run measured EQL at 109.209 ± 8.067 ms/op and 87.986 MB/op, and JPQL at 103.351 ± 7.175 ms/op and 76.213 MB/op. Instrumenting the upstream query-test corpus found no equivalent valid-query fallback in those grammars, so this PR does not change them.

The function-path regression test also verifies the causal behavior directly: affected valid HQL creates two parser instances on current `main` because SLL falls back to LL, and one parser instance with this change.

In an external Spring Boot 4.2.0-M1 application, 10 controlled cold starts improved from 15.2566 s to 13.7356 s on average (-1.521 s, -9.97%); repository initialization improved from 4.161 s to 2.848 s (-31.55%).

The HQL grammar is already compiled into Java at build time. The remaining cost is generated parser initialization and runtime adaptive prediction, so simplifying the ambiguous decisions is the applicable fix rather than moving application work into AOT processing.

Validation:

- Focused renderer, transformer, enhancer, SLL fast-path, and order-expression tests pass in all four Maven executions (438 tests per execution, zero failures).
- All 16 retained binary predicate spellings have focused rendering coverage.
- The full module run reached 2,631 tests with no assertion failures related to this change; only the 14 Testcontainers-backed `PgVectorIntegrationTests` failed because Docker is unavailable on the test host.
