### PR TITLE
Simplify predicate concatenation in JpqlQueryBuilder.and(List)

### DIFF
--- a/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/JpqlQueryBuilder.java
+++ b/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/JpqlQueryBuilder.java
@@ -46,6 +46,7 @@ import org.springframework.util.StringUtils;
  * @author Mark Paluch
  * @author Choi Wang Gyu
  * @author Jeongwon Ryu
+ * @author Junggi Kim
  * @since 4.0
  */
 @SuppressWarnings("JavadocDeclaration")
@@ -416,18 +417,11 @@ public final class JpqlQueryBuilder {
 
 	public static @Nullable Predicate and(List<Predicate> intermediate) {
 
-		Predicate predicate = null;
-
-		for (Predicate other : intermediate) {
-
-			if (predicate == null) {
-				predicate = other;
-			} else {
-				predicate = predicate.and(other);
-			}
+		if (intermediate.isEmpty()) {
+			return null;
 		}
 
-		return predicate;
+		return intermediate.size() == 1 ? intermediate.get(0) : AndPredicate.of(intermediate);
 	}
 
 	public static @Nullable Predicate or(List<Predicate> intermediate) {

--- a/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/JpqlQueryBuilderUnitTests.java
+++ b/spring-data-jpa/src/test/java/org/springframework/data/jpa/repository/query/JpqlQueryBuilderUnitTests.java
@@ -46,6 +46,7 @@ import org.springframework.data.jpa.util.TestMetaModel;
  * @author Mark Paluch
  * @author Choi Wang Gyu
  * @author Jeongwon Ryu
+ * @author Junggi Kim
  */
 class JpqlQueryBuilderUnitTests {
 
@@ -218,6 +219,68 @@ class JpqlQueryBuilderUnitTests {
 
 		assertThat(or.parts()).hasSize(3);
 		assertThat(fragment).isEqualTo("o.id = '1' OR o.id = '2' OR o.id = '3'");
+	}
+
+	@Test // GH-4352
+	void andReturnsNullForEmptyPredicates() {
+		assertThat(JpqlQueryBuilder.and(List.of())).isNull();
+	}
+
+	@Test // GH-4352
+	void andReturnsSinglePredicateAsIs() {
+
+		Entity entity = entity(Order.class);
+		Predicate a = where(path(entity, "id")).eq(literal("1"));
+
+		assertThat(JpqlQueryBuilder.and(List.of(a))).isSameAs(a);
+	}
+
+	@Test // GH-4352
+	void andConcatenatesPredicatesIntoFlatAndPredicate() {
+
+		Entity entity = entity(Order.class);
+		PathAndOrigin id = path(entity, "id");
+
+		Predicate a = where(id).eq(literal("1"));
+		Predicate b = where(id).eq(literal("2"));
+		Predicate c = where(id).eq(literal("3"));
+
+		AndPredicate and = (AndPredicate) JpqlQueryBuilder.and(List.of(a, b, c));
+
+		assertThat(and.parts()).containsExactly(a, b, c);
+		assertThat(and.render(ctx(entity))).isEqualTo("o.id = '1' AND o.id = '2' AND o.id = '3'");
+	}
+
+	@Test // GH-4352
+	void andFlattensNestedAndPredicates() {
+
+		Entity entity = entity(Order.class);
+		PathAndOrigin id = path(entity, "id");
+
+		Predicate a = where(id).eq(literal("1"));
+		Predicate b = where(id).eq(literal("2"));
+		Predicate c = where(id).eq(literal("3"));
+
+		AndPredicate and = (AndPredicate) JpqlQueryBuilder.and(List.of(a.and(b), c));
+
+		assertThat(and.parts()).containsExactly(a, b, c);
+		assertThat(and.render(ctx(entity))).isEqualTo("o.id = '1' AND o.id = '2' AND o.id = '3'");
+	}
+
+	@Test // GH-4352
+	void andRetainsNestedOrPredicates() {
+
+		Entity entity = entity(Order.class);
+		PathAndOrigin id = path(entity, "id");
+
+		Predicate a = where(id).eq(literal("1"));
+		Predicate b = where(id).eq(literal("2"));
+		Predicate c = where(id).eq(literal("3"));
+
+		AndPredicate and = (AndPredicate) JpqlQueryBuilder.and(List.of(a, b.or(c)));
+
+		assertThat(and.parts()).hasSize(2);
+		assertThat(and.render(ctx(entity))).isEqualTo("o.id = '1' AND o.id = '2' OR o.id = '3'");
 	}
 
 	@Test // GH-3588


### PR DESCRIPTION
`JpqlQueryBuilder.and(List)` combines predicates by repeatedly calling `Predicate.and(Predicate)`, and each of those calls flattens everything accumulated so far into a new list, so the element copies are quadratic in the number of predicates. `AndPredicate.of(List)` already flattens a list in one pass and `or(List)`, directly below, already delegates to `OrPredicate.of(List)`, so `and(List)` now delegates the same way. The empty and single-element cases stay explicit to keep the returned instance the same as before.

The only caller is `KeysetScrollSpecification`, where the list holds one predicate per keyset sort key; in the queries the tests generate that is one to four predicates. One thing does change for input that caller never produces: a `null` next to another predicate used to be dropped, or to fail inside `List.of`, and now throws when the predicate is rendered.

The added tests pass against the previous implementation too, and the module test suite passes before and after.

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don't submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
