### PR TITLE
Fix count query derivation for DISTINCT selections containing expressions

### DIFF
--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/QueryTransformers.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/QueryTransformers.java
@@ -44,6 +44,7 @@ class QueryTransformers {
 			List<QueryToken> target = new ArrayList<>(selection.size());
 			boolean skipNext = false;
 			boolean containsNew = false;
+			int nestingLevel = 0;
 
 			for (QueryToken token : selection) {
 
@@ -52,13 +53,15 @@ class QueryTransformers {
 					continue;
 				}
 
-				if (token.equals(TOKEN_AS)) {
-					skipNext = true;
-					continue;
+				if (token.equals(TOKEN_OPEN_PAREN)) {
+					nestingLevel++;
+				} else if (token.equals(TOKEN_CLOSE_PAREN)) {
+					nestingLevel--;
 				}
 
-				if (!token.equals(TOKEN_COMMA) && token.isExpression()) {
-					token = QueryTokens.token(token.value());
+				if (nestingLevel == 0 && token.equals(TOKEN_AS)) {
+					skipNext = true;
+					continue;
 				}
 
 				if (!containsNew && token.equals(TOKEN_NEW)) {
@@ -68,7 +71,34 @@ class QueryTransformers {
 				target.add(token);
 			}
 
+			normalizeSpacing(target);
+
 			return new CountSelectionTokenStream(target, containsNew);
+		}
+
+		/**
+		 * Flattening a composed {@link QueryTokenStream} into a plain token list loses the spacing information that is
+		 * otherwise contributed by the renderer composition. Reconstruct whitespace by rewriting each token into an
+		 * expression (rendered with a trailing space) unless it is followed by a token that must not be preceded by a
+		 * space (comma, closing or opening parenthesis).
+		 *
+		 * @param tokens the token list to normalize.
+		 */
+		private static void normalizeSpacing(List<QueryToken> tokens) {
+
+			for (int i = 0; i < tokens.size(); i++) {
+
+				QueryToken token = tokens.get(i);
+				QueryToken next = i + 1 < tokens.size() ? tokens.get(i + 1) : null;
+
+				boolean spaceAfter = next != null && !token.equals(TOKEN_OPEN_PAREN) && !token.equals(TOKEN_COMMA)
+						&& !token.equals(TOKEN_DOT) && !next.equals(TOKEN_CLOSE_PAREN) && !next.equals(TOKEN_OPEN_PAREN)
+						&& !next.equals(TOKEN_COMMA) && !next.equals(TOKEN_DOT);
+
+				if (spaceAfter != token.isExpression()) {
+					tokens.set(i, spaceAfter ? QueryTokens.expression(token.value()) : QueryTokens.token(token.value()));
+				}
+			}
 		}
 
 		/**
@@ -90,13 +120,16 @@ class QueryTransformers {
 			for (QueryToken token : this) {
 
 				if (token.equals(TOKEN_OPEN_PAREN)) {
-					nestingLevel++;
-					continue;
-				}
 
-				if (token.equals(TOKEN_CLOSE_PAREN)) {
-					nestingLevel--;
-					continue;
+					// skip the constructor parenthesis only, retain nested parentheses (e.g. function calls)
+					if (++nestingLevel == 1) {
+						continue;
+					}
+				} else if (token.equals(TOKEN_CLOSE_PAREN)) {
+
+					if (--nestingLevel == 0) {
+						continue;
+					}
 				}
 
 				if (nestingLevel > 0) {

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/EqlQueryTransformerTests.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/EqlQueryTransformerTests.java
@@ -210,6 +210,23 @@ class EqlQueryTransformerTests {
 				"select count(distinct name, lastname) from User where foo = ?1");
 	}
 
+	@Test // GH-4341
+	void createsCountQueryForConstructorQueriesWithFunctionArguments() {
+
+		assertCountQuery("select distinct new com.example.Dto(coalesce(name, lastname)) from User where foo = ?1",
+				"select count(distinct coalesce(name, lastname)) from User where foo = ?1");
+
+		assertCountQuery("select distinct new com.example.Dto(cast(age as string)) from User",
+				"select count(distinct cast(age as string)) from User");
+	}
+
+	@Test // GH-4341
+	void createsCountQueryForDistinctExpressionSelection() {
+
+		assertCountQuery("select distinct case when u.age > 18 then 'adult' else 'minor' end from User u",
+				"select count(distinct case when u.age > 18 then 'adult' else 'minor' end) from User u");
+	}
+
 	@Test
 	void createsCountQueryForJoins() {
 

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/HqlQueryTransformerTests.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/HqlQueryTransformerTests.java
@@ -237,6 +237,16 @@ class HqlQueryTransformerTests {
 				"select count(distinct name, lastname) from User where foo = ?1");
 	}
 
+	@Test // GH-4341
+	void createsCountQueryForConstructorQueriesWithFunctionArguments() {
+
+		assertCountQuery("select distinct new com.example.Dto(coalesce(name, lastname)) from User where foo = ?1",
+				"select count(distinct coalesce(name, lastname)) from User where foo = ?1");
+
+		assertCountQuery("select distinct new com.example.Dto(cast(age as string)) from User",
+				"select count(distinct cast(age as string)) from User");
+	}
+
 	@Test
 	void createsCountQueryForJoins() {
 

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/JpqlQueryTransformerTests.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/JpqlQueryTransformerTests.java
@@ -210,6 +210,23 @@ class JpqlQueryTransformerTests {
 				"select count(distinct name, lastname) from User where foo = ?1");
 	}
 
+	@Test // GH-4341
+	void createsCountQueryForConstructorQueriesWithFunctionArguments() {
+
+		assertCountQuery("select distinct new com.example.Dto(coalesce(name, lastname)) from User where foo = ?1",
+				"select count(distinct coalesce(name, lastname)) from User where foo = ?1");
+
+		assertCountQuery("select distinct new com.example.Dto(cast(age as string)) from User",
+				"select count(distinct cast(age as string)) from User");
+	}
+
+	@Test // GH-4341
+	void createsCountQueryForDistinctExpressionSelection() {
+
+		assertCountQuery("select distinct case when u.age > 18 then 'adult' else 'minor' end from User u",
+				"select count(distinct case when u.age > 18 then 'adult' else 'minor' end) from User u");
+	}
+
 	@Test
 	void createsCountQueryForJoins() {
 


### PR DESCRIPTION
Closes #4341

Deriving a count query from a `SELECT DISTINCT` query whose selection contains expressions produced invalid JPQL: flattening the selection dropped all whitespace of multi-token expressions (`count(distinct casewhenu.age>18then...)`), `AS` was stripped at any parenthesis nesting level (breaking `cast(x as string)`), and `withoutConstructorExpression()` removed all parentheses instead of only the constructor wrapper (`count(distinct coalescename, lastname)`). The derived queries are rejected by the project's own parsers, so paged repository queries of this shape fail at count-query execution.

This change strips `AS` only at nesting level zero, retains nested parentheses when unwrapping a constructor expression, and reconstructs the spacing of the flattened selection tokens.

Five regression tests added across the HQL/JPQL/EQL transformer tests (all fail on `main`, pass with the fix); the full transformer test suites pass (HQL 102, JPQL 82, EQL 82) and the module unit test suite is green.