### PR TITLE
Apply Sort only to the outermost query for parenthesized HQL set operations

### DIFF
--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/HqlSortedQueryTransformer.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/HqlSortedQueryTransformer.java
@@ -43,6 +43,13 @@ class HqlSortedQueryTransformer extends HqlQueryRenderer {
 	private final @Nullable String primaryFromAlias;
 	private final @Nullable DtoProjectionTransformerDelegate dtoDelegate;
 
+	/**
+	 * Whether the visitor is currently within a parenthesized (nested) query expression. {@link Sort} must only be
+	 * applied to the outermost query level, not to individual arms of a set operation such as
+	 * {@code (SELECT …) UNION (SELECT …)}.
+	 */
+	private boolean nestedQueryExpression = false;
+
 	HqlSortedQueryTransformer(Sort sort, HibernateQueryInformation queryInformation,
 			@Nullable ReturnedType returnedType) {
 
@@ -73,7 +80,7 @@ class HqlSortedQueryTransformer extends HqlQueryRenderer {
 				builder.append(visit(ctx.setOperator(i - 1)));
 			}
 
-			if (i == orderedQueries.size() - 1) {
+			if (i == orderedQueries.size() - 1 && !nestedQueryExpression) {
 				builder.append(visitOrderedQuery(ctx.orderedQuery(i), this.sort));
 			} else {
 				builder.append(visitOrderedQuery(ctx.orderedQuery(i), Sort.unsorted()));
@@ -85,7 +92,7 @@ class HqlSortedQueryTransformer extends HqlQueryRenderer {
 
 	@Override
 	public QueryRendererBuilder visitOrderedQuery(HqlParser.OrderedQueryContext ctx) {
-		return visitOrderedQuery(ctx, this.sort);
+		return visitOrderedQuery(ctx, nestedQueryExpression ? Sort.unsorted() : this.sort);
 	}
 
 	@Override
@@ -168,9 +175,14 @@ class HqlSortedQueryTransformer extends HqlQueryRenderer {
 			builder.append(visit(ctx.query()));
 		} else if (ctx.queryExpression() != null) {
 
+			boolean nested = this.nestedQueryExpression;
+			this.nestedQueryExpression = true;
+
 			builder.append(TOKEN_OPEN_PAREN);
 			builder.appendInline(visit(ctx.queryExpression()));
 			builder.append(TOKEN_CLOSE_PAREN);
+
+			this.nestedQueryExpression = nested;
 		}
 
 		if (!isSubquery(ctx)) {

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/HqlQueryTransformerTests.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/HqlQueryTransformerTests.java
@@ -1219,6 +1219,25 @@ class HqlQueryTransformerTests {
 				+ "UNION SELECT tb FROM Test tb WHERE (tb.type = 'C') order by tb.Type asc");
 	}
 
+	@Test // GH-4342
+	void sortShouldBeAppliedOnlyOnceToSetOperationsOfParenthesizedQueries() {
+
+		String source = "(SELECT tb FROM Test tb WHERE tb.type = 'A') UNION (SELECT tb FROM Test tb WHERE tb.type = 'B')";
+		String target = createQueryFor(source, Sort.by("Type").ascending());
+
+		assertThat(target).isEqualTo("(SELECT tb FROM Test tb WHERE tb.type = 'A')" //
+				+ "UNION (SELECT tb FROM Test tb WHERE tb.type = 'B') order by tb.Type asc");
+	}
+
+	@Test // GH-4342
+	void sortShouldNotBeAppliedToParenthesizedQueryArm() {
+
+		String source = "(SELECT tb FROM Test tb WHERE tb.type = 'A')";
+		String target = createQueryFor(source, Sort.by("Type").ascending());
+
+		assertThat(target).isEqualTo("(SELECT tb FROM Test tb WHERE tb.type = 'A') order by tb.Type asc");
+	}
+
 	@ParameterizedTest // GH-3427
 	@ValueSource(strings = { "", "res" })
 	void sortShouldBeAppendedToSubSelectWithSetOperatorInSubselect(String alias) {


### PR DESCRIPTION
Closes #4342

Rendering a parenthesized query expression re-entered `visitOrderedQuery`, which applied the `Sort` again at every nesting level, so the `ORDER BY` was injected into each arm of a set operation such as `(SELECT ...) UNION (SELECT ...)` in addition to the outer query — three times in total for a two-arm union. With different arm aliases the injected ordering references an unknown alias and Hibernate rejects the query; with equal aliases it changes set-operation semantics.

`HqlSortedQueryTransformer` now tracks whether the visitor is inside a nested query expression and substitutes `Sort.unsorted()` while nested, so the `Sort` is applied exactly once at the outermost level — consistent with the invariant already asserted for FROM-subqueries (GH-3427 test).

Two regression tests added (both fail on `main`, pass with the fix); `HqlQueryTransformerTests` passes 101/101.