### PR TITLE
Exclude AspectJ builddef.lst from published JARs.

### DIFF
--- a/spring-data-jpa/pom.xml
+++ b/spring-data-jpa/pom.xml
@@ -445,6 +445,16 @@
 			</plugin>
 
 			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-jar-plugin</artifactId>
+				<configuration>
+					<excludes>
+						<exclude>builddef.lst</exclude>
+					</excludes>
+				</configuration>
+			</plugin>
+
+			<plugin>
 				<groupId>org.codehaus.mojo</groupId>
 				<artifactId>aspectj-maven-plugin</artifactId>
 				<version>1.16.0</version>
@@ -478,6 +488,8 @@
 					<parameters>true</parameters>
 					<verbose>true</verbose>
 					<showWeaveInfo>true</showWeaveInfo>
+					<!-- Keep AJC's argument file out of target/classes so it is not packaged. -->
+					<argumentFileName>../builddef.lst</argumentFileName>
 					<aspectLibraries>
 						<aspectLibrary>
 							<groupId>org.springframework</groupId>


### PR DESCRIPTION
## Summary
- `aspectj-maven-plugin` writes `builddef.lst` into `target/classes` by default, so the published `spring-data-jpa` JAR shipped a local-path AJC argument file.
- Relocate that file to `target/builddef.lst` and exclude `builddef.lst` from the JAR.

Closes #4350

## Test plan
Executed:

- `./mvnw -pl spring-data-jpa -am package -DskipTests` (before): `jar tf` listed `builddef.lst`.
- `./mvnw -pl spring-data-jpa -am package -DskipTests` (after): `jar tf` no longer lists `builddef.lst`; `Automatic-Module-Name` / `Implementation-*` manifest entries remain.
- `./mvnw -pl spring-data-jpa -Dtest=AuditingNamespaceUnitTests,JpaRuntimeHintsUnitTests test`: 7 tests, 0 failures (Surefire default/unit/integration/eclipselink executions).