### PR TITLE
Allow `PERCENT` in the HQL `fetch` clause.

### DIFF
--- a/spring-data-jpa/src/main/antlr4/org/springframework/data/jpa/repository/query/Hql.g4
+++ b/spring-data-jpa/src/main/antlr4/org/springframework/data/jpa/repository/query/Hql.g4
@@ -226,7 +226,7 @@ offsetClause
     ;
 
 fetchClause
-    : FETCH (FIRST | NEXT) (parameterOrIntegerLiteral | parameterOrNumberLiteral '%') (ROW | ROWS) (ONLY | WITH TIES)
+    : FETCH (FIRST | NEXT) (parameterOrIntegerLiteral | parameterOrNumberLiteral PERCENT) (ROW | ROWS) (ONLY | WITH TIES)
     ;
 
 /*******************

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/HqlQueryRendererTests.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/HqlQueryRendererTests.java
@@ -36,6 +36,7 @@ import org.junit.jupiter.params.provider.ValueSource;
  * @author Yannick Brandt
  * @author Oscar Fanchin
  * @author Jewoo Shin
+ * @author OhKyu Chan
  * @since 3.1
  */
 class HqlQueryRendererTests extends JpqlQueryRendererTckTests {
@@ -1152,6 +1153,23 @@ class HqlQueryRendererTests extends JpqlQueryRendererTckTests {
 				"join fetch p.calls " + //
 				"order by p " + //
 				"limit 50");
+	}
+
+	@Test // GH-4345
+	void fetchClauseShouldSupportPercentKeyword() {
+
+		assertQuery("select c " + //
+				"from Call c " + //
+				"order by c.duration " + //
+				"fetch first 10 percent rows only");
+		assertQuery("select c " + //
+				"from Call c " + //
+				"order by c.duration " + //
+				"fetch next 2.5 percent rows with ties");
+		assertQuery("select c " + //
+				"from Call c " + //
+				"order by c.duration " + //
+				"fetch first :percentage percent rows only");
 	}
 
 	@Test // GH-2962


### PR DESCRIPTION
Hibernate's HQL grammar expects the `PERCENT` keyword in a `FETCH FIRST … PERCENT ROWS` clause, whereas Spring Data JPA's grammar expected the `%` operator. Valid HQL was therefore rejected with a `BadJpqlGrammarException`, while the `%` spelling that Hibernate does not accept parsed successfully. Point `fetchClause` at the `PERCENT` token that the grammar already declares and cover the round-trip rendering path.

Closes #4345

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).